### PR TITLE
allow canvas to build with either libjpeg62-dev or libjpeg8-dev

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -14,6 +14,7 @@
 
 #ifdef HAVE_JPEG
 #include <jpeglib.h>
+#include <jerror.h>
 #endif
 
 #ifdef HAVE_GIF
@@ -546,6 +547,45 @@ Image::loadGIFFromBuffer(uint8_t *buf, unsigned len) {
 // JPEG support
 
 #ifdef HAVE_JPEG
+
+// libjpeg 6.2 does not have jpeg_mem_src; define it ourselves here unless
+// libjpeg 8 is installed.
+#if JPEG_LIB_VERSION < 80
+
+/* Read JPEG image from a memory segment */
+static void init_source (j_decompress_ptr cinfo) {}
+static boolean fill_input_buffer (j_decompress_ptr cinfo) {
+  ERREXIT(cinfo, JERR_INPUT_EMPTY);
+  return TRUE;
+}
+static void skip_input_data (j_decompress_ptr cinfo, long num_bytes) {
+  struct jpeg_source_mgr* src = (struct jpeg_source_mgr*) cinfo->src;
+  if (num_bytes > 0) {
+    src->next_input_byte += (size_t) num_bytes;
+    src->bytes_in_buffer -= (size_t) num_bytes;
+  }
+}
+static void term_source (j_decompress_ptr cinfo) {}
+static void jpeg_mem_src (j_decompress_ptr cinfo, void* buffer, long nbytes) {
+  struct jpeg_source_mgr* src;
+
+  if (cinfo->src == NULL) {   /* first time for this JPEG object? */
+    cinfo->src = (struct jpeg_source_mgr *)
+      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_PERMANENT,
+                                  sizeof(struct jpeg_source_mgr));
+  }
+
+  src = (struct jpeg_source_mgr*) cinfo->src;
+  src->init_source = init_source;
+  src->fill_input_buffer = fill_input_buffer;
+  src->skip_input_data = skip_input_data;
+  src->resync_to_restart = jpeg_resync_to_restart; /* use default method */
+  src->term_source = term_source;
+  src->bytes_in_buffer = nbytes;
+  src->next_input_byte = (JOCTET*)buffer;
+}
+
+#endif
 
 /*
  * Load jpeg from buffer.


### PR DESCRIPTION
Hi!  this is in reply to https://github.com/LearnBoost/node-canvas/issues/98 - my servers have libjpeg62-dev and i can't install libjpeg8-dev since i have a bunch of other stuff that specifically depends on libjpeg62-dev.  this patch should allow canvas to build with either one, i tested it on my ubuntu box.

i'm new to github and pull requests so apologies if i got something wrong with this process, please let me know if so!  thanks!
