### PR TITLE
Build node-canvas with node.js 0.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 0.4
+  - 0.6
+  - 0.7 # development version of 0.8, may be unstable

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
    , "mocha": "*"
    , "should": "*"
  }
- , "engines": { "node": ">= 0.4.0 && < 0.7.0" }
+ , "engines": { "node": ">= 0.4.0 && < 0.9.0" }
  , "main": "./lib/canvas.js"
 }

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -45,6 +45,10 @@ class Canvas: public node::ObjectWrap {
     static Handle<Value> StreamPNGSync(const Arguments &args);
     static Handle<Value> StreamJPEGSync(const Arguments &args);
     static Local<Value> Error(cairo_status_t status);
+#if NODE_VERSION_AT_LEAST(0, 6, 0)
+    static void ToBufferAsync(uv_work_t *req);
+    static void ToBufferAsyncAfter(uv_work_t *req);
+#else
     static
 #if NODE_VERSION_AT_LEAST(0, 5, 4)
       void
@@ -53,6 +57,8 @@ class Canvas: public node::ObjectWrap {
 #endif
       EIO_ToBuffer(eio_req *req);
     static int EIO_AfterToBuffer(eio_req *req);
+#endif
+
     inline cairo_surface_t *surface(){ return _surface; }
     inline uint8_t *data(){ return cairo_image_surface_get_data(_surface); }
     inline int stride(){ return cairo_image_surface_get_stride(_surface); }


### PR DESCRIPTION
Hi,

I needed to use node-canvas with node.js v0.7.x, but it did not work, so I had to patch it to use libuv instead of direct libeio calls (which is apparently the preferred method since node.js 0.6.0).

I submit my patch to you, hoping it will be useful.

Regards,

Philippe
