### PR TITLE
get rid of C++ compiler warnings

### DIFF
--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -75,8 +75,7 @@ NAN_METHOD(Pattern::New) {
  * Initialize linear gradient.
  */
 
-Pattern::Pattern(cairo_surface_t *surface, int w, int h):
-  _width(w), _height(h) {
+Pattern::Pattern(cairo_surface_t *surface, int w, int h) {
   _pattern = cairo_pattern_create_for_surface(surface);
 }
 

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -20,7 +20,6 @@ class Pattern: public Nan::ObjectWrap {
 
   private:
     ~Pattern();
-    int _width, _height;
     // TODO REPEAT/REPEAT_X/REPEAT_Y
     cairo_pattern_t *_pattern;
 };

--- a/src/FontFace.h
+++ b/src/FontFace.h
@@ -19,12 +19,11 @@ class FontFace: public Nan::ObjectWrap {
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     FontFace(FT_Face ftFace, cairo_font_face_t *crFace)
-      :_ftFace(ftFace), _crFace(crFace) {}
+      :_crFace(crFace) {}
 
     inline cairo_font_face_t *cairoFace(){ return _crFace; }
   private:
     ~FontFace();
-    FT_Face   _ftFace;
     cairo_font_face_t *_crFace;
     static bool _initLibrary;
 };

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -60,7 +60,7 @@ NAN_METHOD(ImageData::New) {
     length = width * height * 4;
 
 #if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 10
-    Local<Int32> sizeHandle = Nan::New(length);
+    Local<Uint32> sizeHandle = Nan::New(length);
     Local<Value> caargv[] = { sizeHandle };
     clampedArray = global->Get(Nan::New("Uint8ClampedArray").ToLocalChecked()).As<Function>()->NewInstance(1, caargv);
 #else

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -44,7 +44,7 @@ NAN_METHOD(ImageData::New) {
 
   uint32_t width;
   uint32_t height;
-  int length;
+  uint32_t length;
 
   if (info[0]->IsUint32() && info[1]->IsUint32()) {
     width = info[0]->Uint32Value();


### PR DESCRIPTION
```
...
In file included from ../src/CanvasPattern.cc:10:
../src/CanvasPattern.h:23:9: warning: private field '_width' is not used [-Wunused-private-field]
    int _width, _height;
        ^
../src/CanvasPattern.h:23:17: warning: private field '_height' is not used [-Wunused-private-field]
    int _width, _height;
                ^
2 warnings generated.
...
../src/ImageData.cc:98:55: warning: comparison of integers of different signs: 'uint32_t' (aka 'unsigned int') and 'int' [-Wsign-compare]
    if (info[2]->IsUint32() && info[2]->Uint32Value() != height) {
                               ~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~
1 warning generated.
...
In file included from ../src/FontFace.cc:7:
../src/FontFace.h:27:13: warning: private field '_ftFace' is not used [-Wunused-private-field]
    FT_Face _ftFace;
            ^
1 warning generated.
...
```