### PR TITLE
Fix memory leak in Canvas constructor

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -617,7 +617,6 @@ NAN_METHOD(Canvas::RegisterFont) {
 
 Canvas::Canvas(Backend* backend) : ObjectWrap() {
   _backend = backend;
-  this->backend()->createSurface();
 }
 
 /*

--- a/src/backend/ImageBackend.cc
+++ b/src/backend/ImageBackend.cc
@@ -17,9 +17,10 @@ ImageBackend::~ImageBackend()
 
 cairo_surface_t* ImageBackend::createSurface()
 {
+	assert(!this->surface);
 	this->surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 	assert(this->surface);
-  Nan::AdjustExternalMemory(4 * width * height);
+	Nan::AdjustExternalMemory(4 * width * height);
 
 	return this->surface;
 }
@@ -34,7 +35,6 @@ cairo_surface_t* ImageBackend::recreateSurface()
 
 	return createSurface();
 }
-
 
 Nan::Persistent<FunctionTemplate> ImageBackend::constructor;
 

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -13,6 +13,8 @@ using namespace v8;
 PdfBackend::PdfBackend(int width, int height)
 	: Backend("pdf", width, height)
 {
+	_closure = malloc(sizeof(closure_t));
+	assert(_closure);
 	createSurface();
 }
 
@@ -28,8 +30,6 @@ PdfBackend::~PdfBackend()
 
 cairo_surface_t* PdfBackend::createSurface()
 {
-	_closure = malloc(sizeof(closure_t));
-	assert(_closure);
 	cairo_status_t status = closure_init((closure_t*)_closure, this->canvas, 0, PNG_NO_FILTERS);
 	assert(status == CAIRO_STATUS_SUCCESS);
 

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -15,7 +15,6 @@ SvgBackend::SvgBackend(int width, int height)
 {
 	_closure = malloc(sizeof(closure_t));
 	assert(_closure);
-
 	createSurface();
 }
 


### PR DESCRIPTION
Fixes #922 
Fixes #925

@azangru this is simple enough to repro the leak that you reported (run with `node --expose-gc`):

```js
var Canvas = require('./index.js');
var result;
for (var k = 0; k < 2000; k++) {
	result = new Canvas(1200, 600 /*, "pdf" */);
	if (k % 50 === 0) console.log(k, process.memoryUsage().rss);
	gc();
}
```

https://github.com/Automattic/node-canvas/commit/48eb938b70ce593a225a54e49c6e307694cb19f9 created orphaned Cairo surfaces for all three types of backends (PDF, SVG, image).

This also removes some redundant work because both the backend constructors and Canvas constructor were invoking `createSurface`.