### PR TITLE
make util/has_lib.sh work properly on Debian

### DIFF
--- a/util/has_lib.sh
+++ b/util/has_lib.sh
@@ -2,13 +2,17 @@
 has_lib() {
   local regex="lib$1.+(so|dylib)$"
 
+  # Add /sbin to path as ldconfig is located there on some systems - e.g. Debian
+  # (and it still can be used by unprivileged users):
+  PATH="$PATH:/sbin"
+  export PATH
   # Try using ldconfig on linux systems
   for LINE in `which ldconfig > /dev/null && ldconfig -p 2>/dev/null | grep -E $regex`; do
     return 0
   done
 
   # Try just checking common library locations
-  for dir in /lib /usr/lib /usr/local/lib /opt/local/lib; do
+  for dir in /lib /usr/lib /usr/local/lib /opt/local/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu; do
     test -d $dir && ls $dir | grep -E $regex && return 0
   done
 


### PR DESCRIPTION
The current version of util/has_lib.sh fails to detect libraries on Debian, for 2 reasons:
1. On Debian, `ldconfig` lies in `/sbin/` and therefore isn't found if run by a non-root user
2. On Debian, `libjpeg` is in  `/usr/lib/x86_64-linux-gnu/libjpeg.so` , which is not included in the set of library paths for searching.

My commit remedies both of those problems. 
