### PR TITLE
gyp: fix pangocairo detection

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,7 @@
         'with_jpeg%': '<!(./util/has_lib.sh jpeg)',
         'with_gif%': '<!(./util/has_lib.sh gif)',
         # disable pango as it causes issues with freetype.
-        'with_pango%': '<!(./util/has_lib.sh pangocairo)',
+        'with_pango%': '<!(./util/has_pangocairo.sh)',
         'with_freetype%': '<!(./util/has_cairo_freetype.sh)'
       }
     }]

--- a/util/has_pangocairo.sh
+++ b/util/has_pangocairo.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+pkg-config --exists pangocairo && echo true || echo false


### PR DESCRIPTION
*Fixes #599*

This should fix the detection of pangocairo to ask `pkg-config` wether or not it has it, instead of trying to detect it ourselves.

Try it out with the following command:

```sh
npm install LinusU/node-canvas#pangocairo-test
```