### PR TITLE
Accept and ignore toDataURL encoderOptions argument

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -198,12 +198,13 @@ Canvas.prototype.createSyncJPEGStream = function(options){
  * @api public
  */
 
-Canvas.prototype.toDataURL = function(type, fn){
+Canvas.prototype.toDataURL = function(type, encoderOptions, fn){
   // Default to png
   type = type || 'image/png';
 
-  // Allow callback as first arg
+  // Allow callback as first or second arg, ignore encoderOptions
   if ('function' == typeof type) fn = type, type = 'image/png';
+  if ('function' == typeof encoderOptions ) fn = encoderOptions;
 
   // Throw on non-png
   if ('image/png' != type) throw new Error('currently only image/png is supported');

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -383,6 +383,7 @@ module.exports = {
 
     assert.ok(0 == canvas.toDataURL().indexOf('data:image/png;base64,'));
     assert.ok(0 == canvas.toDataURL('image/png').indexOf('data:image/png;base64,'));
+    assert.ok(0 == canvas.toDataURL('image/png',1).indexOf('data:image/png;base64,'));
 
     var err;
     try {
@@ -402,6 +403,13 @@ module.exports = {
 
   'test Canvas#toDataURL() async with type': function(){
     new Canvas(200,200).toDataURL('image/png', function(err, str){
+      assert.ok(!err);
+      assert.ok(0 == str.indexOf('data:image/png;base64,'));
+    });
+  },
+
+  'test Canvas#toDataURL() async with type, encoderOptions': function(){
+    new Canvas(200,200).toDataURL('image/png', 1, function(err, str){
       assert.ok(!err);
       assert.ok(0 == str.indexOf('data:image/png;base64,'));
     });


### PR DESCRIPTION
Added the encoderOptions argument in toDataURL per [spec!](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement.toDataURL) so that node-canvas can be used with other canvas libraries.

The argument is ignored since it is not used with image/png.  Tests included.

Thanks, Team!