### PR TITLE
Allow optional toDataURL arguments to be undefined.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+future / future
+==================
+  * Allow optional arguments in `toDataURL` to be `undefined` (#695)
+
 1.3.5 / 2015-12-07
 ==================
 

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -193,19 +193,23 @@ Canvas.prototype.createSyncJPEGStream = function(options){
  */
 
 Canvas.prototype.toDataURL = function(a1, a2, a3){
-  // valid arg patterns (args -> type, opts, fn):
+  // valid arg patterns (args -> [type, opts, fn]):
   // [] -> ['image/png', null, null]
+  // [undefined] -> ['image/png', null, null]
   // ['image/png'] -> ['image/png', null, null]
   // [fn] -> ['image/png', null, fn]
   // [type, fn] -> [type, null, fn]
+  // [undefined, fn] -> ['image/png', null, fn]
   // ['image/jpeg', fn] -> ['image/jpeg', null, fn]
   // ['image/jpeg', opts, fn] -> ['image/jpeg', opts, fn]
+  // ['image/jpeg', undefined, fn] -> ['image/jpeg', null, fn]
 
   var type;
   var opts = {};
   var fn;
+  var argc = Math.min(arguments.length, 3);
 
-  switch (arguments.length) {
+  switch (argc) {
     case 0:
       type = 'image/png';
       break;
@@ -217,6 +221,8 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
         fn = a1;
       } else if ('image/jpeg' === a1) {
         throw new Error('type "image/jpeg" only supports asynchronous operation');
+      } else if (undefined === a1) {
+        type = 'image/png';
       } else {
         throw new Error('invalid arguments');
       }
@@ -224,6 +230,9 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
     case 2:
       if (('image/png' === a1 || 'image/jpeg' === a1) && 'function' === typeof a2) {
         type = a1;
+        fn = a2;
+      } else if (undefined === a1 && 'function' === typeof a2) {
+        type = 'image/png';
         fn = a2;
       } else if ('image/jpeg' === a1 && 'object' === typeof a2) {
         throw new Error('type "image/jpeg" only supports asynchronous operation');
@@ -237,6 +246,9 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
       if ('image/jpeg' === a1 && 'object' === typeof a2 && 'function' === typeof a3) {
         type = a1;
         opts = a2;
+        fn = a3;
+      } else if ('image/jpeg' === a1 && undefined === a2 && 'function' === typeof a3) {
+        type = a1;
         fn = a3;
       } else {
         throw new Error('invalid arguments');

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -385,6 +385,10 @@ describe('Canvas', function () {
       assert.ok(0 == canvas.toDataURL().indexOf('data:image/png;base64,'));
     });
 
+    it('toDataURL(undefined) works and defaults to PNG', function () {
+      assert.ok(0 == canvas.toDataURL(undefined).indexOf('data:image/png;base64,'));
+    });
+
     it('toDataURL("image/png") works', function () {
       assert.ok(0 == canvas.toDataURL('image/png').indexOf('data:image/png;base64,'));
     });
@@ -402,6 +406,14 @@ describe('Canvas', function () {
 
     it('toDataURL(function (err, str) {...}) works and defaults to PNG', function (done) {
       new Canvas(200,200).toDataURL(function(err, str){
+        assert.ifError(err);
+        assert.ok(0 === str.indexOf('data:image/png;base64,'));
+        done();
+      });
+    });
+
+    it('toDataURL(undefined, function (err, str) {...}) works and defaults to PNG', function (done) {
+      new Canvas(200,200).toDataURL(undefined, function(err, str){
         assert.ifError(err);
         assert.ok(0 === str.indexOf('data:image/png;base64,'));
         done();
@@ -440,6 +452,14 @@ describe('Canvas', function () {
 
     it('toDataURL("image/jpeg", function (err, str) {...}) works', function (done) {
       new Canvas(200,200).toDataURL('image/jpeg', function(err, str){
+        assert.ifError(err);
+        assert.ok(0 === str.indexOf('data:image/jpeg;base64,'));
+        done();
+      });
+    });
+
+    it('toDataURL("image/jpeg", undefined, function (err, str) {...}) works', function (done) {
+      new Canvas(200,200).toDataURL('image/jpeg', undefined, function(err, str){
         assert.ifError(err);
         assert.ok(0 === str.indexOf('data:image/jpeg;base64,'));
         done();


### PR DESCRIPTION
Per discussion in #685, allow optional arguments to toDataURL to be undefined. (Was a regression from adding image/jpeg support.)

cc @domenic 