### PR TITLE
Fix enabling gif/jpeg options on Ubuntu 13.04

### DIFF
--- a/util/has_lib.sh
+++ b/util/has_lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 has_lib() {
-  local regex="lib$1.+(so|dylib)$"
+  local regex="lib$1.+(so|dylib)"
 
   # Try using ldconfig on linux systems
   for LINE in `which ldconfig > /dev/null && ldconfig -p 2>/dev/null | grep -E $regex`; do


### PR DESCRIPTION
It seems the regular expression used in has_lib.sh is a little too restrictive so does not match neither libgif.so.4 nor libjpeg.so.8 on my Ubuntu 13.04.

The effect is that node-canvas built but is silently missing the support for at least for these formats - calling code then passes in GIF images but an exception is thrown with a file could be be read error but no indication this is because of a build time configuration issue.
