### PR TITLE
suppress duplicate `end` events

### DIFF
--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -47,8 +47,10 @@ var JPEGStream = module.exports = function JPEGStream(canvas, options, sync) {
       } else if (chunk) {
         self.emit('data', chunk);
       } else {
-        self.emit('end');
-        self.readable = false;
+        if (self.readable === true) {
+          self.emit('end');
+          self.readable = false;
+        }
       }
     });
   });


### PR DESCRIPTION
The `end` event only needs to be raised once upon reaching EOF.
