### PR TITLE
Don't #define snprintf on VS2015

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -61,10 +61,6 @@
             '<(GTK_Root)/include',
             '<(GTK_Root)/include/cairo',
           ],
-          'defines': [
-            'snprintf=_snprintf',
-            '_USE_MATH_DEFINES' # for M_PI
-          ],
           'configurations': {
             'Debug': {
               'msvs_settings': {
@@ -94,6 +90,17 @@
           'include_dirs': [
             '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)',
             '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)'
+          ]
+        }],
+        ['OS=="win"' and 'MSVS_VERSION!="2015"', {
+          'defines': [
+            'snprintf=_snprintf',
+            '_USE_MATH_DEFINES' # for M_PI
+          ],
+        }],
+        ['OS=="win"' and 'MSVS_VERSION=="2015"', {
+          'defines': [
+            '_USE_MATH_DEFINES' # for M_PI
           ]
         }],
         ['with_freetype=="true"', {


### PR DESCRIPTION
I hope this is the appropriate fix. At least now it compiles with 2015 for me.
Fixes #605 