### PR TITLE
update minimum NAN version to fix #758

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-server": "node test/server.js"
   },
   "dependencies": {
-    "nan": "^2.1.0"
+    "nan": "^2.3.2"
   },
   "devDependencies": {
     "body-parser": "^1.13.3",


### PR DESCRIPTION
Gets rid of warnings in node 6 and makes it compatible for node 7