### PR TITLE
Support canvas.getBuffer('raw')

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,10 +140,22 @@ var stream = canvas.jpegStream({
 
 ### Canvas#toBuffer()
 
-A call to `Canvas#toBuffer()` will return a node `Buffer` instance containing all of the PNG data.
+A call to `Canvas#toBuffer()` will return a node `Buffer` instance containing image data.
 
 ```javascript
-canvas.toBuffer();
+// PNG Buffer, default settings
+var buf = canvas.toBuffer();
+
+// PNG Buffer, zlib compression level 3 (from 0-9), faster but bigger
+var buf2 = canvas.toBuffer(undefined, 3, canvas.PNG_FILTER_NONE);
+
+// ARGB32 Buffer, native-endian
+var buf3 = canvas.toBuffer('raw');
+var stride = canvas.stride;
+// In memory, this is `canvas.height * canvas.stride` bytes long.
+// The top row of pixels, in ARGB order, left-to-right, is:
+var topPixelsARGBLeftToRight = buf3.slice(0, canvas.width * 4);
+var row3 = buf3.slice(2 * canvas.stride, 2 * canvas.stride + canvas.width * 4);
 ```
 
 ### Canvas#toBuffer() async

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -257,7 +257,7 @@ NAN_METHOD(Canvas::ToBuffer) {
     return;
   }
 
-  if (info.Length() == 1 && info[0]->StrictEquals(Nan::New<String>("raw").ToLocalChecked())) {
+  if (info.Length() >= 1 && info[0]->StrictEquals(Nan::New<String>("raw").ToLocalChecked())) {
     // Return raw ARGB data -- just a memcpy()
     cairo_surface_t *surface = canvas->surface();
     cairo_surface_flush(surface);

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -45,6 +45,7 @@ Canvas::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   Nan::SetPrototypeMethod(ctor, "streamJPEGSync", StreamJPEGSync);
 #endif
   Nan::SetAccessor(proto, Nan::New("type").ToLocalChecked(), GetType);
+  Nan::SetAccessor(proto, Nan::New("stride").ToLocalChecked(), GetStride);
   Nan::SetAccessor(proto, Nan::New("width").ToLocalChecked(), GetWidth, SetWidth);
   Nan::SetAccessor(proto, Nan::New("height").ToLocalChecked(), GetHeight, SetHeight);
 
@@ -89,6 +90,14 @@ NAN_METHOD(Canvas::New) {
 NAN_GETTER(Canvas::GetType) {
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
   info.GetReturnValue().Set(Nan::New<String>(canvas->isPDF() ? "pdf" : canvas->isSVG() ? "svg" : "image").ToLocalChecked());
+}
+
+/*
+ * Get stride.
+ */
+NAN_GETTER(Canvas::GetStride) {
+  Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
+  info.GetReturnValue().Set(Nan::New<Number>(canvas->stride()));
 }
 
 /*
@@ -244,6 +253,17 @@ NAN_METHOD(Canvas::ToBuffer) {
     closure_t *closure = (closure_t *) canvas->closure();
 
     Local<Object> buf = Nan::CopyBuffer((char*) closure->data, closure->len).ToLocalChecked();
+    info.GetReturnValue().Set(buf);
+    return;
+  }
+
+  if (info.Length() == 1 && info[0]->StrictEquals(Nan::New<String>("raw").ToLocalChecked())) {
+    // Return raw ARGB data -- just a memcpy()
+    cairo_surface_t *surface = canvas->surface();
+    cairo_surface_flush(surface);
+    const unsigned char *data = cairo_image_surface_get_data(surface);
+    printf("%x %x %x %x %x\n", data[0], data[1], data[2], data[3], data[4]);
+    Local<Object> buf = Nan::CopyBuffer(reinterpret_cast<const char*>(data), canvas->nBytes()).ToLocalChecked();
     info.GetReturnValue().Set(buf);
     return;
   }
@@ -571,7 +591,7 @@ Canvas::Canvas(int w, int h, canvas_type_t t): Nan::ObjectWrap() {
   } else {
     _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
     assert(_surface);
-    Nan::AdjustExternalMemory(4 * w * h);
+    Nan::AdjustExternalMemory(nBytes());
   }
 }
 
@@ -589,8 +609,9 @@ Canvas::~Canvas() {
       cairo_surface_destroy(_surface);
       break;
     case CANVAS_TYPE_IMAGE:
+      int oldNBytes = nBytes();
       cairo_surface_destroy(_surface);
-      Nan::AdjustExternalMemory(-4 * width * height);
+      Nan::AdjustExternalMemory(-oldNBytes);
       break;
   }
 }
@@ -626,11 +647,10 @@ Canvas::resurface(Local<Object> canvas) {
       break;
     case CANVAS_TYPE_IMAGE:
       // Re-surface
-      int old_width = cairo_image_surface_get_width(_surface);
-      int old_height = cairo_image_surface_get_height(_surface);
+      size_t oldNBytes = nBytes();
       cairo_surface_destroy(_surface);
       _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-      Nan::AdjustExternalMemory(4 * (width * height - old_width * old_height));
+      Nan::AdjustExternalMemory(nBytes() - oldNBytes);
 
       // Reset context
       context = canvas->Get(Nan::New<String>("context").ToLocalChecked());

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -262,7 +262,6 @@ NAN_METHOD(Canvas::ToBuffer) {
     cairo_surface_t *surface = canvas->surface();
     cairo_surface_flush(surface);
     const unsigned char *data = cairo_image_surface_get_data(surface);
-    printf("%x %x %x %x %x\n", data[0], data[1], data[2], data[3], data[4]);
     Local<Object> buf = Nan::CopyBuffer(reinterpret_cast<const char*>(data), canvas->nBytes()).ToLocalChecked();
     info.GetReturnValue().Set(buf);
     return;

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -57,6 +57,7 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_METHOD(New);
     static NAN_METHOD(ToBuffer);
     static NAN_GETTER(GetType);
+    static NAN_GETTER(GetStride);
     static NAN_GETTER(GetWidth);
     static NAN_GETTER(GetHeight);
     static NAN_SETTER(SetWidth);
@@ -85,6 +86,7 @@ class Canvas: public Nan::ObjectWrap {
     inline void *closure(){ return _closure; }
     inline uint8_t *data(){ return cairo_image_surface_get_data(_surface); }
     inline int stride(){ return cairo_image_surface_get_stride(_surface); }
+    inline int nBytes(){ return height * stride(); }
     Canvas(int width, int height, canvas_type_t type);
     void resurface(Local<Object> canvas);
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -418,13 +418,21 @@ describe('Canvas', function () {
     var buf = canvas.toBuffer('raw');
     var stride = canvas.stride;
 
+    var isBE = (function() {
+      var b = new ArrayBuffer(4);
+      var u32 = new Uint32Array(b);
+      var u8 = new Uint8Array(b);
+      u32[0] = 1;
+      return u8[0] ? 'LE' : 'BE';
+    }());
+
     function assertPixel(u32, x, y, message) {
       var expected = '0x' + u32.toString(16);
 
       // Buffer doesn't have readUInt32(): it only has readUInt32LE() and
       // readUInt32BE().
       var px = buf.readUInt32BE(y * stride + x * 4);
-      if (os.endianness() === 'LE') {
+      if (isBE) {
         px = (((px & 0xff) << 24)
           | ((px & 0xff00) << 8)
           | ((px & 0xff0000) >> 8)

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -418,13 +418,21 @@ describe('Canvas', function () {
     var buf = canvas.toBuffer('raw');
     var stride = canvas.stride;
 
-    // Buffer doesn't have readUInt32(): it only has readUInt32LE() and
-    // readUInt32BE().
-    if (os.endianness() === 'LE') buf.swap32();
-
     function assertPixel(u32, x, y, message) {
       var expected = '0x' + u32.toString(16);
-      var actual = '0x' + buf.readUInt32BE(y * stride + x * 4).toString(16);
+
+      // Buffer doesn't have readUInt32(): it only has readUInt32LE() and
+      // readUInt32BE().
+      var px = buf.readUInt32BE(y * stride + x * 4);
+      if (os.endianness() === 'LE') {
+        px = (((px & 0xff) << 24)
+          | ((px & 0xff00) << 8)
+          | ((px & 0xff0000) >> 8)
+          | ((px & 0xff000000) >> 24))
+          >>> 0; // -1 => 0xffffffff
+      }
+      var actual = '0x' + px.toString(16);
+
       assert.equal(actual, expected, message);
     }
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -418,7 +418,8 @@ describe('Canvas', function () {
     var buf = canvas.toBuffer('raw');
     var stride = canvas.stride;
 
-    var isBE = (function() {
+    // emulate os.endianness() (until node v0.8 support is dropped)
+    var endianness = (function() {
       var b = new ArrayBuffer(4);
       var u32 = new Uint32Array(b);
       var u8 = new Uint8Array(b);
@@ -431,14 +432,7 @@ describe('Canvas', function () {
 
       // Buffer doesn't have readUInt32(): it only has readUInt32LE() and
       // readUInt32BE().
-      var px = buf.readUInt32BE(y * stride + x * 4);
-      if (isBE) {
-        px = (((px & 0xff) << 24)
-          | ((px & 0xff00) << 8)
-          | ((px & 0xff0000) >> 8)
-          | ((px & 0xff000000) >> 24))
-          >>> 0; // -1 => 0xffffffff
-      }
+      var px = buf['readUInt32' + endianness](y * stride + x * 4);
       var actual = '0x' + px.toString(16);
 
       assert.equal(actual, expected, message);


### PR DESCRIPTION
This should help interface with custom image libraries like LodePNG or
WebP.

refs #306. Also, I think users could handle #562 themselves, using https://github.com/lovell/sharp plus some bit-shifts. (I haven't seen a Node library that does bulk bit-shifts on Buffer data, but it'd be straightforward to write one.)