### PR TITLE
Bump version to 1.2.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+1.2.4 / 2015-07-23
+==================
+
+  * Point `homepage` and `repository` links to
+    [`github.com/Automattic/node-canvas`][repo]
+  * Fix Travis builds and Cairo include paths (thanks, Linus Unnebäck!)
+
+[repo]: [https://github.com/Automattic/node-canvas]
 
 1.2.3 / 2015-05-21
 ==================

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas",
   "description": "Canvas graphics API backed by Cairo",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "TJ Holowaychuk <tj@learnboost.com>",
   "contributors": [
     "Nathan Rajlich <nathan@tootallnate.net>",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "images",
     "pdf"
   ],
-  "homepage": "https://github.com/learnboost/node-canvas",
-  "repository": "git://github.com/learnboost/node-canvas.git",
+  "homepage": "https://github.com/Automattic/node-canvas",
+  "repository": "git://github.com/Automattic/node-canvas.git",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Cuts new release for @LinusU's work:

* Automattic/node-canvas#574 Include paths for #217, #541, #572
* Automattic/node-canvas#583 Travis builds
