### PR TITLE
fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ node_js:
   - "iojs"
 before_install:
   - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
-  - npm install -g npm@latest
   - sudo chown -R $USER /usr/local
   - sh install


### PR DESCRIPTION
This should fix the travis builds for both Node.js 0.8 and iojs.

**The problem with Node.js 0.8**

The version of `npm` that ships with 0.8 doesn't support the `^` notation for dependency versions. This makes npm install fails when trying to install `"nan": "^1.8.4"`.

**The fix:** When running as Node.js 0.8, install a newer version of npm.

This was fixed by @TooTallNate 

**The problem with iojs**

When installing the latest npm `npm install -g npm@latest` it will override the iojs provided npm with the default one, the one for Node.js. The breaks `node-gyp` which is what compiles this module.

**The fix:** Don't install the latest npm. It's better to test with the npm that ships with whats installed since that better represent what our users will be running.
