### PR TITLE
Load version from package.json

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -18,7 +18,8 @@ var canvas = require('./bindings')
   , PNGStream = require('./pngstream')
   , JPEGStream = require('./jpegstream')
   , FontFace = canvas.FontFace
-  , fs = require('fs');
+  , fs = require('fs')
+  , package = require("../package.json");
 
 /**
  * Export `Canvas` as the module.
@@ -30,7 +31,7 @@ var Canvas = exports = module.exports = Canvas;
  * Library version.
  */
 
-exports.version = '1.0.0';
+exports.version = package.version;
 
 /**
  * Cairo version.


### PR DESCRIPTION
`canvas.version` has been lagging behind the NPM-visible version number.  This unites the 2 by using values in `package.json`.
