### PR TITLE
Clamp JPEG buffer size. Fixes #674

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -185,8 +185,11 @@ Canvas.prototype.createJPEGStream = function(options){
 Canvas.prototype.syncJPEGStream =
 Canvas.prototype.createSyncJPEGStream = function(options){
   options = options || {};
+  // Don't allow the buffer size to exceed the size of the canvas (#674)
+  var maxBufSize = this.width * this.height * 4;
+  var clampedBufSize = Math.min(options.bufsize || 4096, maxBufSize);
   return new JPEGStream(this, {
-      bufsize: options.bufsize || 4096
+      bufsize: clampedBufSize
     , quality: options.quality || 75
     , progressive: options.progressive || false
   });

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -786,4 +786,14 @@ describe('Canvas', function () {
       done(err);
     });
   });
+
+  it('Canvas#jpegStream() should clamp buffer size (#674)', function (done) {
+    var c = new Canvas(10, 10);
+    var SIZE = 10 * 1024 * 1024;
+    var s = c.jpegStream({bufsize: SIZE});
+    s.on('data', function (chunk) {
+      assert(chunk.length < SIZE);
+    });
+    s.on('end', done);
+  })
 });


### PR DESCRIPTION
NB: I was somewhat surprised that the default of 4096 doesn't likewise cause errors for tiny canvases...