### PR TITLE
simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,16 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - libcairo2-dev
+      - libjpeg8-dev
+      - libpango1.0-dev
+      - libgif-dev
       - g++-4.8
+env:
+  - CXX=g++-4.8
 before_install:
   - if [[ $TRAVIS_NODE_VERSION == 0.8 ]]; then npm install -g npm@1.4.28; fi
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
-  - $CXX --version
-  - sudo chown -R $USER /usr/local
-  - sh install
   - npm explore npm -g -- npm install node-gyp@latest
 after_script:
   - npm run benchmark
+sudo: false


### PR DESCRIPTION
Currently, CI takes a long time because it has to compile all dependencies before running the test.
Use Ubuntu packages instead of building them from source.
