### PR TITLE
make test-server fails with node 0.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
    "preinstall": "node-waf configure build"
  }
  , "devDependencies": {
-     "express": "2.3.7"
+     "express": ">= 2.3.7 && < 3.0.0"
    , "jade": "0.11.0"
    , "mocha": "*"
    , "should": "*"


### PR DESCRIPTION
```
$ nave use 0.6.9
Already installed: 0.6.9
using 0.6.9
bash-3.2$ make test-server
node-waf configure build
Checking for program g++ or c++          : /usr/bin/g++ 
Checking for program cpp                 : /usr/bin/cpp 
Checking for program ar                  : /usr/bin/ar 
Checking for program ranlib              : /usr/bin/ranlib 
Checking for g++                         : ok  
Checking for node path                   : ok /Users/nulltask/.nave/installed/0.6.9/lib/node 
Checking for node prefix                 : ok /Users/nulltask/.nave/installed/0.6.9 
Checking for library gif                 : not found 
Checking for library jpeg                : not found 
Checking for cairo                       : yes 
'configure' finished successfully (0.418s)
Waf: Entering directory `/Users/nulltask/Documents/node-canvas/build'
[ 1/10] cxx: src/Canvas.cc -> build/Release/src/Canvas_1.o
[ 2/10] cxx: src/CanvasGradient.cc -> build/Release/src/CanvasGradient_1.o
[ 3/10] cxx: src/CanvasPattern.cc -> build/Release/src/CanvasPattern_1.o
[ 4/10] cxx: src/CanvasRenderingContext2d.cc -> build/Release/src/CanvasRenderingContext2d_1.o
[ 5/10] cxx: src/color.cc -> build/Release/src/color_1.o
[ 6/10] cxx: src/Image.cc -> build/Release/src/Image_1.o
[ 7/10] cxx: src/ImageData.cc -> build/Release/src/ImageData_1.o
[ 8/10] cxx: src/init.cc -> build/Release/src/init_1.o
[ 9/10] cxx: src/PixelArray.cc -> build/Release/src/PixelArray_1.o
[10/10] cxx_link: build/Release/src/Canvas_1.o build/Release/src/CanvasGradient_1.o build/Release/src/CanvasPattern_1.o build/Release/src/CanvasRenderingContext2d_1.o build/Release/src/color_1.o build/Release/src/Image_1.o build/Release/src/ImageData_1.o build/Release/src/init_1.o build/Release/src/PixelArray_1.o -> build/Release/canvas.node
Waf: Leaving directory `/Users/nulltask/Documents/node-canvas/build'
'build' finished successfully (2.458s)

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: Cannot find module 'express'
    at Function._resolveFilename (module.js:334:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:357:17)
    at require (module.js:373:17)
    at Object.<anonymous> (/Users/nulltask/Documents/node-canvas/test/server.js:6:15)
    at Module._compile (module.js:444:26)
    at Object..js (module.js:462:10)
    at Module.load (module.js:351:31)
    at Function._load (module.js:310:12)
    at Array.0 (module.js:482:10)
make: *** [test-server] Error 1
```

changed dependency express >= 2.3.7 && < 3.0.0! :)
