### PR TITLE
NAN dep upgrade, full node@<=0.11.8 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
      "test": "make test"
  }
  , "dependencies": {
-     "nan": "~0.3.0"
+     "nan": "~0.4.1"
  }
  , "devDependencies": {
      "express": "3.0"

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -17,7 +17,7 @@ Persistent<FunctionTemplate> Pattern::constructor;
 
 void
 Pattern::Initialize(Handle<Object> target) {
-  HandleScope scope;
+  NanScope();
 
   // Constructor
   Local<FunctionTemplate> ctor = FunctionTemplate::New(Pattern::New);

--- a/src/init.cc
+++ b/src/init.cc
@@ -20,7 +20,7 @@
 
 extern "C" void
 init (Handle<Object> target) {
-  HandleScope scope;
+  NanScope();
   Canvas::Initialize(target);
   Image::Initialize(target);
   ImageData::Initialize(target);


### PR DESCRIPTION
bring nan up to the latest and a couple of minor fixes to make a successful compile & tests passing on Node 0.11.8 (and down to 0.11.4 in the 0.11 releases).
