### PR TITLE
Make sure Canvas#toDataURL is always async if a callback is passed in

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -231,11 +231,6 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
   // ['image/jpeg', qual, fn] -> ['image/jpeg', {quality: qual}, fn]
   // ['image/jpeg', undefined, fn] -> ['image/jpeg', null, fn]
 
-  if (this.width === 0 || this.height === 0) {
-    // Per spec, if the bitmap has no pixels, return this string:
-    return "data:,";
-  }
-
   var type = 'image/png';
   var opts = {};
   var fn;
@@ -262,6 +257,11 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
         throw new TypeError(typeof a3 + ' is not a function');
       }
     }
+  }
+
+  if (this.width === 0 || this.height === 0) {
+    // Per spec, if the bitmap has no pixels, return this string:
+    return fn ? fn(null, "data:,") : "data:,";
   }
 
   if ('image/png' === type) {

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -261,13 +261,13 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
 
   if (this.width === 0 || this.height === 0) {
     // Per spec, if the bitmap has no pixels, return this string:
+    var str = "data:,";
     if (fn) {
       setTimeout(function() {
-        fn(null, "data:,");
+        fn(null, str);
       });
-      return;
     }
-    return "data:,";
+    return str;
   }
 
   if ('image/png' === type) {

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -261,7 +261,13 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
 
   if (this.width === 0 || this.height === 0) {
     // Per spec, if the bitmap has no pixels, return this string:
-    return fn ? fn(null, "data:,") : "data:,";
+    if (fn) {
+      setTimeout(function() {
+        fn(null, "data:,");
+      });
+      return;
+    }
+    return "data:,";
   }
 
   if ('image/png' === type) {

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -519,6 +519,14 @@ describe('Canvas', function () {
       });
     });
 
+    it('toDataURL(function (err, str) {...}) is async even with no canvas data', function (done) {
+      new Canvas().toDataURL(function(err, str){
+        assert.ifError(err);
+        assert.ok('data:,' === str);
+        done();
+      });
+    });
+
     it('toDataURL(0.5, function (err, str) {...}) works and defaults to PNG', function (done) {
       new Canvas(200,200).toDataURL(0.5, function(err, str){
         assert.ifError(err);


### PR DESCRIPTION
Resolves https://github.com/Automattic/node-canvas/issues/873

With unit test :)

Old behaviour: returns the string as the function return value and never executes the callback

```js
> new Canvas().toDataURL(function(err, str){
...   console.log('hi');
...   console.log(str);
... });
'data:,'
```

New behaviour: function instantly returns undefined and callback is executed async.

```js
> new Canvas().toDataURL(function(err, str){
...   console.log('hi');
...   console.log(str);
... });
undefined
hi
data:,
```

It might be worth returning `'data:,'` both sync (instead of undefined) and async for backwards compatibility incase someone is handling this edge case.