### PR TITLE
make PNGStream a real Stream

### DIFF
--- a/lib/pngstream.js
+++ b/lib/pngstream.js
@@ -9,7 +9,7 @@
  * Module dependencies.
  */
 
-var EventEmitter = require('events').EventEmitter;
+var Stream = require('stream').Stream;
 
 /**
  * Initialize a `PNGStream` with the given `canvas`.
@@ -41,16 +41,19 @@ var PNGStream = module.exports = function PNGStream(canvas, sync) {
       : 'streamPNG';
   this.sync = sync;
   this.canvas = canvas;
+  this.readable = true;
   // TODO: implement async
   if ('streamPNG' == method) method = 'streamPNGSync';
   process.nextTick(function(){
     canvas[method](function(err, chunk, len){
       if (err) {
         self.emit('error', err);
+        self.readable = false;
       } else if (len) {
         self.emit('data', chunk, len);
       } else {
         self.emit('end');
+        self.readable = false;
       }
     });
   });
@@ -60,4 +63,4 @@ var PNGStream = module.exports = function PNGStream(canvas, sync) {
  * Inherit from `EventEmitter`.
  */
 
-PNGStream.prototype.__proto__ = EventEmitter.prototype;
+PNGStream.prototype.__proto__ = Stream.prototype;


### PR DESCRIPTION
Just a minor update to make PNGStream subclass require("stream").Stream instead of EventEmittor. This gives access to the pipe() method and makes it more compatible with anything else using Streams.
