### PR TITLE
JPEGStream: add progressive mode option

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -185,6 +185,7 @@ Canvas.prototype.createSyncJPEGStream = function(options){
   return new JPEGStream(this, {
       bufsize: options.bufsize || 4096
     , quality: options.quality || 75
+    , progressive: options.progressive || false
   });
 };
 

--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -40,7 +40,7 @@ var JPEGStream = module.exports = function JPEGStream(canvas, options, sync) {
   // TODO: implement async
   if ('streamJPEG' == method) method = 'streamJPEGSync';
   process.nextTick(function(){
-    canvas[method](options.bufsize, options.quality, function(err, chunk, len){
+    canvas[method](options.bufsize, options.quality, options.progressive, function(err, chunk, len){
       if (err) {
         self.emit('error', err);
         self.readable = false;

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -350,15 +350,17 @@ NAN_METHOD(Canvas::StreamJPEGSync) {
     return NanThrowTypeError("buffer size required");
   if (!args[1]->IsNumber())
     return NanThrowTypeError("quality setting required");
-  if (!args[2]->IsFunction())
+  if (!args[2]->IsBoolean())
+    return NanThrowTypeError("progressive setting required");
+  if (!args[3]->IsFunction())
     return NanThrowTypeError("callback function required");
 
   Canvas *canvas = ObjectWrap::Unwrap<Canvas>(args.This());
   closure_t closure;
-  closure.fn = Handle<Function>::Cast(args[2]);
+  closure.fn = Handle<Function>::Cast(args[3]);
 
   TryCatch try_catch;
-  write_to_jpeg_stream(canvas->surface(), args[0]->NumberValue(), args[1]->NumberValue(), &closure);
+  write_to_jpeg_stream(canvas->surface(), args[0]->NumberValue(), args[1]->NumberValue(), args[2]->BooleanValue(), &closure);
 
   if (try_catch.HasCaught())
     NanReturnValue(try_catch.ReThrow());

--- a/src/JPEGStream.h
+++ b/src/JPEGStream.h
@@ -96,7 +96,7 @@ jpeg_closure_dest(j_compress_ptr cinfo, closure_t * closure, int bufsize){
 }
 
 void
-write_to_jpeg_stream(cairo_surface_t *surface, int bufsize, int quality, closure_t *closure){
+write_to_jpeg_stream(cairo_surface_t *surface, int bufsize, int quality, bool progressive, closure_t *closure){
   int w = cairo_image_surface_get_width(surface);
   int h = cairo_image_surface_get_height(surface);
   struct jpeg_compress_struct cinfo;
@@ -110,6 +110,8 @@ write_to_jpeg_stream(cairo_surface_t *surface, int bufsize, int quality, closure
   cinfo.image_width = w;
   cinfo.image_height = h;
   jpeg_set_defaults(&cinfo);
+  if (progressive)
+     jpeg_simple_progression(&cinfo);
   jpeg_set_quality(&cinfo, quality, (quality<25)?0:1);
   jpeg_closure_dest(&cinfo, closure, bufsize);
 


### PR DESCRIPTION
Progressive jpegs have several very useful advantages over baseline
jpegs:
- Slightly smaller for the same quality (3-7%)
- Load much faster in most browsers.

This adds the `options.progressive` option to the
canvas.jpegCreateStream() function.
