### PR TITLE
implement blur on images (drawImage)

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -895,7 +895,10 @@ NAN_METHOD(Context2d::DrawImage) {
       context->blur(shadow_surface, context->state->shadowBlur / 2);
 
       // paint
-      // @todo figure out where the 1.4 comes from
+      // @note: ShadowBlur looks different in each browser. This implementation matches chrome as close as possible.
+      //        The 1.4 offset comes from visual tests with Chrome. I have read the spec and part of the shadowBlur
+      //        implementation, and its not immediately clear why an offset is necessary, but without it, the result
+      //        in chrome is different.
       cairo_set_source_surface(ctx, shadow_surface,
         dx - sx + context->state->shadowOffsetX - pad + 1.4,
         dx - sx + context->state->shadowOffsetY - pad + 1.4);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -900,6 +900,10 @@ NAN_METHOD(Context2d::DrawImage) {
         dx - sx + context->state->shadowOffsetX - pad + 1.15,
         dx - sx + context->state->shadowOffsetY - pad + 1.15);
       cairo_paint(ctx);
+      
+      // cleanup
+      cairo_destroy(shadow_context);
+      cairo_surface_destroy(shadow_surface);
     } else {
       context->setSourceRGBA(context->state->shadow);
       cairo_mask_surface(ctx, surface,

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -895,10 +895,10 @@ NAN_METHOD(Context2d::DrawImage) {
       context->blur(shadow_surface, context->state->shadowBlur / 2);
 
       // paint
-      // @todo figure out where the 1.15 comes from
+      // @todo figure out where the 1.4 comes from
       cairo_set_source_surface(ctx, shadow_surface,
-        dx - sx + context->state->shadowOffsetX - pad + 1.15,
-        dx - sx + context->state->shadowOffsetY - pad + 1.15);
+        dx - sx + context->state->shadowOffsetX - pad + 1.4,
+        dx - sx + context->state->shadowOffsetY - pad + 1.4);
       cairo_paint(ctx);
       
       // cleanup


### PR DESCRIPTION
Quickly implemented blur on images based on @woodcoder's advice. This PR fixes https://github.com/Automattic/node-canvas/issues/133.

I have done a few things that I do not fully understand yet. In order to replicate the blur, I:
* Divided the shadowBlur by 2 when calling blur()
* Offset the surface by 1.15

@woodcoder: In your implementation of shadow blur, you offset the surface by 1 (https://github.com/woodcoder/node-canvas/blob/8c6984a0999253a22fbd74713d4823da8b2cdd48/src/CanvasRenderingContext2d.cc#L395). Any insight as to why 1? That's what I did initially as well, but it was slightly off.

