### PR TITLE
Upgraded Freetype version, Added FontConfig

### DIFF
--- a/install
+++ b/install
@@ -3,7 +3,8 @@
 PKG_CONFIG="http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
 PIXMAN="http://www.cairographics.org/releases/pixman-0.32.4.tar.gz"
 CAIRO="http://cairographics.org/releases/cairo-1.12.16.tar.xz"
-FREETYPE="http://download.savannah.gnu.org/releases/freetype/freetype-2.4.10.tar.gz"
+FONTCONFIG="http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz"
+FREETYPE="http://download.savannah.gnu.org/releases/freetype/freetype-2.5.3.tar.gz"
 LIBPNG="http://downloads.sourceforge.net/project/libpng/libpng16/1.6.10/libpng-1.6.10.tar.gz"
 PREFIX=${1-/usr/local}
 
@@ -58,6 +59,7 @@ require tar
 test `which pkg-config` || fetch $PKG_CONFIG
 require 'pkg-config'
 fetch $LIBPNG
+fetch $FONTCONFIG
 fetch $FREETYPE
 fetch $PIXMAN
 fetch_xz $CAIRO


### PR DESCRIPTION
We might want to leave FontConfig out, but Freetype itself recommends it.

I did however update the Freetype version which is required, I must have missed it in my last PR.