### PR TITLE
Load font file in FontConfig when using Pango

### DIFF
--- a/src/FontFace.cc
+++ b/src/FontFace.cc
@@ -8,6 +8,8 @@
 
 #include <nan.h>
 
+#include <fontconfig/fontconfig.h>
+
 Persistent<FunctionTemplate> FontFace::constructor;
 
 /*
@@ -80,6 +82,14 @@ NAN_METHOD(FontFace::New) {
   if (ftError) {
     return NanThrowError("Could not load font file");
   }
+
+#if HAVE_PANGO
+  // Load the font file in fontconfig
+  FcBool ok = FcConfigAppFontAddFile(FcConfigGetCurrent(), (FcChar8 *)(*filePath));
+  if (!ok) {
+    return NanThrowError("Could not load font in FontConfig");
+  }
+#endif
 
   // Create new cairo font face.
   crFace = cairo_ft_font_face_create_for_ft_face(ftFace, 0);


### PR DESCRIPTION
We need the text rendering capabilities of Pango (i.e. kerning), so we built node-canvas with 'with_pango' set to true. Problem is, that we use a custom TrueType font and it seems that node-canvas doesn't load it properly when using Pango.

The proposed change fixes the font loading step by calling FontConfig API.

Sample code:

    var canvas = new Canvas(400,40);
    var ctx = canvas.getContext('2d');
    var Font = Canvas.Font;
    
    var myFont = new Font('MyFont', '../fonts/pip.ttf');
    myFont.addFace('../fonts/pipBold.ttf', 'bold');
    
    // Do not call addFont when using Pango
    //ctx.addFont(myFont);
    
    ctx.font = "30px MyFont";
    ctx.fillText("kerning enabled AVAVAVA", 2, 32);
