### PR TITLE
Added support for Freetype, JPEG, Giflib, and Pango on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -123,8 +123,16 @@
           'conditions': [
             ['OS=="win"', {
               'libraries': [
-                '-l<(GTK_Root)/lib/pangocairo.lib'
-              ]
+                '-l<(GTK_Root)/lib/fontconfig.lib',
+                '-l<(GTK_Root)/lib/gobject-2.0.lib',
+                '-l<(GTK_Root)/lib/pango-1.0.lib',
+                '-l<(GTK_Root)/lib/pangocairo-1.0.lib'
+              ],
+			  'include_dirs': [
+                '<(GTK_Root)/include/glib-2.0',
+                '<(GTK_Root)/lib/glib-2.0/include',
+                '<(GTK_Root)/include/pango-1.0',
+			  ]
             }, { # 'OS!="win"'
               'include_dirs': [ # tried to pass through cflags but failed
                 '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)'

--- a/binding.gyp
+++ b/binding.gyp
@@ -64,6 +64,7 @@
           'include_dirs': [
             '<(GTK_Root)/include',
             '<(GTK_Root)/include/cairo',
+			'src/unistd' # needed for Freetype, GifLib, and Pango
           ],
           'defines': [
             'snprintf=_snprintf',

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,8 @@
         'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
         'JPEG_ROOT%': 'C:/libjpeg-turbo', # Set the location of LibJpeg Turbo
 		'GIF_Root': 'C:/giflib', # Set the location of GifLib source root
+		# NOTE: Freetype2 when built and installed by CMake, creates the include directory like: linclude/freetype2. You need to rename freetype2 to freetype.
+		'FT_Root': 'C:/freetype', # Points to Freetype root of CMake install directory
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
@@ -74,6 +76,9 @@
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
                   'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+                },
+                'VCLinkerTool': {
+                  'IgnoreDefaultLibraryNames': ['libcmtd']
                 }
               }
             },
@@ -83,6 +88,9 @@
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
                   'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+                },
+                'VCLinkerTool': {
+                  'IgnoreDefaultLibraryNames': ['libcmt']
                 }
               }
             }
@@ -107,7 +115,13 @@
           ],
           'conditions': [
             ['OS=="win"', {
-              # No support for windows right now.
+              'libraries': [
+                '-l<(FT_Root)/lib/freetype.lib'
+              ],
+			  'include_dirs': [
+                '<(FT_Root)/include',
+                '<(FT_Root)/include/freetype'
+              ]
             }, { # 'OS!="win"'
               'include_dirs': [ # tried to pass through cflags but failed.
                 # Need to include the header files of cairo AND freetype.

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,7 @@
       'variables': {
         'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
         'JPEG_ROOT%': 'C:/libjpeg-turbo', # Set the location of LibJpeg Turbo
+		'GIF_Root': 'C:/giflib', # Set the location of GifLib source root
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
@@ -168,9 +169,16 @@
           ],
           'conditions': [
             ['OS=="win"', {
-              'libraries': [
-                '-l<(GTK_Root)/lib/gif.lib'
-              ]
+              'sources': [
+                '<(GIF_Root)/lib/dgif_lib.c',
+                '<(GIF_Root)/lib/egif_lib.c',
+                '<(GIF_Root)/lib/gif_err.c',
+                '<(GIF_Root)/lib/gif_font.c',
+                '<(GIF_Root)/lib/gif_hash.c',
+                '<(GIF_Root)/lib/quantize.c',
+                '<(GIF_Root)/lib/gifalloc.c'
+              ],
+		      'include_dirs': ["<(GIF_Root)/lib"]
             }, {
               'libraries': [
                 '-lgif'

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     ['OS=="win"', {
       'variables': {
         'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
+        'JPEG_ROOT%': 'C:/libjpeg-turbo', # Set the location of LibJpeg Turbo
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
@@ -141,7 +142,10 @@
           'conditions': [
             ['OS=="win"', {
               'libraries': [
-                '-l<(GTK_Root)/lib/jpeg.lib'
+                '-l<(JPEG_ROOT)/lib/jpeg.lib'
+              ],
+              'include_dirs': [
+               '<(JPEG_ROOT)/include'
               ]
             }, {
               'libraries': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -76,9 +76,6 @@
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
                   'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
-                },
-                'VCLinkerTool': {
-                  'IgnoreDefaultLibraryNames': ['libcmtd']
                 }
               }
             },
@@ -88,9 +85,6 @@
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
                   'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
-                },
-                'VCLinkerTool': {
-                  'IgnoreDefaultLibraryNames': ['libcmt']
                 }
               }
             }
@@ -121,7 +115,23 @@
 			  'include_dirs': [
                 '<(FT_Root)/include',
                 '<(FT_Root)/include/freetype'
-              ]
+              ],
+              'configurations': {
+                'Debug': {
+                  'msvs_settings': {
+                    'VCLinkerTool': {
+                      'IgnoreDefaultLibraryNames': ['libcmtd']
+                    }
+                  }
+                },
+                'Release': {
+                  'msvs_settings': {
+                    'VCLinkerTool': {
+                      'IgnoreDefaultLibraryNames': ['libcmt']
+                    }
+                  }
+                }
+              }
             }, { # 'OS!="win"'
               'include_dirs': [ # tried to pass through cflags but failed.
                 # Need to include the header files of cairo AND freetype.

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -29,6 +29,11 @@
 #define isinf(x) (!_finite(x))
 #endif
 
+#ifdef _WIN32
+// This is not available out of the box on Windows (MSVC)
+char* strndup( const char* s , size_t size );
+#endif
+
 #ifndef isnan
 #define isnan(x) std::isnan(x)
 #define isinf(x) std::isinf(x)
@@ -2548,3 +2553,27 @@ NAN_METHOD(Context2d::ArcTo) {
 
   NanReturnUndefined();
 }
+
+#ifdef _WIN32
+// From: https://code.google.com/p/madp-win/source/browse/src/argp-standalone-1.3/strndup.c
+char *
+strndup (const char *s, size_t size)
+{
+  char *r;
+  char *end = (char*)memchr(s, 0, size);
+  
+  if (end)
+    /* Length + 1 */
+    size = end - s + 1;
+  
+  r = (char*)malloc(size);
+
+  if (size)
+    {
+      memcpy(r, s, size-1);
+      r[size-1] = '\0';
+    }
+  return r;
+}
+#endif
+

--- a/src/unistd/unistd.h
+++ b/src/unistd/unistd.h
@@ -1,0 +1,2 @@
+/* This is needed on Windows (MSVC) for Freetype, Pango, and GifLib to pass compilation */
+#include <stdint.h>


### PR DESCRIPTION
I have only tested this with Visual Studio 2013 (Update 5) x64 build. Following versions of dependencies I have used:
- [GTK+ 2.22.1 bundle](http://gemmei.acc.umu.se/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip)
- [Freetype 2.6](http://superb-dca2.dl.sourceforge.net/project/freetype/freetype2/2.6/freetype-2.6.tar.bz2)
- [GifLib 5.1.1](http://superb-dca2.dl.sourceforge.net/project/giflib/giflib-5.1.1.tar.bz2)
- [LibJpeg Turbo 1.4.1](http://skylineservers.dl.sourceforge.net/project/libjpeg-turbo/1.4.1/libjpeg-turbo-1.4.1-vc64.exe)

Note that I have not used the same Freetype that comes with GTK+, because it was slightly outdated and I would rather building Freetype from scratch since it uses CMake and it takes literally two minutes to build and install it. After installation `include/freetype2` needs to be renamed to `include/freetype`.

Giflib comes with `autoconf` scripts for its build management. Honestly the easiest way to build it, is just including it in the source tree. That's how [Leptonica](http://www.leptonica.org/vs2008doc/building-image-libraries.html) builds it as well.
