### PR TITLE
Replace unescpaed \ with / in browser tests

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -31,7 +31,8 @@ function testFn(req){
   req.body.fn = req.body.fn
     .replace("'state.png'", "'" + __dirname + "/public/state.png'")
     .replace("'face.jpeg'", "'" + __dirname + "/public/face.jpeg'")
-    .replace("'star.png'", "'" + __dirname + "/public/star.png'");
+    .replace("'star.png'", "'" + __dirname + "/public/star.png'")
+    .replace(/\\/g, "/"); // unescaped \ path sep causes issues on Windows, at least
 
   // Do not try this at home :)
   return eval('(' + req.body.fn + ')');


### PR DESCRIPTION
Oddly, #646 seems to have broken browser tests (presumably on Windows only). I bisected the history back to that commit, although I don't see why it would have broken it.

Without this, the tests appear to not complete -- the [empty onError hooks](https://github.com/Automattic/node-canvas/blob/master/test/public/tests.js#L1536) were suppressing a cairo error ("failed to read from input stream").