### PR TITLE
Export the "jpegVersion" and "gifVersion" strings when support for them is enabled

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -46,6 +46,14 @@ if (canvas.jpegVersion) {
 }
 
 /**
+ * gif_lib version.
+ */
+
+if (canvas.gifVersion) {
+  exports.gifVersion = canvas.gifVersion.replace(/[^.\d]/g, '');
+}
+
+/**
  * Expose constructors.
  */
 

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -13,7 +13,6 @@
 #include <node_buffer.h>
 
 #ifdef HAVE_GIF
-#include <gif_lib.h>
 typedef struct {
   uint8_t *buf;
   unsigned len;

--- a/src/Image.h
+++ b/src/Image.h
@@ -15,6 +15,10 @@
 #include <jerror.h>
 #endif
 
+#ifdef HAVE_GIF
+#include <gif_lib.h>
+#endif
+
 class Image: public node::ObjectWrap {
   public:
     char *filename;

--- a/src/init.cc
+++ b/src/init.cc
@@ -30,6 +30,9 @@ init (Handle<Object> target) {
   snprintf(jpeg_version, 10, "%d%c", JPEG_LIB_VERSION_MAJOR, JPEG_LIB_VERSION_MINOR + 'a' - 1);
   target->Set(String::New("jpegVersion"), String::New(jpeg_version));
 #endif
+#ifdef HAVE_GIF
+  target->Set(String::New("gifVersion"), String::New(GIF_LIB_VERSION));
+#endif
 }
 
 NODE_MODULE(canvas,init);


### PR DESCRIPTION
Looks something like:

![](http://f.cl.ly/items/0a3i2T3C0d2l2Y3x073D/Screen%20Shot%202012-07-24%20at%2011.13.19%20AM.png)
