### PR TITLE
node v0.3 support

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -20,3 +20,13 @@ Buffer.prototype.concat = function(other) {
   other.copy(buf, len, 0);
   return buf;
 };
+
+// patch if not v0.2 of node.js and Buffer.isBuffer fails for SlowBuffer
+if (process.version.indexOf("v0.2") == -1) {
+    var SlowBuffer = process.binding('buffer').SlowBuffer;
+    if (!Buffer.isBuffer(new SlowBuffer(10))) {
+        Buffer.isBuffer = function (b) {
+            return (b instanceof Buffer) || (b instanceof SlowBuffer);
+        };
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
  , "scripts": {
    "preinstall": "node-waf configure build"
  }
- , "engines": { "node": ">= 0.2.3 < 0.3.0" }
+ , "engines": { "node": ">= 0.3.0" }
  , "main": "./lib/canvas.js"
 }

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -8,6 +8,7 @@
 #include "Canvas.h"
 #include <string.h>
 #include <node_buffer.h>
+#include <node_version.h>
 
 using namespace v8;
 using namespace node;
@@ -109,7 +110,11 @@ static cairo_status_t
 writeToBuffer(void *c, const uint8_t *data, unsigned len) {
   closure_t *closure = (closure_t *) c;
   Buffer *buf = Buffer::New(len);
+#if NODE_VERSION_AT_LEAST(0,3,0)
+  memcpy(Buffer::Data(buf->handle_), data, len);
+#else
   memcpy(buf->data(), data, len);
+#endif
   Handle<Value> argv[3] = { Null(), buf->handle_, Integer::New(len) };
   closure->fn->Call(Context::GetCurrent()->Global(), 3, argv);
   return CAIRO_STATUS_SUCCESS;


### PR DESCRIPTION
reflects v0.3 Buffer API change and conditionally installs temporary patch of Buffer.isBuffer method.
