### PR TITLE
Wrap std::min calls in paranthesis to prevent macro expansion on windows

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -619,6 +619,8 @@ NAN_METHOD(Context2d::PutImageData) {
       if (dx < 0) sw += dx, sx -= dx, dx = 0;
       if (dy < 0) sh += dy, sy -= dy, dy = 0;
       // clamp width at canvas size
+      // Need to wrap std::min calls using parens to prevent macro expansion on
+      // windows. See http://stackoverflow.com/questions/5004858/stdmin-gives-error
       cols = (std::min)(sw, context->canvas()->width - dx);
       rows = (std::min)(sh, context->canvas()->height - dy);
       break;

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -592,8 +592,8 @@ NAN_METHOD(Context2d::PutImageData) {
   switch (info.Length()) {
     // imageData, dx, dy
     case 3:
-      cols = std::min(imageData->width(), context->canvas()->width - dx);
-      rows = std::min(imageData->height(), context->canvas()->height - dy);
+      cols = (std::min)(imageData->width(), context->canvas()->width - dx);
+      rows = (std::min)(imageData->height(), context->canvas()->height - dy);
       break;
     // imageData, dx, dy, sx, sy, sw, sh
     case 7:
@@ -617,8 +617,8 @@ NAN_METHOD(Context2d::PutImageData) {
       if (dx < 0) sw += dx, sx -= dx, dx = 0;
       if (dy < 0) sh += dy, sy -= dy, dy = 0;
       // clamp width at canvas size
-      cols = std::min(sw, context->canvas()->width - dx);
-      rows = std::min(sh, context->canvas()->height - dy);
+      cols = (std::min)(sw, context->canvas()->width - dx);
+      rows = (std::min)(sh, context->canvas()->height - dy);
       break;
     default:
       return Nan::ThrowError("invalid arguments");

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -592,6 +592,8 @@ NAN_METHOD(Context2d::PutImageData) {
   switch (info.Length()) {
     // imageData, dx, dy
     case 3:
+      // Need to wrap std::min calls using parens to prevent macro expansion on
+      // windows. See http://stackoverflow.com/questions/5004858/stdmin-gives-error
       cols = (std::min)(imageData->width(), context->canvas()->width - dx);
       rows = (std::min)(imageData->height(), context->canvas()->height - dy);
       break;


### PR DESCRIPTION
Fixes #659.