### PR TITLE
Remove unused member variables warned by compiler

### DIFF
--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -41,8 +41,6 @@ NAN_METHOD(Pattern::New) {
     return Nan::ThrowTypeError("Class constructors cannot be invoked without 'new'");
   }
 
-  int w = 0
-    , h = 0;
   cairo_surface_t *surface;
 
   Local<Object> obj = info[0]->ToObject();
@@ -53,15 +51,11 @@ NAN_METHOD(Pattern::New) {
     if (!img->isComplete()) {
       return Nan::ThrowError("Image given has not completed loading");
     }
-    w = img->width;
-    h = img->height;
     surface = img->surface();
 
   // Canvas
   } else if (Nan::New(Canvas::constructor)->HasInstance(obj)) {
     Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(obj);
-    w = canvas->width;
-    h = canvas->height;
     surface = canvas->surface();
 
   // Invalid
@@ -69,7 +63,7 @@ NAN_METHOD(Pattern::New) {
     return Nan::ThrowTypeError("Image or Canvas expected");
   }
 
-  Pattern *pattern = new Pattern(surface,w,h);
+  Pattern *pattern = new Pattern(surface);
   pattern->Wrap(info.This());
   info.GetReturnValue().Set(info.This());
 }
@@ -79,8 +73,7 @@ NAN_METHOD(Pattern::New) {
  * Initialize linear gradient.
  */
 
-Pattern::Pattern(cairo_surface_t *surface, int w, int h):
-  _width(w), _height(h) {
+Pattern::Pattern(cairo_surface_t *surface) {
   _pattern = cairo_pattern_create_for_surface(surface);
 }
 

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -15,12 +15,11 @@ class Pattern: public Nan::ObjectWrap {
     static Nan::Persistent<FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
-    Pattern(cairo_surface_t *surface, int w, int h);
+    Pattern(cairo_surface_t *surface);
     inline cairo_pattern_t *pattern(){ return _pattern; }
 
   private:
     ~Pattern();
-    int _width, _height;
     // TODO REPEAT/REPEAT_X/REPEAT_Y
     cairo_pattern_t *_pattern;
 };

--- a/src/FontFace.cc
+++ b/src/FontFace.cc
@@ -107,7 +107,7 @@ NAN_METHOD(FontFace::New) {
   // get released by cairo although the JS font face object is still alive.
   cairo_font_face_reference(crFace);
 
-  FontFace *face = new FontFace(ftFace, crFace);
+  FontFace *face = new FontFace(crFace);
   face->Wrap(info.This());
   info.GetReturnValue().Set(info.This());
 }

--- a/src/FontFace.h
+++ b/src/FontFace.h
@@ -18,13 +18,12 @@ class FontFace: public Nan::ObjectWrap {
     static Nan::Persistent<FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
-    FontFace(FT_Face ftFace, cairo_font_face_t *crFace)
-      :_ftFace(ftFace), _crFace(crFace) {}
+    FontFace(cairo_font_face_t *crFace)
+      :_crFace(crFace) {}
 
     inline cairo_font_face_t *cairoFace(){ return _crFace; }
   private:
     ~FontFace();
-    FT_Face   _ftFace;
     cairo_font_face_t *_crFace;
     static bool _initLibrary;
 };


### PR DESCRIPTION
Hi, thank you for nice library.  I'm testing my `<canvas>` application with this and this works great.

I found that some fields were reported as unused by Clang.  So I removed them safely and confirmed all tests passed.  I also confirmed my application tests pass with my fork.