### PR TITLE
add OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
+os:
+  - linux
+  - osx
+osx_image: xcode8 # has everything we need but cairo
 node_js:
   - '6'
   - '4'
@@ -10,6 +14,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - pax-utils
       - libcairo2-dev
       - libjpeg8-dev
       - libpango1.0-dev
@@ -18,6 +23,7 @@ addons:
 env:
   - CXX=g++-4.9
 before_install:
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew update && brew install cairo; fi
   - if [[ $TRAVIS_NODE_VERSION == 0.8 ]]; then npm install -g npm@1.4.28; fi
   - npm explore npm -g -- npm install node-gyp@latest
 sudo: false


### PR DESCRIPTION
This is a small part of a larger project I'm working on to automate build & deploy binaries to NPM. I thought it would be good to get this in sooner since it's sort of an independent part

There was [a bug](https://github.com/travis-ci/travis-ci/issues/6315) in Travis (well, really in Node on OS X) that I had to wait to be fixed till I could create this

One downside is that the builds take stupid long now. 
- [master build on my fork](https://travis-ci.org/chearon/node-canvas/builds/145023188) - 11m 36s
- [add-os-build build on my fork](https://travis-ci.org/chearon/node-canvas/builds/147796775) - 28m 7s 😖

I have seen it sometimes go faster

Unrelated sorta:

I've been getting really close to having the Windows version of pango work with MSYS2 instead of a downloaded ZIP from the wiki. When I get that done, the path is clear to having a Windows build on AppVeyor, but it will change the wiki and the binding.gyp significantly!
