### PR TITLE
Use Nan::TypedArrayContents, fix a signed/unsigned comp warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-server": "node test/server.js"
   },
   "dependencies": {
-    "nan": "^2.0.9"
+    "nan": "^2.1.0"
   },
   "devDependencies": {
     "body-parser": "^1.13.3",

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -736,22 +736,15 @@ NAN_METHOD(Context2d::GetImageData) {
   Local<Object> global = Context::GetCurrent()->Global();
 
   Local<Int32> sizeHandle = Nan::New(size);
-  Local<Value> bufargv[] = { sizeHandle };
-  Local<Object> buffer = global->Get(Nan::New("ArrayBuffer").ToLocalChecked()).As<Function>()->NewInstance(1, bufargv);
-
-  Local<Int32> zeroHandle = Nan::New(0);
-  Local<Value> caargv[] = { buffer, zeroHandle, sizeHandle };
+  Local<Value> caargv[] = { sizeHandle };
   Local<Object> clampedArray = global->Get(Nan::New("Uint8ClampedArray").ToLocalChecked()).As<Function>()->NewInstance(3, caargv);
-  uint8_t *dst = (uint8_t *) clampedArray->GetIndexedPropertiesExternalArrayData();
 #else
   Local<ArrayBuffer> buffer = ArrayBuffer::New(Isolate::GetCurrent(), size);
   Local<Uint8ClampedArray> clampedArray = Uint8ClampedArray::New(buffer, 0, size);
-#if NODE_MAJOR_VERSION < 3
-   uint8_t *dst = (uint8_t *)clampedArray->GetIndexedPropertiesExternalArrayData();
-#else
-  uint8_t *dst = (uint8_t *)buffer->GetContents().Data();
 #endif
-#endif
+
+  Nan::TypedArrayContents<uint8_t> typedArrayContents(clampedArray);
+  uint8_t* dst = *typedArrayContents;
   
   // Normalize data (argb -> rgba)
   for (int y = 0; y < sh; ++y) {

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -42,8 +42,8 @@ NAN_METHOD(ImageData::New) {
   Local<Uint8ClampedArray> clampedArray;
 #endif
 
-  int width;
-  int height;
+  uint32_t width;
+  uint32_t height;
   int length;
 
   if (info[0]->IsUint32() && info[1]->IsUint32()) {
@@ -104,13 +104,9 @@ NAN_METHOD(ImageData::New) {
     return;
   }
 
-#if NODE_MAJOR_VERSION < 3
-  void *dataPtr = clampedArray->GetIndexedPropertiesExternalArrayData();
-#else
-  void *dataPtr = clampedArray->Buffer()->GetContents().Data();
-#endif
+  Nan::TypedArrayContents<uint8_t> dataPtr(clampedArray);
 
-  ImageData *imageData = new ImageData(reinterpret_cast<uint8_t*>(dataPtr), width, height);
+  ImageData *imageData = new ImageData(reinterpret_cast<uint8_t*>(*dataPtr), width, height);
   imageData->Wrap(info.This());
   info.This()->Set(Nan::New("data").ToLocalChecked(), clampedArray);
   info.GetReturnValue().Set(info.This());


### PR DESCRIPTION
Fixes #637, plus a compiler warning. Was also able to remove some unnecessary code that creates an ArrayBuffer explicitly in CanvasRenderingContext2d.