### PR TITLE
Add toDataURL tests inspired by a failure seen with jsdom.

### DIFF
--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -407,6 +407,24 @@ module.exports = {
     });
   },
 
+  'test Canvas#toDataURL() {width,height}=': function(){
+    var canvas = new Canvas;
+    canvas.width = 50;
+    canvas.height = 50;
+    assert.equal(50, canvas.width);
+    assert.equal(50, canvas.height);
+    assert.ok(0 == canvas.toDataURL().indexOf('data:image/png;base64,'));
+    assert.ok(0 == canvas.toDataURL('image/png').indexOf('data:image/png;base64,'));
+  },
+
+  'test Canvas#toDataURL() default {width,height}': function(){
+    var canvas = new Canvas;
+    assert.equal(0, canvas.width);
+    assert.equal(0, canvas.height);
+    assert.ok(0 == canvas.toDataURL().indexOf('data:image/png;base64,'));
+    assert.ok(0 == canvas.toDataURL('image/png').indexOf('data:image/png;base64,'));
+  },
+
   'test Context2d#createImageData(width, height)': function(){
     var canvas = new Canvas(20, 20)
       , ctx = canvas.getContext('2d');


### PR DESCRIPTION
I'm getting the following error when using  with jsdom and it's integration with node-canvas for a `<canvas></canvas>` parse. The canvas init looks like `new Canvas(0,0)`. 
```
Error: the surface type is not appropriate for the operation
```

I've written two simple tests here that duplicate the behavior. I believe jsdom intends to be using the behavior of the first test where width/height are set later (that test passes). However, it's inadvertently mimicking the behavior of the second test, which fails. Is that expected? or should the error be caught?

Thanks! Awesome project.
