### PR TITLE
travis: temporarily allow node.js 5.x to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ node_js:
   - "iojs-v3.3.0"
   - "4"
   - "5"
+matrix:
+  allow_failures:
+    - node_js: "5"
 addons:
   apt:
     sources:


### PR DESCRIPTION
I've been merging builds when I have tested them manually but that makes it looked like we merged failed builds. I believe that explicitly stating this is better.

Here is the bug in npm that we need fixed: npm/npm#9633