### PR TITLE
Fix filter parameter in toBuffer method

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -277,7 +277,7 @@ NAN_METHOD(Canvas::ToBuffer) {
 
     if (!args[2]->StrictEquals(Undefined())) {
       if (args[2]->IsUint32()) {
-        filter = args[1]->Uint32Value();
+        filter = args[2]->Uint32Value();
       } else {
         return NanThrowTypeError("Invalid filter value.");
       }


### PR DESCRIPTION
I tried to write a png to disk using a custom compressionLevel and filter method. But it always failed with `libpng error: Unknown row filter for method 0`. I found this line in the code and it seems to me that the filter is using the wrong index for the parameter (`args[1]` is compressionLevel). So I fixed it.
