### PR TITLE
Fix 2.0 regression, warnings, v8 memory dealloc hint

### DIFF
--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -85,7 +85,7 @@ class Canvas: public Nan::ObjectWrap {
 
     inline uint8_t *data(){ return cairo_image_surface_get_data(surface()); }
     inline int stride(){ return cairo_image_surface_get_stride(surface()); }
-    inline int nBytes(){ return backend()->getWidth() * stride(); }
+    inline int nBytes(){ return getHeight() * stride(); }
 
     inline int getWidth() { return backend()->getWidth(); }
     inline int getHeight() { return backend()->getHeight(); }

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -745,8 +745,8 @@ NAN_METHOD(Context2d::GetImageData) {
   Local<Int32> shHandle = Nan::New(sh);
   Local<Value> argv[argc] = { clampedArray, swHandle, shHandle };
 
-  Local<Function> constructor = Nan::GetFunction(Nan::New(ImageData::constructor)).ToLocalChecked();
-  Local<Object> instance = Nan::NewInstance(constructor, argc, argv).ToLocalChecked();
+  Local<Function> ctor = Nan::GetFunction(Nan::New(ImageData::constructor)).ToLocalChecked();
+  Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 
   info.GetReturnValue().Set(instance);
 }

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -810,7 +810,7 @@ Image::decodeJPEGBufferIntoMimeSurface(uint8_t *buf, unsigned len) {
 
 void
 clearMimeData(void *closure) {
-  Nan::AdjustExternalMemory(-((read_closure_t *)closure)->len);
+  Nan::AdjustExternalMemory(-static_cast<int>(((read_closure_t *)closure)->len));
   free(((read_closure_t *) closure)->buf);
   free(closure);
 }

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -16,9 +16,9 @@ Backend::~Backend()
 }
 
 
-void Backend::setCanvas(Canvas* canvas)
+void Backend::setCanvas(Canvas* _canvas)
 {
-	this->canvas = canvas;
+	this->canvas = _canvas;
 }
 
 
@@ -53,9 +53,9 @@ int Backend::getWidth()
 {
 	return this->width;
 }
-void Backend::setWidth(int width)
+void Backend::setWidth(int width_)
 {
-	this->width = width;
+	this->width = width_;
 	this->recreateSurface();
 }
 
@@ -63,9 +63,9 @@ int Backend::getHeight()
 {
 	return this->height;
 }
-void Backend::setHeight(int height)
+void Backend::setHeight(int height_)
 {
-	this->height = height;
+	this->height = height_;
 	this->recreateSurface();
 }
 

--- a/src/toBuffer.cc
+++ b/src/toBuffer.cc
@@ -9,7 +9,7 @@
  */
 
 cairo_status_t
-toBuffer(void *c, const uint8_t *data, unsigned len) {
+toBuffer(void *c, const uint8_t *odata, unsigned len) {
   closure_t *closure = (closure_t *) c;
 
   if (closure->len + len > closure->max_len) {
@@ -26,7 +26,7 @@ toBuffer(void *c, const uint8_t *data, unsigned len) {
     closure->max_len = max;
   }
 
-  memcpy(closure->data + closure->len, data, len);
+  memcpy(closure->data + closure->len, odata, len);
   closure->len += len;
 
   return CAIRO_STATUS_SUCCESS;

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -386,10 +386,10 @@ describe('Canvas', function () {
   });
 
   describe('#toBuffer("raw")', function() {
-    var canvas = new Canvas(10, 10)
+    var canvas = new Canvas(11, 10)
         , ctx = canvas.getContext('2d');
 
-    ctx.clearRect(0, 0, 10, 10);
+    ctx.clearRect(0, 0, 11, 10);
 
     ctx.fillStyle = 'rgba(200, 200, 200, 0.505)';
     ctx.fillRect(0, 0, 5, 5);
@@ -404,16 +404,16 @@ describe('Canvas', function () {
     ctx.fillRect(5, 5, 4, 5);
 
     /** Output:
-     *    *****RRRRR
-     *    *****RRRRR
-     *    *****RRRRR
-     *    *****RRRRR
-     *    *****RRRRR
-     *    GGGGGBBBB-
-     *    GGGGGBBBB-
-     *    GGGGGBBBB-
-     *    GGGGGBBBB-
-     *    GGGGGBBBB-
+     *    *****RRRRR-
+     *    *****RRRRR-
+     *    *****RRRRR-
+     *    *****RRRRR-
+     *    *****RRRRR-
+     *    GGGGGBBBB--
+     *    GGGGGBBBB--
+     *    GGGGGBBBB--
+     *    GGGGGBBBB--
+     *    GGGGGBBBB--
      */
 
     var buf = canvas.toBuffer('raw');

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -19,7 +19,7 @@ describe('Canvas', function () {
   });
 
   it('.version', function () {
-    assert.ok(/^\d+\.\d+\.\d+$/.test(Canvas.version));
+    assert.ok(/^\d+\.\d+\.\d+(-(alpha|beta)\.\d+)?$/.test(Canvas.version));
   });
 
   it('.cairoVersion', function () {


### PR DESCRIPTION
Handful of little fixes:

1. `nBytes` was wrong as of 1a6dffe, but the tests didn't catch it because they used a square canvas.
1. Allow alpha and beta version in the test assertions.
1. Minor: fix shadowing warnings during compilation.
1. Fix v8 memory dealloc hint. When this function was run, it would have actually hinted to v8 that a massive amount of external memory was being used.