### PR TITLE
Add another search path for system dependencies [Ubuntu 12.04]

### DIFF
--- a/util/has_lib.sh
+++ b/util/has_lib.sh
@@ -8,7 +8,7 @@ has_lib() {
   done
 
   # Try just checking common library locations
-  for dir in /lib /usr/lib /usr/local/lib /opt/local/lib; do
+  for dir in /lib /usr/lib /usr/local/lib /opt/local/lib /usr/lib/x86_64-linux-gnu; do
     test -d $dir && ls $dir | grep -E $regex && return 0
   done
 


### PR DESCRIPTION
This was my solution for the problem in #244. I'd installed dependencies using apt-get according to the installation instructions but I wasn't getting jpeg/gif support. has_lib.sh wasn't finding anything.

This may or may not be a proper solution for this. Perhaps the test should recurse rather than add a specific sub directory? I feel like I'm out of my league here but I'd love to save someone else this hassle.
