### PR TITLE
rename package variable to packageJson

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -19,7 +19,7 @@ var canvas = require('./bindings')
   , JPEGStream = require('./jpegstream')
   , FontFace = canvas.FontFace
   , fs = require('fs')
-  , package = require("../package.json");
+  , packageJson = require("../package.json");
 
 /**
  * Export `Canvas` as the module.
@@ -31,7 +31,7 @@ var Canvas = exports = module.exports = Canvas;
  * Library version.
  */
 
-exports.version = package.version;
+exports.version = packageJson.version;
 
 /**
  * Cairo version.


### PR DESCRIPTION
`package` is a future reserved keyword. Throws error in iojs. [MDN Future reserved keywords](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords)