### PR TITLE
Backends support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 # Vim cruft
 *.swp
 *.un~
+npm-debug.log

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,11 +2,11 @@
   'conditions': [
     ['OS=="win"', {
       'variables': {
-        'GTK_Root%': 'C:/GTK', # Set the location of GTK all-in-one bundle
+        'GTK_Root%': 'C:/GTK',  # Set the location of GTK all-in-one bundle
         'with_jpeg%': 'false',
         'with_gif%': 'false'
       }
-    }, { # 'OS!="win"'
+    }, {  # 'OS!="win"'
       'variables': {
         'with_jpeg%': '<!(./util/has_lib.sh jpeg)',
         'with_gif%': '<!(./util/has_lib.sh gif)'
@@ -46,15 +46,22 @@
       'target_name': 'canvas',
       'include_dirs': ["<!(node -e \"require('nan')\")"],
       'sources': [
+        'src/backend/Backend.cc',
+        'src/backend/ImageBackend.cc',
+        'src/backend/PdfBackend.cc',
+        'src/backend/SvgBackend.cc',
+        'src/Backends.cc',
         'src/Canvas.cc',
         'src/CanvasGradient.cc',
         'src/CanvasPattern.cc',
         'src/CanvasRenderingContext2d.cc',
+        'src/closure.cc',
         'src/color.cc',
         'src/Image.cc',
         'src/ImageData.cc',
+        'src/init.cc',
         'src/register_font.cc',
-        'src/init.cc'
+        'src/toBuffer.cc'
       ],
       'conditions': [
         ['OS=="win"', {
@@ -76,7 +83,7 @@
             '<(GTK_Root)/lib/glib-2.0/include'
           ],
           'defines': [
-            '_USE_MATH_DEFINES' # for M_PI
+            '_USE_MATH_DEFINES'  # for M_PI
           ],
           'configurations': {
             'Debug': {
@@ -84,7 +91,9 @@
                 'VCCLCompilerTool': {
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
-                  'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+                  'DisableSpecificWarnings': [
+                    4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512
+                  ]
                 }
               }
             },
@@ -93,12 +102,14 @@
                 'VCCLCompilerTool': {
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
-                  'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+                  'DisableSpecificWarnings': [
+                    4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512
+                  ]
                 }
               }
             }
           }
-        }, { # 'OS!="win"'
+        }, {  # 'OS!="win"'
           'libraries': [
             '<!@(pkg-config pixman-1 --libs)',
             '<!@(pkg-config cairo --libs)',

--- a/examples/backends.js
+++ b/examples/backends.js
@@ -1,0 +1,18 @@
+var fs = require('fs')
+var resolve = require('path').resolve
+
+var Canvas = require('..')
+
+var imagebackend = new Canvas.backends.ImageBackend(800, 600)
+
+var canvas = new Canvas(imagebackend)
+var ctx = canvas.getContext('2d')
+
+console.log('Width: ' + canvas.width + ', Height: ' + canvas.height)
+
+ctx.fillStyle = '#00FF00'
+ctx.fillRect(50, 50, 100, 100)
+
+var outPath = resolve(__dirname, 'rectangle.png')
+
+canvas.createPNGStream().pipe(fs.createWriteStream(outPath))

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -11,6 +11,7 @@
  */
 
 var canvas = require('./bindings')
+  , Backends = canvas.Backends
   , Canvas = canvas.Canvas
   , Image = canvas.Image
   , cairoVersion = canvas.cairoVersion
@@ -27,6 +28,8 @@ var canvas = require('./bindings')
  */
 
 var Canvas = exports = module.exports = Canvas;
+
+exports.backends = Backends;
 
 /**
  * Library version.

--- a/src/Backends.cc
+++ b/src/Backends.cc
@@ -1,0 +1,18 @@
+#include "Backends.h"
+
+#include "backend/ImageBackend.h"
+#include "backend/PdfBackend.h"
+#include "backend/SvgBackend.h"
+
+using namespace v8;
+
+void Backends::Initialize(Handle<Object> target) {
+  Nan::HandleScope scope;
+
+  Local<Object> obj = Nan::New<Object>();
+  ImageBackend::Initialize(obj);
+  PdfBackend::Initialize(obj);
+  SvgBackend::Initialize(obj);
+
+  target->Set(Nan::New<String>("Backends").ToLocalChecked(), obj);
+}

--- a/src/Backends.h
+++ b/src/Backends.h
@@ -1,0 +1,14 @@
+#ifndef __NODE_BACKENDS_H__
+#define __NODE_BACKENDS_H__
+
+#include <nan.h>
+
+#include "backend/Backend.h"
+
+
+class Backends : public Nan::ObjectWrap {
+  public:
+    static void Initialize(v8::Handle<v8::Object> target);
+};
+
+#endif

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -18,10 +18,15 @@
 #include "CanvasRenderingContext2d.h"
 #include "closure.h"
 #include "register_font.h"
+#include "toBuffer.h"
 
 #ifdef HAVE_JPEG
 #include "JPEGStream.h"
 #endif
+
+#include "backend/ImageBackend.h"
+#include "backend/PdfBackend.h"
+#include "backend/SvgBackend.h"
 
 #define GENERIC_FACE_ERROR \
   "The second argument to registerFont is required, and should be an object " \
@@ -80,17 +85,35 @@ NAN_METHOD(Canvas::New) {
     return Nan::ThrowTypeError("Class constructors cannot be invoked without 'new'");
   }
 
-  int width = 0, height = 0;
-  canvas_type_t type = CANVAS_TYPE_IMAGE;
-  if (info[0]->IsNumber()) width = info[0]->Uint32Value();
-  if (info[1]->IsNumber()) height = info[1]->Uint32Value();
-  if (info[2]->IsString()) type = !strcmp("pdf", *String::Utf8Value(info[2]))
-    ? CANVAS_TYPE_PDF
-    : !strcmp("svg", *String::Utf8Value(info[2]))
-      ? CANVAS_TYPE_SVG
-      : CANVAS_TYPE_IMAGE;
-  Canvas *canvas = new Canvas(width, height, type);
+  Backend* backend = NULL;
+  if (info[0]->IsNumber()) {
+    int width = info[0]->Uint32Value(), height = 0;
+
+    if (info[1]->IsNumber()) height = info[1]->Uint32Value();
+
+    if (info[2]->IsString()) {
+      if (0 == strcmp("pdf", *String::Utf8Value(info[2])))
+        backend = new PdfBackend(width, height);
+      else if (0 == strcmp("svg", *String::Utf8Value(info[2])))
+        backend = new SvgBackend(width, height);
+      else
+        backend = new ImageBackend(width, height);
+    }
+    else
+      backend = new ImageBackend(width, height);
+  }
+  else if (info[0]->IsObject()) {
+    backend = Nan::ObjectWrap::Unwrap<Backend>(info[0]->ToObject());
+  }
+  else {
+    backend = new ImageBackend(0, 0);
+  }
+
+  Canvas* canvas = new Canvas(backend);
   canvas->Wrap(info.This());
+
+  backend->setCanvas(canvas);
+
   info.GetReturnValue().Set(info.This());
 }
 
@@ -100,7 +123,7 @@ NAN_METHOD(Canvas::New) {
 
 NAN_GETTER(Canvas::GetType) {
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
-  info.GetReturnValue().Set(Nan::New<String>(canvas->isPDF() ? "pdf" : canvas->isSVG() ? "svg" : "image").ToLocalChecked());
+  info.GetReturnValue().Set(Nan::New<String>(canvas->backend()->getName()).ToLocalChecked());
 }
 
 /*
@@ -117,7 +140,7 @@ NAN_GETTER(Canvas::GetStride) {
 
 NAN_GETTER(Canvas::GetWidth) {
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
-  info.GetReturnValue().Set(Nan::New<Number>(canvas->width));
+  info.GetReturnValue().Set(Nan::New<Number>(canvas->getWidth()));
 }
 
 /*
@@ -127,7 +150,7 @@ NAN_GETTER(Canvas::GetWidth) {
 NAN_SETTER(Canvas::SetWidth) {
   if (value->IsNumber()) {
     Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
-    canvas->width = value->Uint32Value();
+    canvas->backend()->setWidth(value->Uint32Value());
     canvas->resurface(info.This());
   }
 }
@@ -138,7 +161,7 @@ NAN_SETTER(Canvas::SetWidth) {
 
 NAN_GETTER(Canvas::GetHeight) {
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
-  info.GetReturnValue().Set(Nan::New<Number>(canvas->height));
+  info.GetReturnValue().Set(Nan::New<Number>(canvas->getHeight()));
 }
 
 /*
@@ -148,37 +171,9 @@ NAN_GETTER(Canvas::GetHeight) {
 NAN_SETTER(Canvas::SetHeight) {
   if (value->IsNumber()) {
     Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
-    canvas->height = value->Uint32Value();
+    canvas->backend()->setHeight(value->Uint32Value());
     canvas->resurface(info.This());
   }
-}
-
-/*
- * Canvas::ToBuffer callback.
- */
-
-static cairo_status_t
-toBuffer(void *c, const uint8_t *data, unsigned len) {
-  closure_t *closure = (closure_t *) c;
-
-  if (closure->len + len > closure->max_len) {
-    uint8_t *data;
-    unsigned max = closure->max_len;
-
-    do {
-      max *= 2;
-    } while (closure->len + len > max);
-
-    data = (uint8_t *) realloc(closure->data, max);
-    if (!data) return CAIRO_STATUS_NO_MEMORY;
-    closure->data = data;
-    closure->max_len = max;
-  }
-
-  memcpy(closure->data + closure->len, data, len);
-  closure->len += len;
-
-  return CAIRO_STATUS_SUCCESS;
 }
 
 /*
@@ -259,9 +254,10 @@ NAN_METHOD(Canvas::ToBuffer) {
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
 
   // TODO: async / move this out
-  if (canvas->isPDF() || canvas->isSVG()) {
+  const string name = canvas->backend()->getName();
+  if (name == "pdf" || name == "svg") {
     cairo_surface_finish(canvas->surface());
-    closure_t *closure = (closure_t *) canvas->closure();
+    closure_t *closure = (closure_t *) canvas->backend()->closure();
 
     Local<Object> buf = Nan::CopyBuffer((char*) closure->data, closure->len).ToLocalChecked();
     info.GetReturnValue().Set(buf);
@@ -515,14 +511,14 @@ NAN_METHOD(Canvas::StreamPDFSync) {
 
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.Holder());
 
-  if (!canvas->isPDF())
+  if (canvas->backend()->getName() != "pdf")
     return Nan::ThrowTypeError("wrong canvas type");
 
   cairo_surface_finish(canvas->surface());
 
   closure_t closure;
-  closure.data = static_cast<closure_t *>(canvas->closure())->data;
-  closure.len = static_cast<closure_t *>(canvas->closure())->len;
+  closure.data = static_cast<closure_t*>(canvas->backend()->closure())->data;
+  closure.len = static_cast<closure_t*>(canvas->backend()->closure())->len;
   closure.fn = info[0].As<Function>();
 
   Nan::TryCatch try_catch;
@@ -650,30 +646,9 @@ NAN_METHOD(Canvas::RegisterFont) {
  * Initialize cairo surface.
  */
 
-Canvas::Canvas(int w, int h, canvas_type_t t): Nan::ObjectWrap() {
-  type = t;
-  width = w;
-  height = h;
-  _surface = NULL;
-  _closure = NULL;
-
-  if (CANVAS_TYPE_PDF == t) {
-    _closure = malloc(sizeof(closure_t));
-    assert(_closure);
-    cairo_status_t status = closure_init((closure_t *) _closure, this, 0, PNG_NO_FILTERS);
-    assert(status == CAIRO_STATUS_SUCCESS);
-    _surface = cairo_pdf_surface_create_for_stream(toBuffer, _closure, w, h);
-  } else if (CANVAS_TYPE_SVG == t) {
-    _closure = malloc(sizeof(closure_t));
-    assert(_closure);
-    cairo_status_t status = closure_init((closure_t *) _closure, this, 0, PNG_NO_FILTERS);
-    assert(status == CAIRO_STATUS_SUCCESS);
-    _surface = cairo_svg_surface_create_for_stream(toBuffer, _closure, w, h);
-  } else {
-    _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
-    assert(_surface);
-    Nan::AdjustExternalMemory(nBytes());
-  }
+Canvas::Canvas(Backend* backend) : ObjectWrap() {
+  _backend = backend;
+  this->backend()->createSurface();
 }
 
 /*
@@ -681,20 +656,9 @@ Canvas::Canvas(int w, int h, canvas_type_t t): Nan::ObjectWrap() {
  */
 
 Canvas::~Canvas() {
-  switch (type) {
-    case CANVAS_TYPE_PDF:
-    case CANVAS_TYPE_SVG:
-      cairo_surface_finish(_surface);
-      closure_destroy((closure_t *) _closure);
-      free(_closure);
-      cairo_surface_destroy(_surface);
-      break;
-    case CANVAS_TYPE_IMAGE:
-      int oldNBytes = nBytes();
-      cairo_surface_destroy(_surface);
-      Nan::AdjustExternalMemory(-oldNBytes);
-      break;
-  }
+  if (_backend != NULL) {
+		delete _backend;
+	}
 }
 
 std::vector<FontFace>
@@ -812,44 +776,17 @@ void
 Canvas::resurface(Local<Object> canvas) {
   Nan::HandleScope scope;
   Local<Value> context;
-  switch (type) {
-    case CANVAS_TYPE_PDF:
-      cairo_pdf_surface_set_size(_surface, width, height);
-      break;
-    case CANVAS_TYPE_SVG:
-      // Re-surface
-      cairo_surface_finish(_surface);
-      closure_destroy((closure_t *) _closure);
-      cairo_surface_destroy(_surface);
-      closure_init((closure_t *) _closure, this, 0, PNG_NO_FILTERS);
-      _surface = cairo_svg_surface_create_for_stream(toBuffer, _closure, width, height);
 
-      // Reset context
-      context = canvas->Get(Nan::New<String>("context").ToLocalChecked());
-      if (!context->IsUndefined()) {
-        Context2d *context2d = Nan::ObjectWrap::Unwrap<Context2d>(context->ToObject());
-        cairo_t *prev = context2d->context();
-        context2d->setContext(cairo_create(surface()));
-        cairo_destroy(prev);
-      }
-      break;
-    case CANVAS_TYPE_IMAGE:
-      // Re-surface
-      size_t oldNBytes = nBytes();
-      cairo_surface_destroy(_surface);
-      _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-      Nan::AdjustExternalMemory(nBytes() - oldNBytes);
+  backend()->recreateSurface();
 
-      // Reset context
-      context = canvas->Get(Nan::New<String>("context").ToLocalChecked());
-      if (!context->IsUndefined()) {
-        Context2d *context2d = Nan::ObjectWrap::Unwrap<Context2d>(context->ToObject());
-        cairo_t *prev = context2d->context();
-        context2d->setContext(cairo_create(surface()));
-        cairo_destroy(prev);
-      }
-      break;
-  }
+  // Reset context
+	context = canvas->Get(Nan::New<String>("context").ToLocalChecked());
+	if (!context->IsUndefined()) {
+		Context2d *context2d = ObjectWrap::Unwrap<Context2d>(context->ToObject());
+		cairo_t *prev = context2d->context();
+		context2d->setContext(cairo_create(surface()));
+		cairo_destroy(prev);
+	}
 }
 
 /*

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -528,7 +528,7 @@ NAN_METHOD(Context2d::New) {
 
 NAN_METHOD(Context2d::AddPage) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-  if (!context->canvas()->isPDF()) {
+  if (context->canvas()->backend()->getName() != "pdf") {
     return Nan::ThrowError("only PDF canvases support .nextPage()");
   }
   cairo_show_page(context->context());
@@ -573,8 +573,8 @@ NAN_METHOD(Context2d::PutImageData) {
     case 3:
       // Need to wrap std::min calls using parens to prevent macro expansion on
       // windows. See http://stackoverflow.com/questions/5004858/stdmin-gives-error
-      cols = (std::min)(imageData->width(), context->canvas()->width - dx);
-      rows = (std::min)(imageData->height(), context->canvas()->height - dy);
+      cols = (std::min)(imageData->width(), context->canvas()->getWidth() - dx);
+      rows = (std::min)(imageData->height(), context->canvas()->getHeight() - dy);
       break;
     // imageData, dx, dy, sx, sy, sw, sh
     case 7:
@@ -600,8 +600,8 @@ NAN_METHOD(Context2d::PutImageData) {
       // clamp width at canvas size
       // Need to wrap std::min calls using parens to prevent macro expansion on
       // windows. See http://stackoverflow.com/questions/5004858/stdmin-gives-error
-      cols = (std::min)(sw, context->canvas()->width - dx);
-      rows = (std::min)(sh, context->canvas()->height - dy);
+      cols = (std::min)(sw, context->canvas()->getWidth() - dx);
+      rows = (std::min)(sh, context->canvas()->getHeight() - dy);
       break;
     default:
       return Nan::ThrowError("invalid arguments");
@@ -686,8 +686,10 @@ NAN_METHOD(Context2d::GetImageData) {
     sh = -sh;
   }
 
-  if (sx + sw > canvas->width) sw = canvas->width - sx;
-  if (sy + sh > canvas->height) sh = canvas->height - sy;
+  int width  = canvas->getWidth();
+  int height = canvas->getHeight();
+  if (sx + sw > width) sw = width - sx;
+  if (sy + sh > height) sh = height - sy;
 
   // WebKit/moz functionality. node-canvas used to return in either case.
   if (sw <= 0) sw = 1;
@@ -801,8 +803,8 @@ NAN_METHOD(Context2d::DrawImage) {
   // Canvas
   } else if (Nan::New(Canvas::constructor)->HasInstance(obj)) {
     Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(obj);
-    sw = canvas->width;
-    sh = canvas->height;
+    sw = canvas->getWidth();
+    sh = canvas->getHeight();
     surface = canvas->surface();
 
   // Invalid

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -1,0 +1,89 @@
+#include "Backend.h"
+
+
+Backend::Backend(string name, int width, int height)
+	: name(name)
+	, width(width)
+	, height(height)
+	, surface(NULL)
+	, canvas(NULL)
+	, _closure(NULL)
+{}
+
+Backend::~Backend()
+{
+	this->destroySurface();
+}
+
+
+void Backend::setCanvas(Canvas* canvas)
+{
+	this->canvas = canvas;
+}
+
+
+cairo_surface_t* Backend::recreateSurface()
+{
+	this->destroySurface();
+
+	return this->createSurface();
+}
+
+cairo_surface_t* Backend::getSurface()
+{
+	return surface;
+}
+
+void Backend::destroySurface()
+{
+	if(this->surface)
+	{
+		cairo_surface_destroy(this->surface);
+		this->surface = NULL;
+	}
+}
+
+
+string Backend::getName()
+{
+	return name;
+}
+
+int Backend::getWidth()
+{
+	return this->width;
+}
+void Backend::setWidth(int width)
+{
+	this->width = width;
+	this->recreateSurface();
+}
+
+int Backend::getHeight()
+{
+	return this->height;
+}
+void Backend::setHeight(int height)
+{
+	this->height = height;
+	this->recreateSurface();
+}
+
+
+BackendOperationNotAvailable::BackendOperationNotAvailable(Backend* backend,
+	string operation_name)
+	: backend(backend)
+	, operation_name(operation_name)
+{};
+
+BackendOperationNotAvailable::~BackendOperationNotAvailable() throw() {};
+
+const char* BackendOperationNotAvailable::what() const throw()
+{
+	std::ostringstream o;
+
+	o << "operation " << this->operation_name;
+	o << " not supported by backend " + backend->getName();
+
+	return o.str().c_str();
+};

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -1,0 +1,72 @@
+#ifndef __BACKEND_H__
+#define __BACKEND_H__
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <exception>
+
+#include <nan.h>
+
+#if HAVE_PANGO
+  #include <pango/pangocairo.h>
+#else
+  #include <cairo/cairo.h>
+#endif
+
+class Canvas;
+
+using namespace std;
+
+class Backend : public Nan::ObjectWrap
+{
+  private:
+    const string name;
+
+  protected:
+    int width;
+    int height;
+    cairo_surface_t* surface;
+    Canvas* canvas;
+
+    Backend(string name, int width, int height);
+
+  public:
+    virtual ~Backend();
+
+    // TODO Used only by SVG and PDF, move there
+    void* _closure;
+    inline void* closure(){ return _closure; }
+
+    void setCanvas(Canvas* canvas);
+
+    virtual cairo_surface_t* createSurface() = 0;
+    virtual cairo_surface_t* recreateSurface();
+
+    cairo_surface_t* getSurface();
+    void             destroySurface();
+
+    string getName();
+
+    int getWidth();
+    virtual void setWidth(int width);
+
+    int getHeight();
+    virtual void setHeight(int height);
+};
+
+
+class BackendOperationNotAvailable: public exception
+{
+  private:
+    Backend* backend;
+    string operation_name;
+
+  public:
+    BackendOperationNotAvailable(Backend* backend, string operation_name);
+    ~BackendOperationNotAvailable() throw();
+
+    const char* what() const throw();
+};
+
+#endif

--- a/src/backend/ImageBackend.cc
+++ b/src/backend/ImageBackend.cc
@@ -1,0 +1,63 @@
+#include "ImageBackend.h"
+
+using namespace v8;
+
+ImageBackend::ImageBackend(int width, int height)
+	: Backend("image", width, height)
+{
+	createSurface();
+}
+
+ImageBackend::~ImageBackend()
+{
+	destroySurface();
+
+	Nan::AdjustExternalMemory(-4 * width * height);
+}
+
+cairo_surface_t* ImageBackend::createSurface()
+{
+	this->surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+	assert(this->surface);
+  Nan::AdjustExternalMemory(4 * width * height);
+
+	return this->surface;
+}
+
+cairo_surface_t* ImageBackend::recreateSurface()
+{
+	// Re-surface
+	int old_width = cairo_image_surface_get_width(this->surface);
+	int old_height = cairo_image_surface_get_height(this->surface);
+	this->destroySurface();
+	Nan::AdjustExternalMemory(-4 * old_width * old_height);
+
+	return createSurface();
+}
+
+
+Nan::Persistent<FunctionTemplate> ImageBackend::constructor;
+
+void ImageBackend::Initialize(Handle<Object> target)
+{
+	Nan::HandleScope scope;
+
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageBackend::New);
+	ImageBackend::constructor.Reset(ctor);
+	ctor->InstanceTemplate()->SetInternalFieldCount(1);
+	ctor->SetClassName(Nan::New<String>("ImageBackend").ToLocalChecked());
+	target->Set(Nan::New<String>("ImageBackend").ToLocalChecked(), ctor->GetFunction());
+}
+
+NAN_METHOD(ImageBackend::New)
+{
+	int width  = 0;
+	int height = 0;
+	if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
+	if (info[1]->IsNumber()) height = info[1]->Uint32Value();
+
+	ImageBackend* backend = new ImageBackend(width, height);
+
+	backend->Wrap(info.This());
+	info.GetReturnValue().Set(info.This());
+}

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -1,0 +1,25 @@
+#ifndef __IMAGE_BACKEND_H__
+#define __IMAGE_BACKEND_H__
+
+#include <v8.h>
+
+#include "Backend.h"
+
+using namespace std;
+
+class ImageBackend : public Backend
+{
+  private:
+    cairo_surface_t* createSurface();
+    cairo_surface_t* recreateSurface();
+
+  public:
+    ImageBackend(int width, int height);
+    ~ImageBackend();
+
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static void Initialize(v8::Handle<v8::Object> target);
+    static NAN_METHOD(New);
+};
+
+#endif

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -1,0 +1,73 @@
+#include "PdfBackend.h"
+
+#include <cairo-pdf.h>
+#include <png.h>
+
+#include "../Canvas.h"
+#include "../closure.h"
+#include "../toBuffer.h"
+
+
+using namespace v8;
+
+PdfBackend::PdfBackend(int width, int height)
+	: Backend("pdf", width, height)
+{
+	createSurface();
+}
+
+PdfBackend::~PdfBackend()
+{
+	cairo_surface_finish(this->surface);
+	closure_destroy((closure_t*)_closure);
+	free(_closure);
+
+	destroySurface();
+}
+
+
+cairo_surface_t* PdfBackend::createSurface()
+{
+	_closure = malloc(sizeof(closure_t));
+	assert(_closure);
+	cairo_status_t status = closure_init((closure_t*)_closure, this->canvas, 0, PNG_NO_FILTERS);
+	assert(status == CAIRO_STATUS_SUCCESS);
+
+	this->surface = cairo_pdf_surface_create_for_stream(toBuffer, _closure, width, height);
+
+	return this->surface;
+}
+
+cairo_surface_t* PdfBackend::recreateSurface()
+{
+	cairo_pdf_surface_set_size(this->surface, width, height);
+
+	return this->surface;
+}
+
+
+Nan::Persistent<FunctionTemplate> PdfBackend::constructor;
+
+void PdfBackend::Initialize(Handle<Object> target)
+{
+	Nan::HandleScope scope;
+
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New);
+	PdfBackend::constructor.Reset(ctor);
+	ctor->InstanceTemplate()->SetInternalFieldCount(1);
+	ctor->SetClassName(Nan::New<String>("PdfBackend").ToLocalChecked());
+	target->Set(Nan::New<String>("PdfBackend").ToLocalChecked(), ctor->GetFunction());
+}
+
+NAN_METHOD(PdfBackend::New)
+{
+	int width  = 0;
+	int height = 0;
+	if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
+	if (info[1]->IsNumber()) height = info[1]->Uint32Value();
+
+	PdfBackend* backend = new PdfBackend(width, height);
+
+	backend->Wrap(info.This());
+	info.GetReturnValue().Set(info.This());
+}

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -1,0 +1,25 @@
+#ifndef __PDF_BACKEND_H__
+#define __PDF_BACKEND_H__
+
+#include <v8.h>
+
+#include "Backend.h"
+
+using namespace std;
+
+class PdfBackend : public Backend
+{
+  private:
+    cairo_surface_t* createSurface();
+    cairo_surface_t* recreateSurface();
+
+  public:
+    PdfBackend(int width, int height);
+    ~PdfBackend();
+
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static void Initialize(v8::Handle<v8::Object> target);
+    static NAN_METHOD(New);
+};
+
+#endif

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -1,0 +1,76 @@
+#include "SvgBackend.h"
+
+#include <cairo-svg.h>
+#include <png.h>
+
+#include "../Canvas.h"
+#include "../closure.h"
+#include "../toBuffer.h"
+
+
+using namespace v8;
+
+SvgBackend::SvgBackend(int width, int height)
+	: Backend("svg", width, height)
+{
+	_closure = malloc(sizeof(closure_t));
+	assert(_closure);
+
+	createSurface();
+}
+
+SvgBackend::~SvgBackend()
+{
+	cairo_surface_finish(this->surface);
+	closure_destroy((closure_t*)_closure);
+	free(_closure);
+
+	destroySurface();
+}
+
+
+cairo_surface_t* SvgBackend::createSurface()
+{
+	cairo_status_t status = closure_init((closure_t*)_closure, this->canvas, 0, PNG_NO_FILTERS);
+	assert(status == CAIRO_STATUS_SUCCESS);
+
+	this->surface = cairo_svg_surface_create_for_stream(toBuffer, _closure, width, height);
+
+	return this->surface;
+}
+
+cairo_surface_t* SvgBackend::recreateSurface()
+{
+	cairo_surface_finish(this->surface);
+	closure_destroy((closure_t*)_closure);
+	cairo_surface_destroy(this->surface);
+
+	return createSurface();
+ }
+
+
+Nan::Persistent<FunctionTemplate> SvgBackend::constructor;
+
+void SvgBackend::Initialize(Handle<Object> target)
+{
+	Nan::HandleScope scope;
+
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(SvgBackend::New);
+	SvgBackend::constructor.Reset(ctor);
+	ctor->InstanceTemplate()->SetInternalFieldCount(1);
+	ctor->SetClassName(Nan::New<String>("SvgBackend").ToLocalChecked());
+	target->Set(Nan::New<String>("SvgBackend").ToLocalChecked(), ctor->GetFunction());
+}
+
+NAN_METHOD(SvgBackend::New)
+{
+	int width  = 0;
+	int height = 0;
+	if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
+	if (info[1]->IsNumber()) height = info[1]->Uint32Value();
+
+	SvgBackend* backend = new SvgBackend(width, height);
+
+	backend->Wrap(info.This());
+	info.GetReturnValue().Set(info.This());
+}

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -1,0 +1,25 @@
+#ifndef __SVG_BACKEND_H__
+#define __SVG_BACKEND_H__
+
+#include <v8.h>
+
+#include "Backend.h"
+
+using namespace std;
+
+class SvgBackend : public Backend
+{
+  private:
+    cairo_surface_t* createSurface();
+    cairo_surface_t* recreateSurface();
+
+  public:
+    SvgBackend(int width, int height);
+    ~SvgBackend();
+
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static void Initialize(v8::Handle<v8::Object> target);
+    static NAN_METHOD(New);
+};
+
+#endif

--- a/src/closure.cc
+++ b/src/closure.cc
@@ -1,0 +1,30 @@
+#include "closure.h"
+
+
+/*
+ * Initialize the given closure.
+ */
+
+cairo_status_t
+closure_init(closure_t *closure, Canvas *canvas, unsigned int compression_level, unsigned int filter) {
+  closure->len = 0;
+  closure->canvas = canvas;
+  closure->data = (uint8_t *) malloc(closure->max_len = PAGE_SIZE);
+  if (!closure->data) return CAIRO_STATUS_NO_MEMORY;
+  closure->compression_level = compression_level;
+  closure->filter = filter;
+  return CAIRO_STATUS_SUCCESS;
+}
+
+/*
+ * Free the given closure's data,
+ * and hint V8 at the memory dealloc.
+ */
+
+void
+closure_destroy(closure_t *closure) {
+  if (closure->len) {
+    free(closure->data);
+    Nan::AdjustExternalMemory(-((intptr_t) closure->max_len));
+  }
+}

--- a/src/closure.h
+++ b/src/closure.h
@@ -18,6 +18,8 @@
 
 #include <nan.h>
 
+#include "Canvas.h"
+
 /*
  * PNG stream closure.
  */
@@ -39,15 +41,7 @@ typedef struct {
  */
 
 cairo_status_t
-closure_init(closure_t *closure, Canvas *canvas, unsigned int compression_level, unsigned int filter) {
-  closure->len = 0;
-  closure->canvas = canvas;
-  closure->data = (uint8_t *) malloc(closure->max_len = PAGE_SIZE);
-  if (!closure->data) return CAIRO_STATUS_NO_MEMORY;
-  closure->compression_level = compression_level;
-  closure->filter = filter;
-  return CAIRO_STATUS_SUCCESS;
-}
+closure_init(closure_t *closure, Canvas *canvas, unsigned int compression_level, unsigned int filter);
 
 /*
  * Free the given closure's data,
@@ -55,11 +49,6 @@ closure_init(closure_t *closure, Canvas *canvas, unsigned int compression_level,
  */
 
 void
-closure_destroy(closure_t *closure) {
-  if (closure->len) {
-    free(closure->data);
-    Nan::AdjustExternalMemory(-((intptr_t) closure->max_len));
-  }
-}
+closure_destroy(closure_t *closure);
 
 #endif /* __NODE_CLOSURE_H__ */

--- a/src/init.cc
+++ b/src/init.cc
@@ -26,6 +26,7 @@
 #endif
 
 NAN_MODULE_INIT(init) {
+  Backends::Initialize(target);
   Canvas::Initialize(target);
   Image::Initialize(target);
   ImageData::Initialize(target);

--- a/src/init.cc
+++ b/src/init.cc
@@ -8,12 +8,15 @@
 #include <stdio.h>
 #include <pango/pango.h>
 #include <glib.h>
+
+#include "Backends.h"
 #include "Canvas.h"
-#include "Image.h"
-#include "ImageData.h"
 #include "CanvasGradient.h"
 #include "CanvasPattern.h"
 #include "CanvasRenderingContext2d.h"
+#include "Image.h"
+#include "ImageData.h"
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
@@ -73,4 +76,4 @@ NAN_MODULE_INIT(init) {
   target->Set(Nan::New<String>("freetypeVersion").ToLocalChecked(), Nan::New<String>(freetype_version).ToLocalChecked());
 }
 
-NODE_MODULE(canvas,init);
+NODE_MODULE(canvas, init);

--- a/src/toBuffer.cc
+++ b/src/toBuffer.cc
@@ -1,0 +1,33 @@
+#include <string.h>
+
+#include "closure.h"
+#include "toBuffer.h"
+
+
+/*
+ * Canvas::ToBuffer callback.
+ */
+
+cairo_status_t
+toBuffer(void *c, const uint8_t *data, unsigned len) {
+  closure_t *closure = (closure_t *) c;
+
+  if (closure->len + len > closure->max_len) {
+    uint8_t *data;
+    unsigned max = closure->max_len;
+
+    do {
+      max *= 2;
+    } while (closure->len + len > max);
+
+    data = (uint8_t *) realloc(closure->data, max);
+    if (!data) return CAIRO_STATUS_NO_MEMORY;
+    closure->data = data;
+    closure->max_len = max;
+  }
+
+  memcpy(closure->data + closure->len, data, len);
+  closure->len += len;
+
+  return CAIRO_STATUS_SUCCESS;
+}

--- a/src/toBuffer.h
+++ b/src/toBuffer.h
@@ -1,0 +1,4 @@
+#include <cairo.h>
+
+
+cairo_status_t toBuffer(void* c, const uint8_t* data, unsigned len);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -215,13 +215,13 @@ describe('Canvas', function () {
 
   it('Canvas#type', function () {
     var canvas = new Canvas(10, 10);
-    assert('image' == canvas.type);
+    assert.equal(canvas.type, 'image');
     var canvas = new Canvas(10, 10, 'pdf');
-    assert('pdf' == canvas.type);
+    assert.equal(canvas.type, 'pdf');
     var canvas = new Canvas(10, 10, 'svg');
-    assert('svg' == canvas.type);
+    assert.equal(canvas.type, 'svg');
     var canvas = new Canvas(10, 10, 'hey');
-    assert('image' == canvas.type);
+    assert.equal(canvas.type, 'image');
   });
 
   it('Canvas#getContext("2d")', function () {
@@ -907,7 +907,7 @@ describe('Canvas', function () {
     stream.on('data', function (chunk) {
       if (firstChunk) {
         firstChunk = false;
-        assert.equal('PDF', chunk.slice(1, 4).toString());
+        assert.equal(chunk.slice(1, 4).toString(), 'PDF');
       }
     });
     stream.on('end', function () {


### PR DESCRIPTION
This is a stripped-down version of pull-request #571 focused only on the
backends support, but adding also support for PDF and SVG backends and
passing the tests. it also retain backwards compatibility with the old API,
so this would be easy to merge since it's mostly to move around the PDF and
SVG code and checks to independent classes. There's some code for
`pdfStream` and similar methods that I think they should be moved too since
they are mostly backend specific, and make more sense there. I didn't do
that since it would break the API, but maybe it would be added some
functions on the Canvas object that proxy the petitions to the backend to
retain compatibility.

I know it's a big pull-request, so I'm open for comments over it.
