### PR TITLE
Fix compile error with Visual C++

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -21,6 +21,12 @@
 #include "FontFace.h"
 #endif
 
+// Windows doesn't support the C99 names for these
+#ifndef isnan
+#define isnan(x) _isnan(x)
+#define isinf(x) (!_finite(x))
+#endif
+
 Persistent<FunctionTemplate> Context2d::constructor;
 
 /*


### PR DESCRIPTION
Microsoft's Visual C++ doesn't support C99 and so variable length arrays, `isnan()`, and `isinf()` don't compile. These commits address that.

The discussion for these changes [took place here](https://github.com/LearnBoost/node-canvas/pull/373/files#diff-d52111b9458a13e196dab8299f822c29R2035).

This should fix Issue #420.
