### PR TITLE
CanvasRenderingContext2D class name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -170,7 +170,7 @@ canvas.toDataURL('image/jpeg', {opts...}, function(err, jpeg){ }); // see Canvas
 canvas.toDataURL('image/jpeg', quality, function(err, jpeg){ }); // spec-following; quality from 0 to 1
 ```
 
-### CanvasRenderingContext2d#patternQuality
+### CanvasRenderingContext2D#patternQuality
 
 Given one of the values below will alter pattern (gradients, images, etc) render quality, defaults to _good_.
 
@@ -180,7 +180,7 @@ Given one of the values below will alter pattern (gradients, images, etc) render
   - nearest
   - bilinear
 
-### CanvasRenderingContext2d#textDrawingMode
+### CanvasRenderingContext2D#textDrawingMode
 
 Can be either `path` or `glyph`. Using `glyph` is much faster than `path` for drawing, and when using a PDF context will embed the text natively, so will be selectable and lower filesize. The downside is that cairo does not have any subpixel precision for `glyph`, so this will be noticeably lower quality for text positioning in cases such as rotated text. Also, strokeText in `glyph` will act the same as fillText, except using the stroke style for the fill.
 
@@ -188,7 +188,7 @@ Defaults to _path_.
 
 This property is tracked as part of the canvas state in save/restore.
 
-### CanvasRenderingContext2d#filter
+### CanvasRenderingContext2D#filter
 
 Like `patternQuality`, but applies to transformations effecting more than just patterns. Defaults to _good_.
 

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -98,7 +98,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Context2d::New);
   constructor.Reset(ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("CanvasRenderingContext2d").ToLocalChecked());
+  ctor->SetClassName(Nan::New("CanvasRenderingContext2D").ToLocalChecked());
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();


### PR DESCRIPTION
Rendering context called "CanvasRenderingContext2D" in the [specification].(https://html.spec.whatwg.org/#2dcontext) 
Also I saw [object CanvasRenderingContext2D] in Chrome, FF and Safari after this code:
```
document.createElement('canvas').getContext('2d').toString();
```