### PR TITLE
Unify the API for working with fonts when Pango is enabled.

### DIFF
--- a/examples/font.js
+++ b/examples/font.js
@@ -23,7 +23,7 @@ pfennigFont.addFace(fontFile('PfennigBold.ttf'),   'bold');
 pfennigFont.addFace(fontFile('PfennigItalic.ttf'), 'normal', 'italic');
 pfennigFont.addFace(fontFile('PfennigBoldItalic.ttf'), 'bold', 'italic');
 
-var canvas = new Canvas(320, 320)
+var canvas = new Canvas(320, 390)
 var ctx = canvas.getContext('2d')
 
 // Tell the ctx to use the font.
@@ -36,11 +36,14 @@ ctx.fillText('Quo Vaids?', 0, 70);
 ctx.font = 'bold 50px pfennigFont';
 ctx.fillText('Quo Vaids?', 0, 140);
 
-ctx.font = 'italic 50px pfennigFont';
+ctx.font = '50px pfennigFont';
 ctx.fillText('Quo Vaids?', 0, 210);
 
-ctx.font = 'bold italic 50px pfennigFont';
+ctx.font = 'italic 50px pfennigFont';
 ctx.fillText('Quo Vaids?', 0, 280);
+
+ctx.font = 'bold italic 50px pfennigFont';
+ctx.fillText('Quo Vaids?', 0, 350);
 
 var out = fs.createWriteStream(__dirname + '/font.png');
 var stream = canvas.createPNGStream();

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1822,10 +1822,36 @@ NAN_METHOD(Context2d::SetFontFace) {
   double size = args[1]->NumberValue();
 
   Context2d *context = ObjectWrap::Unwrap<Context2d>(args.This());
+
+#if HAVE_PANGO
+
+  state_assign_fontFamily(context->state, face->freeTypeFace()->family_name);
+  context->state->fontSize = size;
+
+  FT_Long styleFlags = face->freeTypeFace()->style_flags;
+
+  PangoStyle s = PANGO_STYLE_NORMAL;
+  if (styleFlags & FT_STYLE_FLAG_ITALIC) {
+    s = PANGO_STYLE_ITALIC;
+  }
+  context->state->fontStyle = s;
+
+  PangoWeight w = PANGO_WEIGHT_NORMAL;
+  if (styleFlags & FT_STYLE_FLAG_BOLD) {
+    w = PANGO_WEIGHT_BOLD;
+  }
+  context->state->fontWeight = w;
+
+  context->setFontFromState();
+
+#else
+
   cairo_t *ctx = context->context();
 
   cairo_set_font_size(ctx, size);
   cairo_set_font_face(ctx, face->cairoFace());
+
+#endif
 
   NanReturnUndefined();
 }

--- a/src/FontFace.h
+++ b/src/FontFace.h
@@ -22,6 +22,7 @@ class FontFace: public node::ObjectWrap {
       :_ftFace(ftFace), _crFace(crFace) {}
 
     inline cairo_font_face_t *cairoFace(){ return _crFace; }
+    inline FT_Face freeTypeFace(){ return _ftFace; }
   private:
     ~FontFace();
     FT_Face   _ftFace;


### PR DESCRIPTION
Relating to the discussion of issue #525, I've tried to make sure that the API works the same whether or not Pango is enabled. Previously, calling `addFont` with Pango enabled would cause the font rendering to break. Also, the font had to be referenced by family name. With this change, the `addFont` call is optional, but if it is called, the font can be referenced using the name provided to the `Font` constructor.

So, after setting up the font like this:

    var font = new Font('myFontAlias', '/path/to/MyFont.ttf');
    context.addFont(font);

This:

    context.font = '50px myFontAlias';

Is equivalent to this (assuming the font's family name is 'My Font'):

    context.font = '50px \'My Font\'';

But I'm not familiar with C++, Pango or Cairo, so my changes might be no good.