### PR TITLE
use assert.ok in type tests

### DIFF
--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -160,11 +160,11 @@ module.exports = {
 
   'test Canvas#type': function(){
     var canvas = new Canvas(10, 10);
-    assert('image' == canvas.type);
+    assert.ok('image' == canvas.type);
     var canvas = new Canvas(10, 10, 'pdf');
-    assert('pdf' == canvas.type);
+    assert.ok('pdf' == canvas.type);
     var canvas = new Canvas(10, 10, 'hey');
-    assert('image' == canvas.type);
+    assert.ok('image' == canvas.type);
   },
 
   'test Canvas#getContext("2d")': function(){


### PR DESCRIPTION
`canvas.test.js` was failing for me because the tests added in 03d1cacf9c064b64f2e9b9b42be8fdfc2991f1aa were using `assert(...)` instead of `assert.ok(...)`. This commit fixes that and all tests pass here.

I'm not sure if there's a change to `assert` in newer node versions but the older tests use `assert.ok(...)` so I think this is the correct fix.
