### PR TITLE
Remove source support for node < 4

### DIFF
--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -63,15 +63,13 @@ JPEGStream.prototype._read = function _read() {
   var bufsize = this.options.bufsize;
   var quality = this.options.quality;
   var progressive = this.options.progressive;
-  process.nextTick(function(){
-    self.canvas[method](bufsize, quality, progressive, function(err, chunk){
-      if (err) {
-        self.emit('error', err);
-      } else if (chunk) {
-        self.push(chunk);
-      } else {
-        self.push(null);
-      }
-    });
+  self.canvas[method](bufsize, quality, progressive, function(err, chunk){
+    if (err) {
+      self.emit('error', err);
+    } else if (chunk) {
+      self.push(chunk);
+    } else {
+      self.push(null);
+    }
   });
 };

--- a/lib/pdfstream.js
+++ b/lib/pdfstream.js
@@ -56,15 +56,13 @@ PDFStream.prototype._read = function _read() {
   // call canvas.streamPDFSync once and let it emit data at will.
   this._read = noop;
   var self = this;
-  process.nextTick(function(){
-    self.canvas[self.method](function(err, chunk, len){
-      if (err) {
-        self.emit('error', err);
-      } else if (len) {
-        self.push(chunk);
-      } else {
-        self.push(null);
-      }
-    });
+  self.canvas[self.method](function(err, chunk, len){
+    if (err) {
+      self.emit('error', err);
+    } else if (len) {
+      self.push(chunk);
+    } else {
+      self.push(null);
+    }
   });
 };

--- a/lib/pngstream.js
+++ b/lib/pngstream.js
@@ -51,23 +51,6 @@ var PNGStream = module.exports = function PNGStream(canvas, sync) {
 
 util.inherits(PNGStream, Readable);
 
-var PNGStream = module.exports = function PNGStream(canvas, sync) {
-  Readable.call(this);
-
-  var self = this;
-  var method = sync
-      ? 'streamPNGSync'
-      : 'streamPNG';
-  this.sync = sync;
-  this.canvas = canvas;
-
-  // TODO: implement async
-  if ('streamPNG' === method) method = 'streamPNGSync';
-  this.method = method;
-};
-
-util.inherits(PNGStream, Readable);
-
 function noop() {}
 
 PNGStream.prototype._read = function _read() {

--- a/lib/pngstream.js
+++ b/lib/pngstream.js
@@ -75,15 +75,13 @@ PNGStream.prototype._read = function _read() {
   // call canvas.streamPNGSync once and let it emit data at will.
   this._read = noop;
   var self = this;
-  process.nextTick(function(){
-    self.canvas[self.method](function(err, chunk, len){
-      if (err) {
-        self.emit('error', err);
-      } else if (len) {
-        self.push(chunk);
-      } else {
-        self.push(null);
-      }
-    });
+  self.canvas[self.method](function(err, chunk, len){
+    if (err) {
+      self.emit('error', err);
+    } else if (len) {
+      self.push(chunk);
+    } else {
+      self.push(null);
+    }
   });
 };

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -63,19 +63,8 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_METHOD(StreamJPEGSync);
     static NAN_METHOD(RegisterFont);
     static Local<Value> Error(cairo_status_t status);
-#if NODE_VERSION_AT_LEAST(0, 6, 0)
     static void ToBufferAsync(uv_work_t *req);
     static void ToBufferAsyncAfter(uv_work_t *req);
-#else
-    static
-#if NODE_VERSION_AT_LEAST(0, 5, 4)
-      void
-#else
-      int
-#endif
-      EIO_ToBuffer(eio_req *req);
-    static int EIO_AfterToBuffer(eio_req *req);
-#endif
     static PangoWeight GetWeightFromCSSString(const char *weight);
     static PangoStyle GetStyleFromCSSString(const char *style);
     static PangoFontDescription *ResolveFontDescription(const PangoFontDescription *desc);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -697,16 +697,8 @@ NAN_METHOD(Context2d::GetImageData) {
 
   uint8_t *src = canvas->data();
 
-#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 10
-  Local<Object> global = Context::GetCurrent()->Global();
-
-  Local<Int32> sizeHandle = Nan::New(size);
-  Local<Value> caargv[] = { sizeHandle };
-  Local<Object> clampedArray = global->Get(Nan::New("Uint8ClampedArray").ToLocalChecked()).As<Function>()->NewInstance(1, caargv);
-#else
   Local<ArrayBuffer> buffer = ArrayBuffer::New(Isolate::GetCurrent(), size);
   Local<Uint8ClampedArray> clampedArray = Uint8ClampedArray::New(buffer, 0, size);
-#endif
 
   Nan::TypedArrayContents<uint8_t> typedArrayContents(clampedArray);
   uint8_t* dst = *typedArrayContents;

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -39,13 +39,7 @@ NAN_METHOD(ImageData::New) {
     return Nan::ThrowTypeError("Class constructors cannot be invoked without 'new'");
   }
 
-#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 10
-  Local<v8::Object> clampedArray;
-  Local<Object> global = Context::GetCurrent()->Global();
-#else
   Local<Uint8ClampedArray> clampedArray;
-#endif
-
   uint32_t width;
   uint32_t height;
   int length;
@@ -63,23 +57,11 @@ NAN_METHOD(ImageData::New) {
     }
     length = width * height * 4;
 
-#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 10
-    Local<Int32> sizeHandle = Nan::New(length);
-    Local<Value> caargv[] = { sizeHandle };
-    clampedArray = global->Get(Nan::New("Uint8ClampedArray").ToLocalChecked()).As<Function>()->NewInstance(1, caargv);
-#else
     clampedArray = Uint8ClampedArray::New(ArrayBuffer::New(Isolate::GetCurrent(), length), 0, length);
-#endif
 
-#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 10
-  } else if (info[0]->ToObject()->GetIndexedPropertiesExternalArrayDataType() == kExternalPixelArray && info[1]->IsUint32()) {
-    clampedArray = info[0]->ToObject();
-    length = clampedArray->GetIndexedPropertiesExternalArrayDataLength();
-#else
   } else if (info[0]->IsUint8ClampedArray() && info[1]->IsUint32()) {
     clampedArray = info[0].As<Uint8ClampedArray>();
     length = clampedArray->Length();
-#endif
     if (length == 0) {
       Nan::ThrowRangeError("The input data has a zero byte length.");
       return;


### PR DESCRIPTION
*Branched from https://github.com/Automattic/node-canvas/pull/917 -- please review that PR first*

* Removes `nextTick` bits in stream implementations, per #740 
* Removes preprocessor directives targeting old versions of node.