### PR TITLE
garbage collection never happening

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -312,9 +312,11 @@ Canvas::~Canvas() {
 void
 Canvas::resurface(Handle<Object> canvas) {
   // Re-surface
+  int old_width = cairo_image_surface_get_width(_surface);
+  int old_height = cairo_image_surface_get_height(_surface);
   cairo_surface_destroy(_surface);
   _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-  V8::AdjustAmountOfExternalAllocatedMemory(4 * width * height);
+  V8::AdjustAmountOfExternalAllocatedMemory(4 * (width * height - old_width * old_height));
 
   // Reset context
   Handle<Value> context = canvas->Get(String::New("context"));


### PR DESCRIPTION
simple test (run it with `-trace_gc`)

``` javascript
var Canvas = require('../lib/canvas');

function hog() {
    var c = new Canvas(2000, 2000);
    var m = process.memoryUsage();
    console.log(''+ m.rss / 1e6, '\t', m.vsize / 1e6);
    setTimeout(hog, 1000);
};

hog();
```

the fix might be an overkill, but it solved the problem for me.
