### PR TITLE
Add `toAnsiString` to Canvas and Image when compiled with libcaca

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,8 @@
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
-        'with_freetype%': 'false'
+        'with_freetype%': 'false',
+        'with_caca%': 'false'
       }
     }, { # 'OS!="win"'
       'variables': {
@@ -14,7 +15,8 @@
         'with_gif%': '<!(./util/has_lib.sh gif)',
         # disable pango as it causes issues with freetype.
         'with_pango%': 'false',
-        'with_freetype%': '<!(./util/has_cairo_freetype.sh)'
+        'with_freetype%': '<!(./util/has_cairo_freetype.sh)',
+        'with_caca%': '<!(./util/has_lib.sh caca)'
       }
     }]
   ],
@@ -162,6 +164,28 @@
             }, {
               'libraries': [
                 '-lgif'
+              ]
+            }]
+          ]
+        }],
+        ['with_caca=="true"', {
+          'defines': [
+            'HAVE_CACA'
+          ],
+          'sources': [
+            'src/Caca.cc'
+          ],
+          'conditions': [
+            ['OS=="win"', {
+              'libraries': [
+                '-l<(GTK_Root)/lib/caca.lib'
+              ]
+            }, {
+              'include_dirs': [ # tried to pass through cflags but failed
+                '<!@(pkg-config caca --cflags-only-I | sed s/-I//g)'
+              ],
+              'libraries': [
+                '<!@(pkg-config caca --libs)'
               ]
             }]
           ]

--- a/examples/caca.js
+++ b/examples/caca.js
@@ -1,0 +1,32 @@
+var Canvas = require('../lib/canvas')
+  , Image = Canvas.Image
+  , canvas = new Canvas(480, 408)
+  , ctx = canvas.getContext('2d')
+  , fs = require('fs');
+
+var cat = fs.readFileSync(__dirname + '/images/lime-cat.jpg');
+img = new Image;
+img.src = cat;
+ctx.drawImage(img, 0, 0);
+
+if (process.stdout.isTTY) {
+  var cols = process.stdout.columns;
+  var rows = process.stdout.rows;
+} else {
+  var cols = 80;
+  var rows = 24;
+}
+
+var fontWidth = 10;
+var fontHeight = 20;
+
+var options = {fontWidth: fontWidth, fontHeight: fontHeight};
+
+var terminalAspectRatio = (cols * fontWidth) / (rows * fontHeight);
+if (canvas.width / canvas.height > terminalAspectRatio) {
+  options.cols = cols;
+} else {
+  options.rows = rows;
+}
+process.stdout.write(canvas.toAnsiString(options));
+

--- a/install
+++ b/install
@@ -6,6 +6,7 @@ CAIRO="http://cairographics.org/releases/cairo-1.12.16.tar.xz"
 FREETYPE="http://download.savannah.gnu.org/releases/freetype/freetype-2.4.10.tar.gz"
 LIBPNG="http://downloads.sourceforge.net/project/libpng/libpng16/1.6.10/libpng-1.6.10.tar.gz"
 GIF_LIB="https://downloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.1.6/giflib-4.1.6.tar.gz"
+LIBCACA="http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz"
 PREFIX=${1-/usr/local}
 
 require() {
@@ -62,4 +63,5 @@ fetch $LIBPNG
 fetch $GIF_LIB
 fetch $FREETYPE
 fetch $PIXMAN
+fetch $LIBCACA
 fetch_xz $CAIRO

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -220,3 +220,36 @@ Canvas.prototype.toDataURL = function(type, fn){
     return prefix + this.toBuffer().toString('base64');
   }
 };
+
+if (canvas.toAnsiString) {
+  Canvas.prototype.toAnsiString =
+  Image.prototype.toAnsiString =
+  function(options) {
+    if (options == null) { // null or undefined
+      options = {};
+    }
+
+    var cols = options.cols || options.columns;
+    var rows = options.rows || options.lines;
+    var fontWidth = options.fontWidth;
+    var fontHeight = options.fontHeight;
+
+    // default options are the same as those of libcaca's img2txt
+    if (!(fontWidth > 0)) {
+      fontWidth = 6;
+    }
+    if (!(fontHeight > 0)) {
+      fontHeight = 10;
+    }
+    if (!(cols > 0) && !(rows > 0)) {
+      cols = 60;
+      rows = cols * this.height * fontWidth / this.width / fontHeight;
+    } else if (!(rows > 0)) {
+      rows = cols * this.height * fontWidth / this.width / fontHeight;
+    } else if (!(cols > 0)) {
+      cols = rows * this.width * fontHeight / this.height / fontWidth;
+    }
+
+    return canvas.toAnsiString.call(this, cols, rows);
+  }
+}

--- a/src/Caca.cc
+++ b/src/Caca.cc
@@ -1,0 +1,79 @@
+#include "Caca.h"
+
+void
+Caca::Initialize(Handle<Object> target) {
+  NanScope();
+  target->Set(NanNew("toAnsiString"),
+      NanNew<FunctionTemplate>(Caca::ToAnsiString)->GetFunction());
+}
+
+NAN_METHOD(Caca::ToAnsiString) {
+  NanScope();
+  uint8_t *data;
+  int width, height;
+
+  // Image
+  if (NanHasInstance(Image::constructor, args.This())) {
+    Image *img = ObjectWrap::Unwrap<Image>(args.This());
+    if (!img->isComplete()) {
+      return NanThrowError("Image given has not completed loading");
+    }
+    data = img->data();
+    width = img->width;
+    height = img->height;
+
+  // Canvas
+  } else if (NanHasInstance(Canvas::constructor, args.This())) {
+    Canvas *canvas = ObjectWrap::Unwrap<Canvas>(args.This());
+    data = canvas->data();
+    width = canvas->width;
+    height = canvas->height;
+
+  // Invalid
+  } else {
+    return NanThrowTypeError("Image or Canvas expected");
+  }
+
+  int cols = args[0]->Uint32Value();
+  int lines = args[1]->Uint32Value();
+
+  caca_canvas_t *cv = caca_create_canvas(cols, lines);
+
+  if (!cv) {
+    return NanThrowRangeError("Unable to initialize libcaca");
+  }
+
+  unsigned int depth, bpp, rmask, gmask, bmask, amask;
+
+  rmask = 0x00ff0000;
+  gmask = 0x0000ff00;
+  bmask = 0x000000ff;
+  amask = 0xff000000;
+  bpp = 32;
+  depth = 4;
+
+  struct caca_dither *dither = caca_create_dither(
+      bpp, width, height, depth * width, rmask, gmask, bmask, amask);
+
+  if (!dither) {
+    return NanThrowRangeError("Unable to create libcaca dither");
+  }
+
+  caca_set_color_ansi(cv, CACA_DEFAULT, CACA_TRANSPARENT);
+  caca_clear_canvas(cv);
+
+  caca_dither_bitmap(cv, 0, 0, cols, lines, dither, data);
+
+  size_t len;
+  void *text = caca_export_canvas_to_memory(cv, "utf8", &len);
+  if (!text) {
+    return NanThrowRangeError("Unable to export to ansi string");
+  }
+
+  Local<String> ret = NanNew<String>((char *)text, len);
+
+  caca_free_canvas(cv);
+  free(text);
+
+  NanReturnValue(ret);
+}

--- a/src/Caca.h
+++ b/src/Caca.h
@@ -1,0 +1,15 @@
+#ifndef __NODE_CACA_H__
+#define __NODE_CACA_H__
+
+#include "Canvas.h"
+#include "Image.h"
+#include <caca.h>
+
+class Caca {
+  public:
+    static void Initialize(Handle<Object> target);
+    static NAN_METHOD(ToAnsiString);
+};
+
+#endif
+

--- a/src/init.cc
+++ b/src/init.cc
@@ -17,6 +17,9 @@
 #ifdef HAVE_FREETYPE
 #include "FontFace.h"
 #endif
+#ifdef HAVE_CACA
+#include "Caca.h"
+#endif
 
 extern "C" void
 init (Handle<Object> target) {
@@ -30,6 +33,9 @@ init (Handle<Object> target) {
   Pattern::Initialize(target);
 #ifdef HAVE_FREETYPE
   FontFace::Initialize(target);
+#endif
+#ifdef HAVE_CACA
+  Caca::Initialize(target);
 #endif
 
   target->Set(NanNew<String>("cairoVersion"), NanNew<String>(cairo_version_string()));

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -521,6 +521,31 @@ module.exports = {
     }
   },
 
+  'test .toAnsiString': function(){
+    // method not available if not compiled with libcaca
+    if (!Canvas.prototype.toAnsiString) return;
+
+    var pattern = new Canvas(2, 2)
+      , checkers = pattern.getContext('2d');
+
+    // white
+    checkers.fillStyle = '#fff';
+    checkers.fillRect(0,0,2,2);
+
+    // black
+    checkers.fillStyle = '#000';
+    checkers.fillRect(0,0,1,1);
+    checkers.fillRect(1,1,1,1);
+
+    var ansiString = pattern.toAnsiString({rows: 2, cols: 2});
+    var expected = [
+      "\u001b[0;34;40m \u001b[0;37;5;47;107m \u001b[0m",
+      "\u001b[0;37;5;47;107m \u001b[0;34;40m \u001b[0m",
+      ""
+    ].join("\n");
+    assert.equal(expected, ansiString);
+  },
+
   'test Context2d#createPattern(Image)': function(){
     var img = new Canvas.Image();
     img.src = __dirname + '/fixtures/checkers.png';


### PR DESCRIPTION
This is almost a joke, but someone might find it useful for print-debugging (especially if they are developing on a remote server).

I used some code from img2txt in [libcaca](http://caca.zoy.org/wiki/libcaca), which should't be a problem according to it's [Do What The Fuck You Want To Public License](http://www.wtfpl.net/faq/).
