### PR TITLE
Image.cc error when compiled on OS X, fixed but needs to be merged to the NPM repo. 

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -497,7 +497,7 @@ Image::loadGIFFromBuffer(uint8_t *buf, unsigned len) {
 
   gif_data_t gifd = { buf, len, 0 };
 
-  if ((gif = DGifOpen((void*) &gifd, read_gif_from_memory)) == NULL)
+  if ((gif = DGifOpen((void*) &gifd, read_gif_from_memory, (int*) i)) == NULL)
     return CAIRO_STATUS_READ_ERROR; 
 
   if (GIF_OK != DGifSlurp(gif)) {


### PR DESCRIPTION
NPM spat out a error that there was only 2 params in DGIFOPEN. I added
the third, an error interger.
