### PR TITLE
Fixed include path to cairo.h for OSX build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -53,7 +53,7 @@
             '<!@(pkg-config libpng --libs)'
           ],
           'include_dirs': [
-            '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g | sed "s/include\/cairo/include/g")',
+            '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)',
             '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)'
           ]
         }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -53,7 +53,7 @@
             '<!@(pkg-config libpng --libs)'
           ],
           'include_dirs': [
-            '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)',
+            '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g | sed "s/include\/cairo/include/g")',
             '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)'
           ]
         }],

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -16,7 +16,7 @@
 #if HAVE_PANGO
 #include <pango/pangocairo.h>
 #else
-#include <cairo/cairo.h>
+#include <cairo.h>
 #endif
 
 #include "nan.h"

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -2,7 +2,7 @@
 #define _CANVAS_PNG_H
 #include <png.h>
 #include <pngconf.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <stdlib.h>
 #include <string.h>
 #include "closure.h"


### PR DESCRIPTION
This was not affecting Linux env because gcc seems nicer there (e.g. /usr/local/include is added by default to gcc include path).
On OSX, build error was:
../src/Canvas.h:19:10: fatal error: 'cairo/cairo.h' file not found
#include &lt;cairo/cairo.h&gt;
Other way to fix this is to remove “cairo/“ from both #include in ./src/Canvas.h and ./src/PNG.h