### PR TITLE
changed exports version to 1.0.2

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -1,4 +1,3 @@
-
 /*!
  * Canvas
  * Copyright (c) 2010 LearnBoost <tj@learnboost.com>
@@ -30,7 +29,7 @@ var Canvas = exports = module.exports = Canvas;
  * Library version.
  */
 
-exports.version = '1.0.0';
+exports.version = '1.0.2';
 
 /**
  * Cairo version.


### PR DESCRIPTION
`canvas.version` still reports `"1.0.0"`, instead of `"1.0.2"`
