### PR TITLE
Add support for the lineDash API.

### DIFF
--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -100,6 +100,8 @@ class Context2d: public node::ObjectWrap {
     static NAN_METHOD(SetStrokePattern);
     static NAN_METHOD(SetTextBaseline);
     static NAN_METHOD(SetTextAlignment);
+    static NAN_METHOD(SetLineDash);
+    static NAN_METHOD(GetLineDash);
     static NAN_METHOD(MeasureText);
     static NAN_METHOD(BezierCurveTo);
     static NAN_METHOD(QuadraticCurveTo);
@@ -121,6 +123,7 @@ class Context2d: public node::ObjectWrap {
     static NAN_GETTER(GetLineCap);
     static NAN_GETTER(GetLineJoin);
     static NAN_GETTER(GetLineWidth);
+    static NAN_GETTER(GetLineDashOffset);
     static NAN_GETTER(GetShadowOffsetX);
     static NAN_GETTER(GetShadowOffsetY);
     static NAN_GETTER(GetShadowBlur);
@@ -135,6 +138,7 @@ class Context2d: public node::ObjectWrap {
     static NAN_SETTER(SetLineCap);
     static NAN_SETTER(SetLineJoin);
     static NAN_SETTER(SetLineWidth);
+    static NAN_SETTER(SetLineDashOffset);
     static NAN_SETTER(SetShadowOffsetX);
     static NAN_SETTER(SetShadowOffsetY);
     static NAN_SETTER(SetShadowBlur);

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1851,3 +1851,68 @@ tests['putImageData() png data 3'] = function(ctx, done){
   img.onerror = function(){}
   img.src = 'state.png';
 };
+
+tests['setLineDash']  = function(ctx, done){
+  ctx.setLineDash([10, 5, 25, 15]);
+  ctx.lineWidth = 17;
+
+  var y=5;
+  var line = function(lineDash, color){
+    ctx.setLineDash(lineDash);
+    if (color) ctx.strokeStyle = color;
+    ctx.beginPath();
+    ctx.moveTo(0,   y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += ctx.lineWidth + 4;
+  };
+
+  line([15, 30], "blue");
+  line([], "black");
+  line([5,10,15,20,25,30,35,40,45,50], "purple");
+  line([8], "green");
+  line([3, 3, -30], "red");
+  line([4, Infinity, 4]);
+  line([10, 10, NaN]);
+  line((function(){
+    ctx.setLineDash([8]);
+    var a = ctx.getLineDash();
+    a[0] -= 3;
+    a.push(20);
+    return a;
+  })(), "orange");
+};
+
+tests['lineDashOffset']  = function(ctx, done){
+  ctx.setLineDash([10, 5, 25, 15]);
+  ctx.lineWidth = 4;
+
+  var y=5;
+  var line = function(lineDashOffset, color){
+    ctx.lineDashOffset = lineDashOffset;
+    if (color) ctx.strokeStyle = color;
+    ctx.beginPath();
+    ctx.moveTo(0,   y);
+    ctx.lineTo(200, y);
+    ctx.stroke();
+    y += ctx.lineWidth + 4;
+  };
+
+  line(-10, "black");
+  line(0);
+  line(10);
+  line(20);
+  line(30);
+  line(40, "blue");
+  line(NaN)
+  line(50, "green");
+  line(Infinity)
+  line(60, "orange");
+  line(-Infinity)
+  line(70, "purple");
+  line(void 0)
+  line(80, "black");
+  line(ctx.lineDashOffset + 10);
+  for (var i=0; i<10; i++)
+    line(90 + i/5, "red");
+}


### PR DESCRIPTION
Described here:
http://www.w3.org/TR/2dcontext/#dom-context-2d-setlinedash

The test images match on Chrome, but not on Firefox. It looks like
Firefox resets the lineDash to [] when given invalid parameters. My
reading of the spec agrees with Chrome.

-David
