### PR TITLE
waf support for jpeg support on FreeBSD

### DIFF
--- a/wscript
+++ b/wscript
@@ -17,10 +17,10 @@ def configure(conf):
   conf.check_tool('node_addon')
   conf.env.append_value('CPPFLAGS', '-DNDEBUG')
 
-  if conf.check(lib='gif', uselib_store='GIF', mandatory=False):
+  if conf.check(lib='gif', libpath=['/lib', '/usr/lib', '/usr/local/lib'], uselib_store='GIF', mandatory=False):
     conf.env.append_value('CPPFLAGS', '-DHAVE_GIF=1')
 
-  if conf.check(lib='jpeg', uselib_store='JPEG', mandatory=False):
+  if conf.check(lib='jpeg', libpath=['/lib', '/usr/lib', '/usr/local/lib'], uselib_store='JPEG', mandatory=False):
     conf.env.append_value('CPPFLAGS', '-DHAVE_JPEG=1')
 
   if conf.env['USE_PROFILING'] == True:


### PR DESCRIPTION
added libpath options to waf configuration; this was necessary to correctly detect gif and jpeg support on FreeBSD. fixes #110
