### PR TITLE
re-enable pango, use fontconfig and floats for drawImage()

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,7 @@
         'with_jpeg%': '<!(./util/has_lib.sh jpeg)',
         'with_gif%': '<!(./util/has_lib.sh gif)',
         # disable pango as it causes issues with freetype.
-        'with_pango%': 'false',
+        'with_pango%': '<!(./util/has_lib.sh pangocairo)',
         'with_freetype%': '<!(./util/has_cairo_freetype.sh)'
       }
     }]

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -606,7 +606,7 @@ NAN_METHOD(Context2d::DrawImage) {
   if (args.Length() < 3)
     return NanThrowTypeError("invalid arguments");
 
-  int sx = 0
+  float sx = 0
     , sy = 0
     , sw = 0
     , sh = 0

--- a/src/FontFace.cc
+++ b/src/FontFace.cc
@@ -6,6 +6,8 @@
 
 #include "FontFace.h"
 
+#include <fontconfig/fontconfig.h>
+
 Persistent<FunctionTemplate> FontFace::constructor;
 
 /*
@@ -78,6 +80,14 @@ NAN_METHOD(FontFace::New) {
   if (ftError) {
     return NanThrowError("Could not load font file");
   }
+
+  #if HAVE_PANGO
+    // Load the font file in fontconfig
+    FcBool ok = FcConfigAppFontAddFile(FcConfigGetCurrent(), (FcChar8 *)(*filePath));
+    if (!ok) {
+      return NanThrowError("Could not load font in FontConfig");
+    }
+  #endif
 
   // Create new cairo font face.
   crFace = cairo_ft_font_face_create_for_ft_face(ftFace, 0);


### PR DESCRIPTION
- Pango seems to work fine for me (what's the issue its supposed to cause with freetype?) and means I can have fallback fonts, better kerning etc.

- Fontconfig enables finding fonts when using Pango (see also https://github.com/Automattic/node-canvas/issues/266#issuecomment-66109167).

- I have a need for floats rather than ints for the drawImage() arguments.