### PR TITLE
Update nan dependency from 1.7.0 to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
      "test": "make test"
  }
  , "dependencies": {
-     "nan": "~0.7.0"
+     "nan": "~0.7.1"
  }
  , "devDependencies": {
      "express": "3.0"


### PR DESCRIPTION
I had impossible problems with `npm install canvas` on a fairly recent Ubuntu, a freshly compiled node v0.11.12, npm v1.4.3, and all the proper dependencies. My problems seemed to start here:

```
In file included from ../src/Canvas.h:22:0,
                 from ../src/Canvas.cc:7:
../node_modules/nan/nan.h: In function ‘bool _NanGetExternalParts(v8::Handle<v8::Value>, const char**, size_t*)’:
../node_modules/nan/nan.h:810:78: error: no matching function for call to ‘v8::Local<v8::String>::New(v8::Handle<v8::String>)’
   v8::Local<v8::String> str = v8::Local<v8::String>::New(val.As<v8::String>());
                                                                              ^
../node_modules/nan/nan.h:810:78: note: candidates are:
In file included from ../src/Canvas.h:11:0,
                 from ../src/Canvas.cc:7:
/home/tapmodo/.node-gyp/0.11.12/deps/v8/include/v8.h:381:29: note: static v8::Local<T> v8::Local<T>::New(v8::Isolate*, v8::Handle<T>) [with T = v8::String]
   V8_INLINE static Local<T> New(Isolate* isolate, Handle<T> that);
                             ^
/home/tapmodo/.node-gyp/0.11.12/deps/v8/include/v8.h:381:29: note:   candidate expects 2 arguments, 1 provided
/home/tapmodo/.node-gyp/0.11.12/deps/v8/include/v8.h:383:29: note: template<class M> static v8::Local<T> v8::Local<T>::New(v8::Isolate*, const v8::Persistent<T, M>&) [with M = M; T = v8::String]
   V8_INLINE static Local<T> New(Isolate* isolate,
                             ^
/home/tapmodo/.node-gyp/0.11.12/deps/v8/include/v8.h:383:29: note:   template argument deduction/substitution failed:
In file included from ../src/Canvas.h:22:0,
                 from ../src/Canvas.cc:7:
../node_modules/nan/nan.h:810:78: note:   cannot convert ‘val.v8::Handle<T>::As<v8::String>()’ (type ‘v8::Handle<v8::String>’) to type ‘v8::Isolate*’
   v8::Local<v8::String> str = v8::Local<v8::String>::New(val.As<v8::String>());
                                                                              ^
```

**Updating the nan dependency to 0.7.1 solved my problem.**
I had no problems using 0.8.0, also available, but I am not sure what the ramifications of the change are. 0.7.1 was enough to solve my problem. I _do_ know that nan 0.7.0 would not allow me to build node-canvas.
