### PR TITLE
libjpeg-turbo for windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,10 +3,20 @@
     ['OS=="win"', {
       'variables': {
         'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
-        'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
-        'with_freetype%': 'false'
+        'with_freetype%': 'false',
+        'variables': { # Nest jpeg_root to evaluate it before with_jpeg
+          'jpeg_root%': '<!(node ./util/win_jpeg_lookup)'
+        },
+        'jpeg_root%': '<(jpeg_root)', # Take value of nested variable
+        'conditions': [
+          ['jpeg_root==""', {
+            'with_jpeg%': 'false'
+          }, {
+            'with_jpeg%': 'true'
+          }]
+        ]
       }
     }, { # 'OS!="win"'
       'variables': {
@@ -139,7 +149,10 @@
           'conditions': [
             ['OS=="win"', {
               'libraries': [
-                '-l<(GTK_Root)/lib/jpeg.lib'
+                '-l<(jpeg_root)/lib/jpeg-static.lib'
+              ],
+              'include_dirs': [
+                '<(jpeg_root)/include'
               ]
             }, {
               'libraries': [

--- a/util/win_jpeg_lookup.js
+++ b/util/win_jpeg_lookup.js
@@ -1,0 +1,21 @@
+var fs = require('fs')
+var paths = ['C:/libjpeg-turbo']
+
+if (process.arch === 'x64') {
+  paths.unshift('C:/libjpeg-turbo64')
+}
+
+paths.forEach(function(path){
+  if (exists(path)) {
+    process.stdout.write(path)
+    process.exit()
+  }
+})
+
+function exists(path) {
+  try {
+    return fs.lstatSync(path).isDirectory()
+  } catch(e) {
+    return false
+  }
+}


### PR DESCRIPTION
This PR adds JPEG support to canvas under Windows. See also #427. Instructions for user are simple: install `libjpeg-turbo` to it's default location.

A batch script tests if the directory exists, so nothing breaks when libjpeg-turbo is not installed.
