### PR TITLE
Use non-cairo 1.12 API for shadow blur

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -372,7 +372,7 @@ Context2d::shadow(void (fn)(cairo_t *cr)) {
     cairo_user_to_device_distance(_context, &dx, &dy);
     int pad = state->shadowBlur * 2;
     cairo_surface_t *surface = cairo_get_group_target(_context);
-    cairo_surface_t *shadow_surface = cairo_surface_create_similar_image(surface,
+    cairo_surface_t *shadow_surface = cairo_image_surface_create(
       CAIRO_FORMAT_ARGB32,
       dx + 2 * pad,
       dy + 2 * pad);


### PR DESCRIPTION
Just use cairo_image_surface_create for shadow blur surface, rather than cairo_surface_create_similar_image used in #505; this call was introduced in cairo 1.12.  Unfortunately the cairo distributed with GTK+, used in the Windows build, is only 1.10.

Using the similar_image version offers backends the chance to be more efficient, but the alternative used here is used as a fallback in the cairo code anyway.

This should fix #509.