### PR TITLE
TextMetrics API (partial)

### DIFF
--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -12,6 +12,11 @@
 #include "Canvas.h"
 #include "CanvasGradient.h"
 
+typedef enum {
+  TEXT_DRAW_PATHS,
+  TEXT_DRAW_GLYPHS
+} canvas_draw_mode_t;
+
 /*
  * State struct.
  *
@@ -34,7 +39,7 @@ typedef struct {
   int shadowBlur;
   double shadowOffsetX;
   double shadowOffsetY;
-  bool textDrawingPaths;
+  canvas_draw_mode_t textDrawingMode;
 } canvas_state_t;
 
 class Context2d: public node::ObjectWrap {


### PR DESCRIPTION
I don't think it's possible for cairo to give an honest answer for `hangingBaseline`, `ideographicBaseline`, `fontBoundingBoxAscent` or `fontBoundingBoxDescent` without pango, so I've left those unimplemented rather than fudging the answer.

I also changed the calculation of the middle and bottom baselines. Before it was using `fe.height`, which can include external leading, whereas using `fe.ascent` and `fe.descent` won't.
