### PR TITLE
Add support for multiple page size

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -222,6 +222,16 @@ ctx.fillText('Hello World 3', 50, 80);
 ctx.addPage();
 ```
 
+ It is also possible to create pages with different sizes by passing `witdh` and `height` to the `.addPage()` method:
+
+```js
+ctx.font = '22px Helvetica';
+ctx.fillText('Hello World', 50, 80);
+ctx.addPage(400, 800);
+
+ctx.fillText('Hello World 2', 50, 80);
+```
+
 ## Benchmarks
 
  Although node-canvas is extremely new, and we have not even begun optimization yet it is already quite fast. For benchmarks vs other node canvas implementations view this [gist](https://gist.github.com/664922), or update the submodules and run `$ make benchmark` yourself.

--- a/examples/multi-page-pdf.js
+++ b/examples/multi-page-pdf.js
@@ -29,7 +29,7 @@ ctx.addPage();
 reset();
 h1('Page #2');
 p('This is the second page');
-ctx.addPage();
+ctx.addPage(250, 250); // create a page with half the size of the canvas
 
 reset();
 h1('Page #3');

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -479,11 +479,18 @@ Context2d::New(const Arguments &args) {
 Handle<Value>
 Context2d::AddPage(const Arguments &args) {
   HandleScope scope;
+  int width, height;
+
   Context2d *context = ObjectWrap::Unwrap<Context2d>(args.This());
-  if (!context->canvas()->isPDF()) {
+  Canvas * canvas = context->canvas();
+  if (!canvas->isPDF()) {
     return ThrowException(Exception::Error(String::New("only PDF canvases support .nextPage()")));
   }
   cairo_show_page(context->context());
+
+  width = args[0]->IsNumber() ? args[0]->Uint32Value() : canvas->width;
+  height = args[1]->IsNumber() ? args[1]->Uint32Value() : canvas->height;
+  cairo_pdf_surface_set_size(canvas->surface(), width, height);
   return Undefined();
 }
 

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
+#include <cairo/cairo-pdf.h>
 #include "Canvas.h"
 #include "Point.h"
 #include "Image.h"


### PR DESCRIPTION
Hello !

The patch add two optional parameters `witdh` and `height` to the `.addPage()` method to use a different size for the new page. Both are in pixels.

The patch use the [cairo_pdf_surface_set_size](http://cairographics.org/manual/cairo-PDF-Surfaces.html#cairo-pdf-surface-set-size) method.
