### PR TITLE
Support SVG output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ examples/*.jpg
 testing
 out.png
 out.pdf
+out.svg
 .pomo
 node_modules
 

--- a/Readme.md
+++ b/Readme.md
@@ -250,6 +250,17 @@ ctx.fillText('Hello World 3', 50, 80);
 ctx.addPage();
 ```
 
+## SVG support
+
+ Just like PDF support, make sure to install cairo with `--enable-svg=yes`.
+ You also need to tell node-canvas that it is working on SVG upon its initialization:
+
+```js
+var canvas = new Canvas(200, 500, 'svg');
+// Use the normal primitives.
+fs.writeFile('out.svg', canvas.toBuffer());
+```
+
 ## Benchmarks
 
  Although node-canvas is extremely new, and we have not even begun optimization yet it is already quite fast. For benchmarks vs other node canvas implementations view this [gist](https://gist.github.com/664922), or update the submodules and run `$ make benchmark` yourself.

--- a/examples/small-svg.js
+++ b/examples/small-svg.js
@@ -1,0 +1,22 @@
+
+var Canvas = require('../')
+  , canvas = new Canvas(400, 200, 'svg')
+  , ctx = canvas.getContext('2d')
+  , fs = require('fs');
+
+var y = 80
+  , x = 50;
+
+ctx.font = '22px Helvetica';
+ctx.fillText('node-canvas SVG', x, y);
+
+ctx.font = '10px Arial';
+ctx.fillText('Just a quick example of SVGs with node-canvas', x, y += 20);
+
+ctx.globalAlpha = .5;
+ctx.fillRect(x, y += 20, 10, 10);
+ctx.fillRect(x += 20, y, 10, 10);
+ctx.fillRect(x += 20, y, 10, 10);
+
+fs.writeFile('out.svg', canvas.toBuffer());
+console.log('created out.svg');

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -39,7 +39,8 @@ using namespace node;
 
 typedef enum {
   CANVAS_TYPE_IMAGE,
-  CANVAS_TYPE_PDF
+  CANVAS_TYPE_PDF,
+  CANVAS_TYPE_SVG
 } canvas_type_t;
 
 /*
@@ -78,6 +79,7 @@ class Canvas: public node::ObjectWrap {
 #endif
 
     inline bool isPDF(){ return CANVAS_TYPE_PDF == type; }
+    inline bool isSVG(){ return CANVAS_TYPE_SVG == type; }
     inline cairo_surface_t *surface(){ return _surface; }
     inline void *closure(){ return _closure; }
     inline uint8_t *data(){ return cairo_image_surface_get_data(_surface); }

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -165,6 +165,8 @@ module.exports = {
     assert('image' == canvas.type);
     var canvas = new Canvas(10, 10, 'pdf');
     assert('pdf' == canvas.type);
+    var canvas = new Canvas(10, 10, 'svg');
+    assert('svg' == canvas.type);
     var canvas = new Canvas(10, 10, 'hey');
     assert('image' == canvas.type);
   },


### PR DESCRIPTION
Very similarly to how node-canvas supports PDF output, supporting SVG gives huge interesting opportunities.
- Getting SVG paths from text of a specific font (instead of resorting to web-safe fonts),
- Generating customized SVG images server-side, which saves more bandwidth the larger the image _and_ doesn't have that zooming / retina / 2x / <picture> issue,
- Computing SVG images to be inserted in the middle of your HTML page, which makes it part of the DOM and can be animated by a nearby script.

Overall, adding SVG was smooth. There was a tricky bit however. Since, unlike PDFs, cairo doesn't support dynamically changing the size of the display, the next obvious choice was to resort to using cairo's recordable surfaces. However, they do not look as good, for some unfathomable reason:

Direct SVG output: 
![canvas-normal](https://cloud.githubusercontent.com/assets/100689/4098419/fc1e061a-301d-11e4-8899-1a7c18c20497.png)

Recorded surface, repainted on an SVG output:
![canvas-dirty](https://cloud.githubusercontent.com/assets/100689/4098420/0f936b9a-301e-11e4-9277-041333eb787a.png)

So I chose to delete and recreate the SVG surface every time instead.
