### PR TITLE
Changed the node-gyp build to use pkg-config

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -43,8 +43,11 @@
           ]
         }, {  # 'OS!="win"'
           'libraries': [
-            '-lpixman-1',
-            '-lcairo'
+            '<!@(pkg-config pixman-1 --libs)',
+            '<!@(pkg-config cairo --libs)'
+          ],
+          'include_dirs': [
+            '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)'
           ]
         }],
         ['with_pango=="true"', {


### PR DESCRIPTION
This fixes the build on OSX when installing the dependencies through macports, which puts things in /opt/local
