### PR TITLE
Crude PDF stream implementation

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -16,6 +16,7 @@ var canvas = require('./bindings')
   , cairoVersion = canvas.cairoVersion
   , Context2d = require('./context2d')
   , PNGStream = require('./pngstream')
+  , PDFStream = require('./pdfstream')
   , JPEGStream = require('./jpegstream')
   , FontFace = canvas.FontFace
   , fs = require('fs')
@@ -70,6 +71,7 @@ if (canvas.freetypeVersion) {
 
 exports.Context2d = Context2d;
 exports.PNGStream = PNGStream;
+exports.PDFStream = PDFStream;
 exports.JPEGStream = JPEGStream;
 exports.Image = Image;
 exports.ImageData = canvas.ImageData;
@@ -159,6 +161,30 @@ Canvas.prototype.createPNGStream = function(){
 Canvas.prototype.syncPNGStream =
 Canvas.prototype.createSyncPNGStream = function(){
   return new PNGStream(this, true);
+};
+
+/**
+ * Create a `PDFStream` for `this` canvas.
+ *
+ * @return {PDFStream}
+ * @api public
+ */
+
+Canvas.prototype.pdfStream =
+Canvas.prototype.createPDFStream = function(){
+  return new PDFStream(this);
+};
+
+/**
+ * Create a synchronous `PDFStream` for `this` canvas.
+ *
+ * @return {PDFStream}
+ * @api public
+ */
+
+Canvas.prototype.syncPDFStream =
+Canvas.prototype.createSyncPDFStream = function(){
+  return new PDFStream(this, true);
 };
 
 /**

--- a/lib/pdfstream.js
+++ b/lib/pdfstream.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/*!
+ * Canvas - PDFStream
+ */
+
+/**
+ * Module dependencies.
+ */
+
+var Stream = require('stream').Stream;
+
+/**
+ * Initialize a `PDFStream` with the given `canvas`.
+ *
+ * "data" events are emitted with `Buffer` chunks, once complete the
+ * "end" event is emitted. The following example will stream to a file
+ * named "./my.pdf".
+ *
+ *     var out = fs.createWriteStream(__dirname + '/my.pdf')
+ *       , stream = canvas.createPDFStream();
+ *
+ *     stream.pipe(out);
+ *
+ * @param {Canvas} canvas
+ * @param {Boolean} sync
+ * @api public
+ */
+
+var PDFStream = module.exports = function PDFStream(canvas, sync) {
+  var self = this
+    , method = sync
+      ? 'streamPDFSync'
+      : 'streamPDF';
+  this.sync = sync;
+  this.canvas = canvas;
+  this.readable = true;
+  // TODO: implement async
+  if ('streamPDF' == method) method = 'streamPDFSync';
+  process.nextTick(function(){
+    canvas[method](function(err, chunk, len){
+      if (err) {
+        self.emit('error', err);
+        self.readable = false;
+      } else if (len) {
+        self.emit('data', chunk, len);
+      } else {
+        self.emit('end');
+        self.readable = false;
+      }
+    });
+  });
+};
+
+/**
+ * Inherit from `EventEmitter`.
+ */
+
+PDFStream.prototype.__proto__ = Stream.prototype;

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -62,6 +62,7 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_SETTER(SetWidth);
     static NAN_SETTER(SetHeight);
     static NAN_METHOD(StreamPNGSync);
+    static NAN_METHOD(StreamPDFSync);
     static NAN_METHOD(StreamJPEGSync);
     static Local<Value> Error(cairo_status_t status);
 #if NODE_VERSION_AT_LEAST(0, 6, 0)

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -802,6 +802,24 @@ describe('Canvas', function () {
     });
   });
 
+  it('Canvas#createSyncPDFStream()', function (done) {
+    var canvas = new Canvas(20, 20, 'pdf');
+    var stream = canvas.createSyncPDFStream();
+    var firstChunk = true;
+    stream.on('data', function (chunk) {
+      if (firstChunk) {
+        firstChunk = false;
+        assert.equal('PDF', chunk.slice(1, 4).toString());
+      }
+    });
+    stream.on('end', function () {
+      done();
+    });
+    stream.on('error', function (err) {
+      done(err);
+    });
+  });
+
   it('Canvas#jpegStream()', function (done) {
     var canvas = new Canvas(640, 480);
     var stream = canvas.jpegStream();


### PR DESCRIPTION
A Minimial Working PDFStream.

Fixes #778

However, I would not advise merging it as such. It would be better to clean up all the streams code, avoiding the need to keep everything in memory and eliminating unnecessary copying of data. It would also be nice to finally have the asynchronous streams. This would entail a major rewrite of the library and its API, which I do not have time to do.