### PR TITLE
fix segfault on node 0.10.x

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -731,13 +731,13 @@ NAN_METHOD(Context2d::GetImageData) {
   int dstStride = sw * 4;
 
   uint8_t *src = canvas->data();
-  
+
 #if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 10
   Local<Object> global = Context::GetCurrent()->Global();
 
   Local<Int32> sizeHandle = Nan::New(size);
   Local<Value> caargv[] = { sizeHandle };
-  Local<Object> clampedArray = global->Get(Nan::New("Uint8ClampedArray").ToLocalChecked()).As<Function>()->NewInstance(3, caargv);
+  Local<Object> clampedArray = global->Get(Nan::New("Uint8ClampedArray").ToLocalChecked()).As<Function>()->NewInstance(1, caargv);
 #else
   Local<ArrayBuffer> buffer = ArrayBuffer::New(Isolate::GetCurrent(), size);
   Local<Uint8ClampedArray> clampedArray = Uint8ClampedArray::New(buffer, 0, size);
@@ -745,7 +745,7 @@ NAN_METHOD(Context2d::GetImageData) {
 
   Nan::TypedArrayContents<uint8_t> typedArrayContents(clampedArray);
   uint8_t* dst = *typedArrayContents;
-  
+
   // Normalize data (argb -> rgba)
   for (int y = 0; y < sh; ++y) {
     uint32_t *row = (uint32_t *)(src + srcStride * (y + sy));
@@ -902,7 +902,7 @@ NAN_METHOD(Context2d::DrawImage) {
         dx - sx + (context->state->shadowOffsetX / fx) - pad + 1.4,
         dy - sy + (context->state->shadowOffsetY / fy) - pad + 1.4);
       cairo_paint(ctx);
-      
+
       // cleanup
       cairo_destroy(shadow_context);
       cairo_surface_destroy(shadow_surface);


### PR DESCRIPTION
A segfault occurred in `getImageData(...)` on Node.js version 0.10.x because of an incorrect length specified to a function call. V8 then thought that the array was longer than it was and tried to access memory outside of it.

This fixes #688 

I think that the reason this haven't been caught in CI is because it doesn't always happen. My guess is that sometimes the memory after the array is owned by V8 and no segfault occurs. Since the `Uint8ClampedArray` constructor ignores any arguments after the length it probably wasn't a problem to pass in more arguments...