### PR TITLE
fix win32 build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -36,10 +36,12 @@
       'conditions': [
         ['OS=="win"', {
           'libraries': [
-            '-l<(GTK_Root)/lib/cairo.lib'
+            '-l<(GTK_Root)/lib/cairo.lib',
+            '-l<(GTK_Root)/lib/libpng.lib'
           ],
           'include_dirs': [
             '<(GTK_Root)/include',
+            '<(GTK_Root)/include/cairo',
           ],
           'defines': [
             'snprintf=_snprintf',

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -137,10 +137,12 @@ static cairo_status_t canvas_write_png(cairo_surface_t *surface, png_rw_ptr writ
         bpc = 8;
         png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;
         break;
+#if CAIRO_VERSION_MINOR > 10
     case CAIRO_FORMAT_RGB30:
         bpc = 10;
         png_color_type = PNG_COLOR_TYPE_RGB;
         break;
+#endif
     case CAIRO_FORMAT_RGB24:
         bpc = 8;
         png_color_type = PNG_COLOR_TYPE_RGB;


### PR DESCRIPTION
I had a few minor issues building node-canvas on win32 following your guide at https://github.com/LearnBoost/node-canvas/wiki/Installation---Windows
- PNG.h includes cairo.h which resides in GTK/include/cairo
- undefined references to libpng symbols
- unknown CAIRO_FORMAT_RGB30 for the outdated (but at least precompiled) gtk+bundle you referenced

These changes worked for me.
