### PR TITLE
I was doing some benchmarking this weekend on toBuffer

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -134,7 +134,7 @@ toBuffer(void *c, const uint8_t *data, unsigned len) {
   closure_t *closure = (closure_t *) c;
   
   // Olaf: grow buffer
-  if (closure->len + len > closure->max_len) {
+  if ( (closure->len + len) > closure->max_len) {
     uint8_t *data;
     unsigned max = closure->max_len;
   


### PR DESCRIPTION
...memcpy to step on memory

and I noticed 
on line 137  of canvas.cc (https://github.com/LearnBoost/node-canvas/blob/master/src/Canvas.cc#L137)

``` c
if ( closure->len + len > closure->max_len) {
```

wasn't getting to my timing statements as expected, looks like an order of operations bug? Anyway, it was an easy fix to get to my timing statements as desired. 

``` c
if ( (closure->len + len) > closure->max_len) {
```

ps, realloc is slow :(. I rewrote the section with malloc but it only shaved off a few msecs. I noticed after a number of calls it became slower (memory was moving out of fast ram?). I'll continue to review it for optimization, the biggest one being to pre-allocate a larger max_len. Is that simply by creating a larger canvas to begin with?
ie
var Canvas      = require('canvas')
    , canvas = new Canvas(BigEnoughWidth,BigEnoughHeight)

or is closure->max_len coming from somewhere else?
