### PR TITLE
Adding optional trailing `.8` for has_lib searches to prevent false negatives for JPEG lib

### DIFF
--- a/util/has_lib.sh
+++ b/util/has_lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 has_lib() {
-  local regex="lib$1.+(so|dylib)$"
+  local regex="lib$1.+(so(.8)?|dylib)$"
 
   # Try using ldconfig on linux systems
   for LINE in `which ldconfig > /dev/null && ldconfig -p 2>/dev/null | grep -E $regex`; do


### PR DESCRIPTION
This patch adds the conditional for a `.8` ending to the `libjpeg.so` file.
## Debug notes

I recently moved to a new laptop on [Linux Mint 14 Cinnamon](http://www.linuxmint.com/) and was running into the same issues as #254.

I tried moving back to the old version of Cairo, `1.10.2`, which had worked on my older machine but no luck. I verified multiple times that I had the proper `apt-get` dependencies met as [listed in the wiki](https://github.com/LearnBoost/node-canvas/wiki/Installation---Ubuntu#installing-dependencies).

After some more debugging, I found that `./util/has_lib.sh jpeg` was returning `false` when it should be true. Upon grepping my `ldconfig`, I found the following:

```
$ ldconfig -p | grep jpeg
    libopenjpeg.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libopenjpeg.so.2
    libmjpegutils-1.9.so.0 (libc6,x86-64) => /usr/lib/libmjpegutils-1.9.so.0
    liblavjpeg-1.9.so.0 (libc6,x86-64) => /usr/lib/liblavjpeg-1.9.so.0
    libjpeg.so.8 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libjpeg.so.8
    libjpeg.so.8 (libc6) => /usr/lib/i386-linux-gnu/libjpeg.so.8
```

As a result, I added in my conditional, re-built, and everything magically went back to working.
