### PR TITLE
Properly clamp quality in toDataURL

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -232,7 +232,7 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
       if ('object' === typeof a2) {
         opts = a2;
       } else if ('number' === typeof a2) {
-        opts = {quality: Math.min(0, Math.max(1, a2)) * 100};
+        opts = {quality: Math.max(0, Math.min(1, a2)) * 100};
       }
 
       if ('function' === typeof a3) {


### PR DESCRIPTION
Fixing the bug discussed here:
https://github.com/Automattic/node-canvas/issues/726#issuecomment-190248644