### PR TITLE
Add Appveyor CI for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: 0.0.{build}
+environment:
+  matrix:
+    - nodejs_version: "6"
+image:
+  - Visual Studio 2013
+  - Visual Studio 2015
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  # Sets Windows 7.1 SDK env vars.
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
+  # Prepend 2015 and 2013 tools. Harmless when the path for the other version doesn't exist.
+  - set "PATH=%ProgramFiles(x86)%\MSBuild\14.0\Bin;%ProgramFiles(x86)%\MSBuild\12.0\Bin;%PATH%"
+  # Upgrade npm to latest
+  - npm install --loglevel error -g npm 
+  - set "PATH=%APPDATA%\npm;%PATH%"
+  - node -v
+  - npm -v
+  - npm install -g --loglevel error node-gyp
+  # Put GTK in C:/
+  - curl -fLsS -o "gtk.zip" "http://ftp.gnome.org/pub/GNOME/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip"
+  - 7z x gtk.zip -oGTK > nul
+  - mv GTK/ C:/
+  - curl -fLsS -o "libjpeg.exe" "https://downloads.sourceforge.net/project/libjpeg-turbo/1.5.2/libjpeg-turbo-1.5.2-vc64.exe"
+  - .\libjpeg.exe /S
+  - npm install
+build: off
+test_script:
+  - cmd: npm test


### PR DESCRIPTION
This mostly works. VS2015 fails without #670. We need #458 merged for any to fully pass -- see log:
https://ci.appveyor.com/project/zbjornson/node-canvas/build/job/x3domgfjsq77445m After that I need to change the script to install libjpeg-turbo.

For now there's only one node env. Think it's unnecessary to have more than one, but it's easy to add.

(Sorry I've got 83a8b27 upstream from #671 in here.)
