### PR TITLE
Enable freetype for windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
-        'with_freetype%': 'false'
+        'with_freetype%': 'true'
       }
     }, { # 'OS!="win"'
       'variables': {
@@ -106,7 +106,13 @@
           ],
           'conditions': [
             ['OS=="win"', {
-              # No support for windows right now.
+              'libraries' : [
+                '-l<(GTK_Root)/lib/freetype.lib',
+              ],
+              'include_dirs': [
+                '<(GTK_Root)/include/cairo',
+                '<(GTK_Root)/include/freetype2'
+              ]
             }, { # 'OS!="win"'
               'include_dirs': [ # tried to pass through cflags but failed.
                 # Need to include the header files of cairo AND freetype.


### PR DESCRIPTION
Enable freetype flag for windows and set the necessary compiler flags.  Fixes #547 Canvas.Font on Windows.

While this "works on my machine", I'd recommend another couple people test it out prior to merging this.
