### PR TITLE
Drop support for Node.js 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - '4'
   - '0.12'
   - '0.10'
-  - '0.8'
 addons:
   apt:
     sources:
@@ -18,6 +17,5 @@ addons:
 env:
   - CXX=g++-4.9
 before_install:
-  - if [[ $TRAVIS_NODE_VERSION == 0.8 ]]; then npm install -g npm@1.4.28; fi
   - npm explore npm -g -- npm install node-gyp@latest
 sudo: false

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "standard": "^7.1.1"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.10.0"
   },
   "main": "./lib/canvas.js",
   "license": "MIT"

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -418,14 +418,7 @@ describe('Canvas', function () {
     var buf = canvas.toBuffer('raw');
     var stride = canvas.stride;
 
-    // emulate os.endianness() (until node v0.8 support is dropped)
-    var endianness = (function() {
-      var b = new ArrayBuffer(4);
-      var u32 = new Uint32Array(b);
-      var u8 = new Uint8Array(b);
-      u32[0] = 1;
-      return u8[0] ? 'LE' : 'BE';
-    }());
+    var endianness = os.endianness();
 
     function assertPixel(u32, x, y, message) {
       var expected = '0x' + u32.toString(16);


### PR DESCRIPTION
Dropping support for Node.js 0.8 since it's required for #740 to land, and also, nobody uses it anymore...

I would be open to dropping 0.10 and 0.12 as well since they are going out of life this month and this year respectively. That will depend on when we release Canvas 2.0 though...