### PR TITLE
fixed memory leaks in context2d

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -139,6 +139,9 @@ Context2d::Context2d(Canvas *canvas) {
  */
 
 Context2d::~Context2d() {
+  while(stateno>=0) {
+    free(states[stateno--]);
+  }
   cairo_destroy(_context);
 }
 
@@ -205,6 +208,7 @@ void
 Context2d::restorePath() {
   cairo_new_path(_context);
   cairo_append_path(_context, _path);
+  cairo_path_destroy(_path);
 }
 
 /*


### PR DESCRIPTION
I found and fixed some memory leaks in the context2d implementation

1: The initial state and all states that were not popped by restore were not free'd
2: The path that is copied in savePath is not deleted after being appended back to the context in restorePath
