### PR TITLE
Fix build on gentoo system

### DIFF
--- a/util/has_lib.sh
+++ b/util/has_lib.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 has_lib() {
-  local regex="lib$1.+(so|dylib)$"
+  local regex="lib$1.+(so|dylib)("$'\033'"\[0m)?$"
 
   # Try using ldconfig on linux systems
-  for LINE in `which ldconfig > /dev/null && ldconfig -p 2>/dev/null | grep -E $regex`; do
+  for LINE in `which ldconfig 2>&1 > /dev/null && ldconfig -p 2>/dev/null | grep -E $regex`; do
     return 0
   done
 


### PR DESCRIPTION
I couldn't build this on my system because `ls` was returning color
codes and the /$/ regex was failing to match end of line. Fixed this by
making the regex aware of colors.

Additionally `which` was spewing errors causing node-gyp to fail early.
