### PR TITLE
Fix drawImage clipping bug

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -739,6 +739,8 @@ NAN_METHOD(Context2d::DrawImage) {
     cairo_scale(ctx, fx, fy);
     dx /= fx;
     dy /= fy;
+    dw /= fx;
+    dh /= fy;
   }
 
   if (context->hasShadow()) {


### PR DESCRIPTION
Fix regression introduced by reordering of image shadow code in 39766d1 -- the clip width and height wasn't being adjusted for the current scale.  Affected images that were not being drawn at 1:1 scale.

Candidate fix for #512.