### PR TITLE
Optimize getImageData()

### DIFF
--- a/src/PixelArray.cc
+++ b/src/PixelArray.cc
@@ -114,15 +114,18 @@ PixelArray::PixelArray(Canvas *canvas, int sx, int sy, int width, int height):
       uint8_t g = *pixel >> 8;
       uint8_t b = *pixel;
       dst[bx + 3] = a;
+
+      // Performance optimization: fully transparent/opaque pixels
+      // can be processed more efficiently
       if (a != 0 && a != 255) {
-          float alpha = (float) a / 255;
-          dst[bx + 0] = (int)((float) r / alpha);
-          dst[bx + 1] = (int)((float) g / alpha);
-          dst[bx + 2] = (int)((float) b / alpha);
+        float alpha = (float) a / 255;
+        dst[bx + 0] = (int)((float) r / alpha);
+        dst[bx + 1] = (int)((float) g / alpha);
+        dst[bx + 2] = (int)((float) b / alpha);
       } else {
-          dst[bx + 0] = r;
-          dst[bx + 1] = g;
-          dst[bx + 2] = b;
+        dst[bx + 0] = r;
+        dst[bx + 1] = g;
+        dst[bx + 2] = b;
       }
     }
     dst += dstStride;

--- a/src/PixelArray.cc
+++ b/src/PixelArray.cc
@@ -114,10 +114,16 @@ PixelArray::PixelArray(Canvas *canvas, int sx, int sy, int width, int height):
       uint8_t g = *pixel >> 8;
       uint8_t b = *pixel;
       dst[bx + 3] = a;
-      float alpha = (float) a / 255;
-      dst[bx + 0] = (int)((float) r / alpha);
-      dst[bx + 1] = (int)((float) g / alpha);
-      dst[bx + 2] = (int)((float) b / alpha);
+      if (a != 0 && a != 255) {
+          float alpha = (float) a / 255;
+          dst[bx + 0] = (int)((float) r / alpha);
+          dst[bx + 1] = (int)((float) g / alpha);
+          dst[bx + 2] = (int)((float) b / alpha);
+      } else {
+          dst[bx + 0] = r;
+          dst[bx + 1] = g;
+          dst[bx + 2] = b;
+      }
     }
     dst += dstStride;
   }


### PR DESCRIPTION
I've added an optimization of `getImageCanvas()` method for fully transparent and fully opaque pixels (typical situation). It speedups `getImageData(0,0,100,100)` test of `benchmarks/run.js` 2 - 8 times (different Ubuntu OSs). Moreover, 0/0 division (and the following `NaN` casting to `int`) for not filled pixels doesn't happen any more.