### PR TITLE
Fix pango detection

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,7 @@
         'with_jpeg%': '<!(./util/has_lib.sh jpeg)',
         'with_gif%': '<!(./util/has_lib.sh gif)',
         # disable pango as it causes issues with freetype.
-        'with_pango%': '<!(./util/has_lib.sh pangocairo)',
+        'with_pango%': '<!(./util/has_pkgconfig_lib.sh pangocairo)',
         'with_freetype%': '<!(./util/has_cairo_freetype.sh)'
       }
     }]

--- a/util/has_pkgconfig_lib.sh
+++ b/util/has_pkgconfig_lib.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+if pkg-config --exists $1; then
+  echo true
+else
+  echo false
+fi


### PR DESCRIPTION
On my Ubuntu 13.10 machine the pango detection returns true without me having the library installed. This makes the build fail later.

This patch fixes the detection of pango by using the builtin feature `--exists` of `pkg-config`.

This pull request can be tested simply by running the following command:

```bash
npm install LinusU/node-canvas#detect-pango
```