### PR TITLE
Prevent squashing of legitimate require errors, node 0.6.x+

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -1,10 +1,18 @@
 /**
  * Compat for changes from node 0.4.x to 0.6.x.
  */
+var err;
+
 try {
   module.exports = require('../build/Release/canvas');
-} catch (e) { try {
-  module.exports = require('../build/default/canvas');
 } catch (e) {
-  throw e;
-}}
+  err = e;
+  try {
+    module.exports = require('../build/default/canvas');
+  } catch (e) {
+    if (!/^Cannot find module/.test(err.message)) {
+      throw e;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
`lib/bindings.js` contains a double `try`/`catch`, as a workaround for the different default build directories for node `0.4.x` and `0.6.x`.

The problem, however, is that if one is not using node `0.4.x` and one hits something akin to a linker error, the actual error will get squashed by the compatibility check, and the user will only see `Cannot find module "../build/default/canvas"`.  We encountered this issue at Nodejitsu, and we needed to bundle a modified `node-canvas` in a test app before we even knew what, specifically, was failing.

This patch adds a simplistic test, saving the original error, and throwing the original instead in the event that the error from the `0.4.x` require begins with `Cannot find module`.  Testing the error message with a regex is a bit of a hack, but it seemed significantly saner than asking you guys to drop `0.4.x` support. :)
