### PR TITLE
Use .node extension for requiring native module

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('../build/Release/canvas');
+module.exports = require('../build/Release/canvas.node');


### PR DESCRIPTION
According to the [Node.js documentation][1] the file extension CAN be
omitted but omitting it has the disadvantage that webpack can't match these
modules.  So if you try to package a JavaScript application which use
node-canvas then you can't simply use webpack plugins like
[node-native-loader][2].

With this little change webpack and the node-native-loader plugin can be
used to easily create an application package with the canvas.node lib copied
beside the packed JavaScript and everything works fine.

[1]: https://nodejs.org/api/addons.html#addons_loading_addons_using_require
[2]: https://www.npmjs.com/package/node-native-loader