### PR TITLE
expose freetype version

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -57,6 +57,14 @@ if (canvas.gifVersion) {
 }
 
 /**
+ * freetype version.
+ */
+
+if (canvas.freetypeVersion) {
+  exports.freetypeVersion = canvas.freetypeVersion;
+}
+
+/**
  * Expose constructors.
  */
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -15,6 +15,7 @@
 
 #ifdef HAVE_FREETYPE
 #include "FontFace.h"
+#include FT_FREETYPE_H
 #endif
 
 // Compatibility with Visual Studio versions prior to VS2015
@@ -69,6 +70,12 @@ NAN_MODULE_INIT(init) {
 #else
   target->Set(Nan::New<String>("gifVersion").ToLocalChecked(), Nan::New<String>(GIF_LIB_VERSION).ToLocalChecked());
 #endif
+#endif
+
+#ifdef HAVE_FREETYPE
+  char freetype_version[10];
+  snprintf(freetype_version, 10, "%d.%d.%d", FREETYPE_MAJOR, FREETYPE_MINOR, FREETYPE_PATCH);
+  target->Set(Nan::New<String>("freetypeVersion").ToLocalChecked(), Nan::New<String>(freetype_version).ToLocalChecked());
 #endif
 }
 


### PR DESCRIPTION
Makes the freetype verison available as a string under `.freetypeVersion`.

Fixes #299 