### PR TITLE
remove cairo_include.sh

### DIFF
--- a/util/cairo_include.sh
+++ b/util/cairo_include.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-# Make pkg-config lookup include files from the build directory.
-export PKG_CONFIG_PATH=$(cd "$(dirname "$0")"; pwd)/../build_cairo/lib/pkgconfig;
-
-pkg-config cairo --cflags-only-I | sed s/-I//g


### PR DESCRIPTION
This file was only used for one day in 2013, it's time to let it go...