### PR TITLE
Fix image loading for non-POSIX systems.

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -392,7 +392,7 @@ Image::error(Local<Value> err) {
 
 cairo_status_t
 Image::loadSurface() {
-  FILE *stream = fopen(filename, "r");
+  FILE *stream = fopen(filename, "rb");
   if (!stream) return CAIRO_STATUS_READ_ERROR;
   uint8_t buf[5];
   if (1 != fread(&buf, 5, 1, stream)) {


### PR DESCRIPTION
fix fopen mode for non-POSIX platform : on POSIX platform, fopen open file in binary mode by default. On non-POSIX platform (like WIndows), fopen open file in text mode by default. Using 'rb' mode fix this issue.