### PR TITLE
Implement Readable instead of Stream

### DIFF
--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -10,7 +10,8 @@
  * Module dependencies.
  */
 
-var Stream = require('stream').Stream;
+var Readable = require('stream').Readable;
+var util = require('util');
 
 /**
  * Initialize a `JPEGStream` with the given `canvas`.
@@ -30,33 +31,47 @@ var Stream = require('stream').Stream;
  */
 
 var JPEGStream = module.exports = function JPEGStream(canvas, options, sync) {
-  var self = this
-    , method = sync
+  if (!(this instanceof JPEGStream)) {
+    throw new TypeError("Class constructors cannot be invoked without 'new'");
+  }
+
+  Readable.call(this);
+
+  var self = this;
+  var method = sync
       ? 'streamJPEGSync'
       : 'streamJPEG';
   this.options = options;
   this.sync = sync;
   this.canvas = canvas;
-  this.readable = true;
+
   // TODO: implement async
   if ('streamJPEG' == method) method = 'streamJPEGSync';
+  this.method = method;
+};
+
+util.inherits(JPEGStream, Readable);
+
+function noop() {}
+
+JPEGStream.prototype._read = function _read() {
+  // For now we're not controlling the c++ code's data emission, so we only
+  // call canvas.streamJPEGSync once and let it emit data at will.
+  this._read = noop;
+  var self = this;
+  var method = this.method;
+  var bufsize = this.options.bufsize;
+  var quality = this.options.quality;
+  var progressive = this.options.progressive;
   process.nextTick(function(){
-    canvas[method](options.bufsize, options.quality, options.progressive, function(err, chunk){
+    self.canvas[method](bufsize, quality, progressive, function(err, chunk){
       if (err) {
         self.emit('error', err);
-        self.readable = false;
       } else if (chunk) {
-        self.emit('data', chunk);
+        self.push(chunk);
       } else {
-        self.emit('end');
-        self.readable = false;
+        self.push(null);
       }
     });
   });
 };
-
-/**
- * Inherit from `EventEmitter`.
- */
-
-JPEGStream.prototype.__proto__ = Stream.prototype;

--- a/lib/pdfstream.js
+++ b/lib/pdfstream.js
@@ -8,7 +8,8 @@
  * Module dependencies.
  */
 
-var Stream = require('stream').Stream;
+var Readable = require('stream').Readable;
+var util = require('util');
 
 /**
  * Initialize a `PDFStream` with the given `canvas`.
@@ -28,32 +29,42 @@ var Stream = require('stream').Stream;
  */
 
 var PDFStream = module.exports = function PDFStream(canvas, sync) {
+  if (!(this instanceof PDFStream)) {
+    throw new TypeError("Class constructors cannot be invoked without 'new'");
+  }
+
+  Readable.call(this);
+
   var self = this
     , method = sync
       ? 'streamPDFSync'
       : 'streamPDF';
   this.sync = sync;
   this.canvas = canvas;
-  this.readable = true;
+
   // TODO: implement async
   if ('streamPDF' == method) method = 'streamPDFSync';
+  this.method = method;
+};
+
+util.inherits(PDFStream, Readable);
+
+function noop() {}
+
+PDFStream.prototype._read = function _read() {
+  // For now we're not controlling the c++ code's data emission, so we only
+  // call canvas.streamPDFSync once and let it emit data at will.
+  this._read = noop;
+  var self = this;
   process.nextTick(function(){
-    canvas[method](function(err, chunk, len){
+    self.canvas[self.method](function(err, chunk, len){
       if (err) {
         self.emit('error', err);
-        self.readable = false;
       } else if (len) {
-        self.emit('data', chunk, len);
+        self.push(chunk);
       } else {
-        self.emit('end');
-        self.readable = false;
+        self.push(null);
       }
     });
   });
 };
-
-/**
- * Inherit from `EventEmitter`.
- */
-
-PDFStream.prototype.__proto__ = Stream.prototype;

--- a/lib/pngstream.js
+++ b/lib/pngstream.js
@@ -10,7 +10,8 @@
  * Module dependencies.
  */
 
-var Stream = require('stream').Stream;
+var Readable = require('stream').Readable;
+var util = require('util');
 
 /**
  * Initialize a `PNGStream` with the given `canvas`.
@@ -30,32 +31,59 @@ var Stream = require('stream').Stream;
  */
 
 var PNGStream = module.exports = function PNGStream(canvas, sync) {
-  var self = this
-    , method = sync
+  if (!(this instanceof PNGStream)) {
+    throw new TypeError("Class constructors cannot be invoked without 'new'");
+  }
+
+  Readable.call(this);
+
+  var self = this;
+  var method = sync
       ? 'streamPNGSync'
       : 'streamPNG';
   this.sync = sync;
   this.canvas = canvas;
-  this.readable = true;
+
   // TODO: implement async
-  if ('streamPNG' == method) method = 'streamPNGSync';
+  if ('streamPNG' === method) method = 'streamPNGSync';
+  this.method = method;
+};
+
+util.inherits(PNGStream, Readable);
+
+var PNGStream = module.exports = function PNGStream(canvas, sync) {
+  Readable.call(this);
+
+  var self = this;
+  var method = sync
+      ? 'streamPNGSync'
+      : 'streamPNG';
+  this.sync = sync;
+  this.canvas = canvas;
+
+  // TODO: implement async
+  if ('streamPNG' === method) method = 'streamPNGSync';
+  this.method = method;
+};
+
+util.inherits(PNGStream, Readable);
+
+function noop() {}
+
+PNGStream.prototype._read = function _read() {
+  // For now we're not controlling the c++ code's data emission, so we only
+  // call canvas.streamPNGSync once and let it emit data at will.
+  this._read = noop;
+  var self = this;
   process.nextTick(function(){
-    canvas[method](function(err, chunk, len){
+    self.canvas[self.method](function(err, chunk, len){
       if (err) {
         self.emit('error', err);
-        self.readable = false;
       } else if (len) {
-        self.emit('data', chunk, len);
+        self.push(chunk);
       } else {
-        self.emit('end');
-        self.readable = false;
+        self.push(null);
       }
     });
   });
 };
-
-/**
- * Inherit from `EventEmitter`.
- */
-
-PNGStream.prototype.__proto__ = Stream.prototype;

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -460,7 +460,7 @@ NAN_METHOD(Canvas::StreamPNGSync) {
         Nan::Null()
       , Nan::Null()
       , Nan::New<Uint32>(0) };
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), (v8::Local<v8::Function>)closure.fn, 1, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), (v8::Local<v8::Function>)closure.fn, 3, argv);
   }
   return;
 }

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -6,7 +6,8 @@ var Canvas = require('../')
   , assert = require('assert')
   , parseFont = Canvas.Context2d.parseFont
   , fs = require('fs')
-  , os = require('os');
+  , os = require('os')
+  , Readable = require('stream').Readable;
 
 console.log();
 console.log('   canvas: %s', Canvas.version);
@@ -878,6 +879,7 @@ describe('Canvas', function () {
   it('Canvas#createSyncPNGStream()', function (done) {
     var canvas = new Canvas(20, 20);
     var stream = canvas.createSyncPNGStream();
+    assert(stream instanceof Readable);
     var firstChunk = true;
     stream.on('data', function(chunk){
       if (firstChunk) {
@@ -896,6 +898,7 @@ describe('Canvas', function () {
   it('Canvas#createSyncPDFStream()', function (done) {
     var canvas = new Canvas(20, 20, 'pdf');
     var stream = canvas.createSyncPDFStream();
+    assert(stream instanceof Readable);
     var firstChunk = true;
     stream.on('data', function (chunk) {
       if (firstChunk) {
@@ -914,6 +917,7 @@ describe('Canvas', function () {
   it('Canvas#jpegStream()', function (done) {
     var canvas = new Canvas(640, 480);
     var stream = canvas.jpegStream();
+    assert(stream instanceof Readable);
     var firstChunk = true;
     var bytes = 0;
     stream.on('data', function(chunk){


### PR DESCRIPTION
Would benefit from some testers (@mitar?) and feedback...

Both JPEGStream and PNGStream currently inherit from `stream.Stream`, not `stream.Readable`. As a consequence, they are missing a bunch of methods. (See #674, #232.) They will also start flowing without a listener, but because the stream is wrapped in `process.nextTick` I think that would only be noticed from the node prompt.

It was straightforward to switch to `Readable`. I didn't attempt to make the C++ code wait to queue more data after the stream starts (first call to `.read`); after the first chunk it pushes data into the stream queue without waiting for the stream consumer to call `.read` (directly or indirectly). There should be no lost bytes as a result of flowing without a sink anymore, but consumers could see more memory consumption from the queuing of bytes that previously would have been lost into the ether.

I'm still confused about the "async" vs "sync" names of these APIs -- they all emit chunks of data within callbacks, which seems async to the consumer, if not internally.
