### PR TITLE
Fix segmentation fault in Image::loadFromBuffer when buffer is empty

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -201,15 +201,18 @@ NAN_SETTER(Image::SetSource) {
 
 cairo_status_t
 Image::loadFromBuffer(uint8_t *buf, unsigned len) {
-  if (isPNG(buf)) return loadPNGFromBuffer(buf);
+  uint8_t data[4] = {0};
+  memcpy(data, buf, (len < 4 ? len : 4) * sizeof(uint8_t));
+
+  if (isPNG(data)) return loadPNGFromBuffer(buf);
 #ifdef HAVE_GIF
-  if (isGIF(buf)) return loadGIFFromBuffer(buf, len);
+  if (isGIF(data)) return loadGIFFromBuffer(buf, len);
 #endif
 #ifdef HAVE_JPEG
 #if CAIRO_VERSION_MINOR < 10
-  if (isJPEG(buf)) return loadJPEGFromBuffer(buf, len);
+  if (isJPEG(data)) return loadJPEGFromBuffer(buf, len);
 #else
-  if (isJPEG(buf)) {
+  if (isJPEG(data)) {
     if (DATA_IMAGE == data_mode) return loadJPEGFromBuffer(buf, len);
     if (DATA_MIME == data_mode) return decodeJPEGBufferIntoMimeSurface(buf, len);
     if ((DATA_IMAGE | DATA_MIME) == data_mode) {
@@ -944,7 +947,7 @@ Image::extension(const char *filename) {
 }
 
 /*
- * Sniff bytes for JPEG's magic number ff d8.
+ * Sniff bytes 0..1 for JPEG's magic number ff d8.
  */
 
 int

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -80,5 +80,11 @@ module.exports = {
     img.src = png;
 
     assert.equal(1, n);
+  },
+
+  'test Image#src set empty buffer': function(){
+    var image = new Canvas.Image();
+    image.src = new Buffer(0);
+    image.src = new Buffer('');
   }
 };


### PR DESCRIPTION
Copy first 4 bytes of buffer to guest image type. When buffer length is shorter than use it with `null` value for the rest bytes.

Fixes #265, #285