### PR TITLE
Windows JPEG support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -149,7 +149,7 @@
                 '<(jpeg_root)/include'
               ],
               'libraries': [
-                '-l<(GTK_Root)/lib/jpeg.lib'
+                '-l<(jpeg_root)/lib/jpeg.lib',
               ]
             }, {
               'libraries': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,11 +3,21 @@
     ['OS=="win"', {
       'variables': {
         'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
-        'jpeg_root%': 'c:/libjpeg-turbo64',
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
-        'with_freetype%': 'false'
+        'with_freetype%': 'false',
+        'variables': { # Nest jpeg_root to evaluate it before with_jpeg
+          'jpeg_root%': '<!(node ./util/win_jpeg_lookup)'
+        },
+        'jpeg_root%': '<(jpeg_root)', # Take value of nested variable
+        'conditions': [
+          ['jpeg_root==""', {
+            'with_jpeg%': 'false'
+          }, {
+            'with_jpeg%': 'true'
+          }]
+        ]
       }
     }, { # 'OS!="win"'
       'variables': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     ['OS=="win"', {
       'variables': {
         'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
+        'jpeg_root%': 'c:/libjpeg-turbo64',
         'with_jpeg%': 'false',
         'with_gif%': 'false',
         'with_pango%': 'false',
@@ -138,6 +139,15 @@
           ],
           'conditions': [
             ['OS=="win"', {
+              'copies': [{
+                'destination': '<(PRODUCT_DIR)',
+                'files': [
+                  '<(jpeg_root)/bin/jpeg62.dll',
+                ]
+              }],
+              'include_dirs': [
+                '<(jpeg_root)/include'
+              ],
               'libraries': [
                 '-l<(GTK_Root)/lib/jpeg.lib'
               ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas",
   "description": "Canvas graphics API backed by Cairo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "TJ Holowaychuk <tj@learnboost.com>",
   "contributors": [
     "Nathan Rajlich <nathan@tootallnate.net>",

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -9,14 +9,40 @@ var Canvas = require('../')
 
 var png_checkers = __dirname + '/fixtures/checkers.png';
 var png_clock = __dirname + '/fixtures/clock.png';
+var jpg_face = __dirname + '/public/face.jpeg';
 
 describe('Image', function () {
+  this.timeout(5000);
   it('should require new', function () {
     assert.throws(function () { Image(); }, TypeError);
   });
 
   it('Image', function () {
     assert.ok(Image instanceof Function);
+  });
+
+  it('Image set src to JPEG', function () {
+    var img = new Image
+      , onloadCalled = 0;
+
+    assert.strictEqual(null, img.onload);
+    assert.strictEqual(false, img.complete);
+
+    img.onload = function () {
+      onloadCalled += 1;
+      assert.strictEqual(img.src, jpg_face);
+      assert.strictEqual(485, img.width);
+      assert.strictEqual(401, img.height);
+      assert.strictEqual(true, img.complete);
+    };
+
+    img.onerror = function (e) {
+      console.error("ERROR", e); // temporary...
+    };
+
+    img.src = jpg_face;
+    assert.strictEqual(1, onloadCalled);
+    assert.strictEqual(img.src, jpg_face);
   });
 
   it('Image#onload', function () {

--- a/util/win_jpeg_lookup.js
+++ b/util/win_jpeg_lookup.js
@@ -1,0 +1,21 @@
+var fs = require('fs')
+var paths = ['C:/libjpeg-turbo']
+
+if (process.arch === 'x64') {
+  paths.unshift('C:/libjpeg-turbo64')
+}
+
+paths.forEach(function(path){
+  if (exists(path)) {
+    process.stdout.write(path)
+    process.exit()
+  }
+})
+
+function exists(path) {
+  try {
+    return fs.lstatSync(path).isDirectory()
+  } catch(e) {
+    return false
+  }
+}


### PR DESCRIPTION
This PR adds JPEG support on windows.

Basically a duplicate of #458, but this one needs explicit options to be be set on `npm install` and `node-gyp rebuild`. The explicit options make sure nothing breaks.

It needs libjpeg-turbo or libjpeg-turbo64 installed.

Added the `jpeg_root` variable to binding.gyp (default: `c:/libjpeg-turbo64`).
Also `jpeg62.dll` will be copied to `build/Release`

Install:
`node-gyp rebuild --jpeg_root=C:\libjpeg-turbo64 --with_jpeg` 
`npm install --jpeg_root=C:\libjpeg-turbo64 --with_jpeg` 

Tested on win8.1 x64 node 6.2.1, Visual Studio 2015
