### PR TITLE
tests: use standard mocha ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,11 @@
 
 ADDON = build/Release/canvas.node
-REPORTER = dot
 
 $(ADDON): src/*.cc
 	npm install
 
 test: $(ADDON)
-	@./node_modules/.bin/mocha \
-		--reporter $(REPORTER) \
-		--ui exports \
-		test/*.test.js
+	@./node_modules/.bin/mocha test/*.test.js
 
 test-server: $(ADDON)
 	@node test/server.js

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -11,16 +11,16 @@ console.log();
 console.log('   canvas: %s', Canvas.version);
 console.log('   cairo: %s', Canvas.cairoVersion);
 
-module.exports = {
-  'test .version': function(){
+describe('Canvas', function () {
+  it('.version', function () {
     assert.ok(/^\d+\.\d+\.\d+$/.test(Canvas.version));
-  },
+  });
 
-  'test .cairoVersion': function(){
+  it('.cairoVersion', function () {
     assert.ok(/^\d+\.\d+\.\d+$/.test(Canvas.cairoVersion));
-  },
+  });
 
-  'test .parseFont()': function(){
+  it('.parseFont()', function () {
     var tests = [
         '20px Arial'
       , { size: 20, unit: 'px', family: 'Arial' }
@@ -76,9 +76,9 @@ module.exports = {
 
       assert.deepEqual(obj, actual);
     }
-  },
+  });
 
-  'test color serialization': function(){
+  it('color serialization', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -104,9 +104,9 @@ module.exports = {
       ctx[prop] = grad;
       assert.strictEqual(grad, ctx[prop], prop + ' pattern getter failed');
     });
-  },
+  });
 
-  'test color parser': function(){
+  it('color parser', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -206,9 +206,9 @@ module.exports = {
 
     ctx.fillStyle = 'hsl(1.24e2, 760e-1%, 4.7e1%)';
     assert.equal('#1dd329', ctx.fillStyle);
-  },
+  });
 
-  'test Canvas#type': function(){
+  it('Canvas#type', function () {
     var canvas = new Canvas(10, 10);
     assert('image' == canvas.type);
     var canvas = new Canvas(10, 10, 'pdf');
@@ -217,17 +217,17 @@ module.exports = {
     assert('svg' == canvas.type);
     var canvas = new Canvas(10, 10, 'hey');
     assert('image' == canvas.type);
-  },
+  });
 
-  'test Canvas#getContext("2d")': function(){
+  it('Canvas#getContext("2d")', function () {
     var canvas = new Canvas(200, 300)
       , ctx = canvas.getContext('2d');
     assert.ok('object' == typeof ctx);
     assert.equal(canvas, ctx.canvas, 'context.canvas is not canvas');
     assert.equal(ctx, canvas.context, 'canvas.context is not context');
-  },
+  });
 
-  'test Canvas#{width,height}=': function(){
+  it('Canvas#{width,height}=', function () {
     var canvas = new Canvas(100, 200);
     assert.equal(100, canvas.width);
     assert.equal(200, canvas.height);
@@ -240,13 +240,13 @@ module.exports = {
     canvas.height = 50;
     assert.equal(50, canvas.width);
     assert.equal(50, canvas.height);
-  },
+  });
 
-  'test Canvas#getContext("invalid")': function(){
+  it('Canvas#getContext("invalid")', function () {
     assert.equal(null, new Canvas(200, 300).getContext('invalid'));
-  },
+  });
 
-  'test Context2d#patternQuality': function(){
+  it('Context2d#patternQuality', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -255,18 +255,18 @@ module.exports = {
     assert.equal('best', ctx.patternQuality);
     ctx.patternQuality = 'invalid';
     assert.equal('best', ctx.patternQuality);
-  },
+  });
 
-  'test Context2d#font=': function(){
+  it('Context2d#font=', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
     assert.equal('10px sans-serif', ctx.font);
     ctx.font = '15px Arial, sans-serif';
     assert.equal('15px Arial, sans-serif', ctx.font);
-  },
+  });
 
-  'test Context2d#lineWidth=': function(){
+  it('Context2d#lineWidth=', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -280,9 +280,9 @@ module.exports = {
     assert.equal(10, ctx.lineWidth);
     ctx.lineWidth = 0;
     assert.equal(10, ctx.lineWidth);
-  },
+  });
 
-  'test Context2d#antiAlias=': function(){
+  it('Context2d#antiAlias=', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -297,37 +297,36 @@ module.exports = {
     assert.equal('subpixel', ctx.antialias);
     ctx.antialias = 1;
     assert.equal('subpixel', ctx.antialias);
-  },
+  });
 
-  'test Context2d#lineCap=': function(){
+  it('Context2d#lineCap=', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
     assert.equal('butt', ctx.lineCap);
     ctx.lineCap = 'round';
     assert.equal('round', ctx.lineCap);
-  },
+  });
 
-  'test Context2d#lineJoin=': function(){
+  it('Context2d#lineJoin=', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
     assert.equal('miter', ctx.lineJoin);
     ctx.lineJoin = 'round';
     assert.equal('round', ctx.lineJoin);
-  },
+  });
 
-
-  'test Context2d#globalAlpha=': function(){
+  it('Context2d#globalAlpha=', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
     assert.equal(1, ctx.globalAlpha);
     ctx.globalAlpha = 0.5
     assert.equal(0.5, ctx.globalAlpha);
-  },
+  });
 
-  'test Context2d#isPointInPath()': function(){
+  it('Context2d#isPointInPath()', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -344,9 +343,9 @@ module.exports = {
     assert.ok(ctx.isPointInPath(60,110));
     assert.ok(!ctx.isPointInPath(70,110));
     assert.ok(!ctx.isPointInPath(50,120));
-  },
+  });
 
-  'test Context2d#textAlign': function(){
+  it('Context2d#textAlign', function () {
     var canvas = new Canvas(200,200)
       , ctx = canvas.getContext('2d');
 
@@ -359,22 +358,22 @@ module.exports = {
     assert.equal('end', ctx.textAlign);
     ctx.textAlign = 'fail';
     assert.equal('end', ctx.textAlign);
-  },
+  });
 
-  'test Canvas#toBuffer()': function(){
+  it('Canvas#toBuffer()', function () {
     var buf = new Canvas(200,200).toBuffer();
     assert.equal('PNG', buf.slice(1,4).toString());
-  },
+  });
 
-  'test Canvas#toBuffer() async': function(done){
+  it('Canvas#toBuffer() async', function (done) {
     new Canvas(200, 200).toBuffer(function(err, buf){
       assert.ok(!err);
       assert.equal('PNG', buf.slice(1,4).toString());
       done();
     });
-  },
+  });
 
-  'test Canvas#toDataURL()': function(){
+  it('Canvas#toDataURL()', function () {
     var canvas = new Canvas(200, 200)
       , ctx = canvas.getContext('2d');
 
@@ -392,25 +391,25 @@ module.exports = {
       err = e;
     }
     assert.equal('currently only image/png is supported', err.message);
-  },
+  });
 
-  'test Canvas#toDataURL() async': function(done){
+  it('Canvas#toDataURL() async', function (done) {
     new Canvas(200,200).toDataURL(function(err, str){
       assert.ok(!err);
       assert.ok(0 == str.indexOf('data:image/png;base64,'));
       done();
     });
-  },
+  });
 
-  'test Canvas#toDataURL() async with type': function(done){
+  it('Canvas#toDataURL() async with type', function (done) {
     new Canvas(200,200).toDataURL('image/png', function(err, str){
       assert.ok(!err);
       assert.ok(0 == str.indexOf('data:image/png;base64,'));
       done();
     });
-  },
+  });
 
-  'test Context2d#createImageData(width, height)': function(){
+  it('Context2d#createImageData(width, height)', function () {
     var canvas = new Canvas(20, 20)
       , ctx = canvas.getContext('2d');
 
@@ -423,18 +422,18 @@ module.exports = {
     assert.equal(0, imageData.data[1]);
     assert.equal(0, imageData.data[2]);
     assert.equal(0, imageData.data[3]);
-  },
+  });
 
-  'test Context2d#measureText().width': function(){
+  it('Context2d#measureText().width', function () {
     var canvas = new Canvas(20, 20)
       , ctx = canvas.getContext('2d');
 
     assert.ok(ctx.measureText('foo').width);
     assert.ok(ctx.measureText('foo').width != ctx.measureText('foobar').width);
     assert.ok(ctx.measureText('foo').width != ctx.measureText('  foo').width);
-  },
+  });
 
-  'test Context2d#createImageData(ImageData)': function(){
+  it('Context2d#createImageData(ImageData)', function () {
     var canvas = new Canvas(20, 20)
       , ctx = canvas.getContext('2d');
 
@@ -442,9 +441,9 @@ module.exports = {
     assert.equal(2, imageData.width);
     assert.equal(6, imageData.height);
     assert.equal(2 * 6 * 4, imageData.data.length);
-  },
+  });
 
-  'test Context2d#getImageData()': function(){
+  it('Context2d#getImageData()', function () {
     var canvas = new Canvas(3, 6)
       , ctx = canvas.getContext('2d');
 
@@ -502,9 +501,9 @@ module.exports = {
     assert.equal(255, data[0]);
     data[0] = -4444;
     assert.equal(0, data[0]);
-  },
+  });
 
-  'test Context2d#createPattern(Canvas)': function(){
+  it('Context2d#createPattern(Canvas)', function () {
     var pattern = new Canvas(2,2)
       , checkers = pattern.getContext('2d');
 
@@ -574,9 +573,9 @@ module.exports = {
       // alternate b, except when moving to a new row
       b = i % (imageData.width*4) == 0 ? b : !b;
     }
-  },
+  });
 
-  'test Context2d#createPattern(Image)': function(){
+  it('Context2d#createPattern(Image)', function () {
     var img = new Canvas.Image();
     img.src = __dirname + '/fixtures/checkers.png';
 
@@ -608,9 +607,9 @@ module.exports = {
       // alternate b, except when moving to a new row
       b = i % (imageData.width*4) == 0 ? b : !b;
     }
-  },
+  });
 
-  'test Context2d#createLinearGradient()': function(){
+  it('Context2d#createLinearGradient()', function () {
     var canvas = new Canvas(20, 1)
       , ctx = canvas.getContext('2d')
       , gradient = ctx.createLinearGradient(1,1,19,1);
@@ -638,10 +637,9 @@ module.exports = {
     assert.equal(0, imageData.data[i+1]);
     assert.equal(0, imageData.data[i+2]);
     assert.equal(255, imageData.data[i+3]);
+  });
 
-  },
-
-  'test Canvas#createSyncPNGStream()': function(done) {
+  it('Canvas#createSyncPNGStream()', function (done) {
     var canvas = new Canvas(20, 20);
     var stream = canvas.createSyncPNGStream();
     var firstChunk = true;
@@ -657,9 +655,9 @@ module.exports = {
     stream.on('error', function(err) {
       done(err);
     });
-  },
+  });
 
-  'test Canvas#jpegStream()': function(done) {
+  it('Canvas#jpegStream()', function (done) {
     var canvas = new Canvas(640, 480);
     var stream = canvas.jpegStream();
     var firstChunk = true;
@@ -680,5 +678,5 @@ module.exports = {
     stream.on('error', function(err) {
       done(err);
     });
-  }
-}
+  });
+});

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -9,19 +9,19 @@ var Canvas = require('../')
 
 var png = __dirname + '/fixtures/clock.png';
 
-module.exports = {
-  'tset Image': function(){
+describe('Image', function () {
+  it('Image', function () {
     assert.ok(Image instanceof Function);
-  },
+  });
 
-  'test Image#onload': function(){
+  it('Image#onload', function () {
     var img = new Image
       , onloadCalled = 0;
 
     assert.strictEqual(null, img.onload);
     assert.strictEqual(false, img.complete);
 
-    img.onload = function(){
+    img.onload = function () {
       onloadCalled += 1;
       assert.strictEqual(img.src, png);
     };
@@ -33,9 +33,9 @@ module.exports = {
     assert.strictEqual(true, img.complete);
     assert.strictEqual(320, img.width);
     assert.strictEqual(320, img.height);
-  },
+  });
 
-  'test Image#onerror': function(){
+  it('Image#onerror', function () {
     var img = new Image
       , error
       , onerrorCalled = 0;
@@ -43,11 +43,11 @@ module.exports = {
     assert.strictEqual(null, img.onerror);
     assert.strictEqual(false, img.complete);
 
-    img.onload = function(){
+    img.onload = function () {
       assert.fail('called onload');
     };
 
-    img.onerror = function(err){
+    img.onerror = function (err) {
       onerrorCalled += 1;
       error = err;
     };
@@ -63,16 +63,16 @@ module.exports = {
     assert.strictEqual(false, img.complete);
 
     assert.ok(error instanceof Error, 'did not invoke onerror() with error');
-  },
+  });
 
-  'test Image#{width,height}': function(){
+  it('Image#{width,height}', function () {
     var img = new Image
       , onloadCalled = 0;
 
     assert.strictEqual(0, img.width);
     assert.strictEqual(0, img.height);
 
-    img.onload = function(){
+    img.onload = function () {
       onloadCalled += 1;
       assert.strictEqual(320, img.width);
       assert.strictEqual(320, img.height);
@@ -82,11 +82,11 @@ module.exports = {
     assert.strictEqual(1, onloadCalled);
     assert.strictEqual(320, img.width);
     assert.strictEqual(320, img.height);
-  },
+  });
 
-  'test Image#src set empty buffer': function(){
+  it('Image#src set empty buffer', function () {
     var image = new Canvas.Image();
     image.src = new Buffer(0);
     image.src = new Buffer('');
-  }
-};
+  });
+});


### PR DESCRIPTION
This switches the `ui` of mocha to the default (`describe` / `it`) instead of exports (`exports['...']`).

I also switched back to the default reporter because I think it's nice and it removed some lines from the makefile. I don't have a strong opinion on this part so happy to change back is someone loves the dot reporter.

Looks good?