### PR TITLE
Add CAIRO_FORMAT_INVALID

### DIFF
--- a/src/PNG.h
+++ b/src/PNG.h
@@ -15,6 +15,10 @@
 #define unlikely(expr) (expr)
 #endif
 
+#ifndef CAIRO_FORMAT_INVALID
+#define CAIRO_FORMAT_INVALID -1
+#endif
+
 static void canvas_png_flush(png_structp png_ptr) {
     /* Do nothing; fflush() is said to be just a waste of energy. */
     (void) png_ptr;   /* Stifle compiler warning */


### PR DESCRIPTION
Fixes https://github.com/LearnBoost/node-canvas/issues/342

Ubuntu Lucid LTS has Cairo 1.8.10 which doesn't support it. Copied the value from http://cairographics.org/manual/cairo-Image-Surfaces.html
