### PR TITLE
readme: update installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,17 +21,15 @@ $ npm install canvas
 
 Unless previously installed you'll _need_ __Cairo__. For system-specific installation view the [Wiki](https://github.com/Automattic/node-canvas/wiki/_pages).
 
-You can quickly install Cairo and its dependencies for OS X using the one liner below:
+You can quickly install the dependencies by using the command for your OS:
 
-```bash
-$ wget https://raw.githubusercontent.com/Automattic/node-canvas/master/install -O - | sh
-```
-
-or if you use MacPorts
-
-```bash
-sudo port install pkgconfig libpng giflib freetype libpixman cairo
-```
+OS | Command
+----- | -----
+OS X | `brew install pkg-config cairo libpng jpeg giflib`
+Ubuntu | `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
+Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
+Solaris | `pkgin install cairo pkg-config xproto renderproto kbproto xextproto`
+Windows | [Instructions on our wiki](https://github.com/Automattic/node-canvas/wiki/Installation---Windows)
 
 ## Screencasts
 


### PR DESCRIPTION
See discussion in #651

Preview:

OS | Command
----- | -----
OS X | `brew install pkg-config cairo libpng jpeg giflib`
Ubuntu | `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
Solaris | `pkgin install cairo pkg-config xproto renderproto kbproto xextproto`
Windows | [Instructions on our wiki](https://github.com/Automattic/node-canvas/wiki/Installation---Windows)