### PR TITLE
Fixes an issue related to a wrong variable type (#182)

### DIFF
--- a/src/closure.h
+++ b/src/closure.h
@@ -16,7 +16,7 @@ typedef struct {
   Persistent<Function> pfn;
   Handle<Function> fn;
   unsigned len;
-  unsigned max_len;
+  int16_t max_len;
   uint8_t *data;
   Canvas *canvas;
   cairo_status_t status;


### PR DESCRIPTION
The issue was generated by passing the negative value of an unsigned variable as parameter of the function `AdjustAmountOfExternalAllocatedMemory`.

The version of V8 included in node v0.8.x changed the param type of the function `AdjustAmountOfExternalAllocatedMemory` from `int` to `intptr_t`.

The result of this change is that if `foo` is an unsigned variable, passing `-foo` to `AdjustAmountOfExternalAllocatedMemory` is the same of passing the value `(UINT_MAX - foo + 1)` and not the expected `- foo`.

Changing the type of the passed variable to `int16_t` fixed the issue.
