### PR TITLE
Fix include paths for cairo

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -12,8 +12,8 @@
 #include <string.h>
 #include <node_buffer.h>
 #include <node_version.h>
-#include <cairo/cairo-pdf.h>
-#include <cairo/cairo-svg.h>
+#include <cairo-pdf.h>
+#include <cairo-svg.h>
 #include "closure.h"
 
 #ifdef HAVE_JPEG

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -16,7 +16,7 @@
 #if HAVE_PANGO
 #include <pango/pangocairo.h>
 #else
-#include <cairo/cairo.h>
+#include <cairo.h>
 #endif
 
 #include <nan.h>

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -2,7 +2,7 @@
 #define _CANVAS_PNG_H
 #include <png.h>
 #include <pngconf.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <stdlib.h>
 #include <string.h>
 #include "closure.h"


### PR DESCRIPTION
This will need some verification before we can merge, but I think that this is the right thing to do.

`pkg-config` gives the path to a folder that includes the header files for `cairo` right away. This is different for e.g. `fontconfig` which gives a path to a folder that contains a single folder named `fontconfig`.

In the former case `#include <cairo.h>` should be used, but in the latter case `#include <fontconfig/fontconfig.h>` should be used.

This patch fixes the `cairo` includes to point at `<cairo.h>`.

I believe that the reason why it worked before (on linux at least, it seems to be broken on OS X) is because the search path included `/usr/local/include` which in turn contained the folder that (called `cairo`) that `pkg-config` pointed to.

The last proof for that the correct linking should be `<cairo.h>` is the [FAQ page on Cairo's official website](http://cairographics.org/FAQ/).

This pull request can be tested simply by running the following command:

```bash
npm install LinusU/node-canvas#include-paths
```