### PR TITLE
Add one-liner MacPorts install to docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,12 @@ You can quickly install Cairo and its dependencies for OS X using the one liner 
 $ wget https://raw.githubusercontent.com/LearnBoost/node-canvas/master/install -O - | sh
 ```
 
+or if you use MacPorts
+
+```bash
+sudo port install pkgconfig libpng giflib freetype libpixman cairo
+```
+
 ## Screencasts
 
   - [Introduction](http://screenr.com/CTk)


### PR DESCRIPTION
I had a lot of issues with the existing one-liner shell script for installing cairo and its dependencies. Executing the added line in MacPorts worked quickly and without incident.
