### PR TITLE
Call cairo_surface_finish in ~Canvas when pdf

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -1,4 +1,3 @@
-
 //
 // Canvas.cc
 //
@@ -406,6 +405,7 @@ Canvas::Canvas(int w, int h, canvas_type_t t): ObjectWrap() {
 Canvas::~Canvas() {
   switch (type) {
     case CANVAS_TYPE_PDF:
+      cairo_surface_finish(_surface);
       closure_destroy((closure_t *) _closure);
       free(_closure);
       cairo_surface_destroy(_surface);


### PR DESCRIPTION
Fixes an issue where when a pdf surface isn't buffered and then is garbage collected, toBuffer can be called and attempt to realloc the already destroyed closure. cairo_surface_finish ensures that all data from the pdf has been flushed.
