### PR TITLE
Support canvas.getContext("2d", {alpha: boolean, pixelFormat: string})

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ Unreleased / patch
  * Port has_lib.sh to javascript (#872)
  * Support canvas.getContext("2d", {alpha: boolean}) and
    canvas.getContext("2d", {pixelFormat: "..."})
+ * Support indexed PNG encoding.
 
 1.6.0 / 2016-10-16
 ==================

--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@ Unreleased / patch
 ==================
 
  * Port has_lib.sh to javascript (#872)
+ * Support canvas.getContext("2d", {alpha: boolean}) and
+   canvas.getContext("2d", {pixelFormat: "..."})
 
 1.6.0 / 2016-10-16
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -343,6 +343,7 @@ These additional pixel formats have experimental support:
   Some hardware devices and frame buffers use this format. Note that PNG does
   not support this format; when creating a PNG, the image will be converted to
   24-bit RGB. This format is thus suboptimal for generating PNGs.
+  `ImageData` instances for this mode use a `Uint16Array` instead of a `Uint8ClampedArray`.
 * `A1` Each pixel is 1 bit, and pixels are packed together into 32-bit
   quantities. The ordering of the bits matches the endianness of the
   platform: on a little-endian machine, the first pixel is the least-

--- a/Readme.md
+++ b/Readme.md
@@ -117,7 +117,7 @@ img.dataMode = Image.MODE_MIME | Image.MODE_IMAGE; // Both are tracked
 
 If image data is not tracked, and the Image is drawn to an image rather than a PDF canvas, the output will be junk. Enabling mime data tracking has no benefits (only a slow down) unless you are generating a PDF.
 
-### Canvas#pngStream()
+### Canvas#pngStream(options)
 
   To create a `PNGStream` simply call `canvas.pngStream()`, and the stream will start to emit _data_ events, finally emitting _end_ when finished. If an exception occurs the _error_ event is emitted.
 
@@ -136,6 +136,22 @@ stream.on('end', function(){
 ```
 
 Currently _only_ sync streaming is supported, however we plan on supporting async streaming as well (of course :) ). Until then the `Canvas#toBuffer(callback)` alternative is async utilizing `eio_custom()`.
+
+To encode indexed PNGs from canvases with `pixelFormat: 'A8'` or `'A1'`, provide an options object:
+
+```js
+var palette = new Uint8ClampedArray([
+  //r    g    b    a
+    0,  50,  50, 255, // index 1
+   10,  90,  90, 255, // index 2
+  127, 127, 255, 255
+  // ...
+]);
+canvas.pngStream({
+  palette: palette,
+  backgroundIndex: 0 // optional, defaults to 0
+})
+```
 
 ### Canvas#jpegStream() and Canvas#syncJPEGStream()
 
@@ -337,7 +353,9 @@ These additional pixel formats have experimental support:
   `RGBA32` because transparency does not need to be calculated.
 * `A8` Each pixel is 8 bits. This format can either be used for creating
   grayscale images (treating each byte as an alpha value), or for creating
-  indexed PNGs (treating each byte as a palette index).
+  indexed PNGs (treating each byte as a palette index) (see [the example using
+  alpha values with `fillStyle`](examples/indexed-png-alpha.js) and [the
+  example using `imageData`](examples/indexed-png-image-data.js)).
 * `RGB16_565` Each pixel is 16 bits, with red in the upper 5 bits, green in the
   middle 6 bits, and blue in the lower 5 bits, in native platform endianness.
   Some hardware devices and frame buffers use this format. Note that PNG does
@@ -369,7 +387,7 @@ Notes and caveats:
 
 * `A1` and `RGB30` do not yet support `getImageData` or `putImageData`. Have a
   use case and/or opinion on working with these formats? Open an issue and let
-  us know!
+  us know! (See #935.)
 
 * `A1`, `A8`, `RGB30` and `RGB16_565` with shadow blurs may crash or not render
   properly.

--- a/examples/indexed-png-alpha.js
+++ b/examples/indexed-png-alpha.js
@@ -1,0 +1,34 @@
+var Canvas = require('..')
+var fs = require('fs')
+var path = require('path')
+var canvas = new Canvas(200, 200)
+var ctx = canvas.getContext('2d', {pixelFormat: 'A8'})
+
+// Matches the "fillStyle" browser test, made by using alpha fillStyle value
+var palette = new Uint8ClampedArray(37 * 4)
+var i, j
+var k = 0
+// First value is opaque white:
+palette[k++] = 255
+palette[k++] = 255
+palette[k++] = 255
+palette[k++] = 255
+for (i = 0; i < 6; i++) {
+  for (j = 0; j < 6; j++) {
+    palette[k++] = Math.floor(255 - 42.5 * i)
+    palette[k++] = Math.floor(255 - 42.5 * j)
+    palette[k++] = 0
+    palette[k++] = 255
+  }
+}
+for (i = 0; i < 6; i++) {
+  for (j = 0; j < 6; j++) {
+    var index = i * 6 + j + 1.5 // 0.5 to bias rounding
+    var fraction = index / 255
+    ctx.fillStyle = 'rgba(0,0,0,' + fraction + ')'
+    ctx.fillRect(j * 25, i * 25, 25, 25)
+  }
+}
+
+canvas.createPNGStream({palette: palette})
+    .pipe(fs.createWriteStream(path.join(__dirname, 'indexed2.png')))

--- a/examples/indexed-png-image-data.js
+++ b/examples/indexed-png-image-data.js
@@ -1,0 +1,39 @@
+var Canvas = require('..')
+var fs = require('fs')
+var path = require('path')
+var canvas = new Canvas(200, 200)
+var ctx = canvas.getContext('2d', {pixelFormat: 'A8'})
+
+// Matches the "fillStyle" browser test, made by manipulating imageData
+var palette = new Uint8ClampedArray(37 * 4)
+var k = 0
+var i, j
+// First value is opaque white:
+palette[k++] = 255
+palette[k++] = 255
+palette[k++] = 255
+palette[k++] = 255
+for (i = 0; i < 6; i++) {
+  for (j = 0; j < 6; j++) {
+    palette[k++] = Math.floor(255 - 42.5 * i)
+    palette[k++] = Math.floor(255 - 42.5 * j)
+    palette[k++] = 0
+    palette[k++] = 255
+  }
+}
+var idata = ctx.getImageData(0, 0, 200, 200)
+for (i = 0; i < 6; i++) {
+  for (j = 0; j < 6; j++) {
+    var index = j * 6 + i
+    // fill rect:
+    for (var xr = j * 25; xr < j * 25 + 25; xr++) {
+      for (var yr = i * 25; yr < i * 25 + 25; yr++) {
+        idata.data[xr * 200 + yr] = index + 1
+      }
+    }
+  }
+}
+ctx.putImageData(idata, 0, 0)
+
+canvas.createPNGStream({palette: palette})
+    .pipe(fs.createWriteStream(path.join(__dirname, 'indexed.png')))

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -130,25 +130,35 @@ Canvas.prototype.getContext = function (contextType, contextAttributes) {
 /**
  * Create a `PNGStream` for `this` canvas.
  *
+ * @param {Object} options
+ * @param {Uint8ClampedArray} options.palette Provide for indexed PNG encoding.
+ *   entries should be R-G-B-A values.
+ * @param {Number} options.backgroundIndex Optional index of background color
+ *   for indexed PNGs. Defaults to 0.
  * @return {PNGStream}
  * @api public
  */
 
 Canvas.prototype.pngStream =
-Canvas.prototype.createPNGStream = function(){
-  return new PNGStream(this);
+Canvas.prototype.createPNGStream = function(options){
+  return new PNGStream(this, false, options);
 };
 
 /**
  * Create a synchronous `PNGStream` for `this` canvas.
  *
+ * @param {Object} options
+ * @param {Uint8ClampedArray} options.palette Provide for indexed PNG encoding.
+ *   entries should be R-G-B-A values.
+ * @param {Number} options.backgroundIndex Optional index of background color
+ *   for indexed PNGs. Defaults to 0.
  * @return {PNGStream}
  * @api public
  */
 
 Canvas.prototype.syncPNGStream =
-Canvas.prototype.createSyncPNGStream = function(){
-  return new PNGStream(this, true);
+Canvas.prototype.createSyncPNGStream = function(options){
+  return new PNGStream(this, true, options);
 };
 
 /**

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -112,14 +112,15 @@ Canvas.prototype.inspect = function(){
 /**
  * Get a context object.
  *
- * @param {String} contextId
+ * @param {String} contextType must be "2d"
+ * @param {Object {alpha: boolean, pixelFormat: PIXEL_FORMAT} } contextAttributes Optional
  * @return {Context2d}
  * @api public
  */
 
-Canvas.prototype.getContext = function(contextId){
-  if ('2d' == contextId) {
-    var ctx = this._context2d || (this._context2d = new Context2d(this));
+Canvas.prototype.getContext = function (contextType, contextAttributes) {
+  if ('2d' == contextType) {
+    var ctx = this._context2d || (this._context2d = new Context2d(this, contextAttributes));
     this.context = ctx;
     ctx.canvas = this;
     return ctx;

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -274,6 +274,7 @@ Context2d.prototype.createImageData = function (width, height) {
     height = width.height
     width = width.width
   }
-
-  return new ImageData(width, height)
+  var Bpp = this.canvas.stride / this.canvas.width;
+  var nBytes = Bpp * width * height
+  return new ImageData(new Uint8ClampedArray(nBytes), width, height)
 }

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -276,5 +276,11 @@ Context2d.prototype.createImageData = function (width, height) {
   }
   var Bpp = this.canvas.stride / this.canvas.width;
   var nBytes = Bpp * width * height
-  return new ImageData(new Uint8ClampedArray(nBytes), width, height)
+  var arr;
+  if (this.pixelFormat === "RGB16_565") {
+    arr = new Uint16Array(nBytes / 2);
+  } else {
+    arr = new Uint8ClampedArray(nBytes);
+  }
+  return new ImageData(arr, width, height);
 }

--- a/lib/pngstream.js
+++ b/lib/pngstream.js
@@ -27,10 +27,15 @@ var util = require('util');
  *
  * @param {Canvas} canvas
  * @param {Boolean} sync
+ * @param {Object} options
+ * @param {Uint8ClampedArray} options.palette Provide for indexed PNG encoding.
+ *   entries should be R-G-B-A values.
+ * @param {Number} options.backgroundIndex Optional index of background color
+ *   for indexed PNGs. Defaults to 0.
  * @api public
  */
 
-var PNGStream = module.exports = function PNGStream(canvas, sync) {
+var PNGStream = module.exports = function PNGStream(canvas, sync, options) {
   if (!(this instanceof PNGStream)) {
     throw new TypeError("Class constructors cannot be invoked without 'new'");
   }
@@ -43,6 +48,7 @@ var PNGStream = module.exports = function PNGStream(canvas, sync) {
       : 'streamPNG';
   this.sync = sync;
   this.canvas = canvas;
+  this.options = options || {};
 
   // TODO: implement async
   if ('streamPNG' === method) method = 'streamPNGSync';
@@ -66,5 +72,5 @@ PNGStream.prototype._read = function _read() {
     } else {
       self.push(null);
     }
-  });
+  }, self.options);
 };

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -103,6 +103,7 @@ NAN_METHOD(Canvas::New) {
       backend = new ImageBackend(width, height);
   }
   else if (info[0]->IsObject()) {
+    // TODO need to check if this is actually an instance of a Backend to avoid a fault
     backend = Nan::ObjectWrap::Unwrap<Backend>(info[0]->ToObject());
   }
   else {
@@ -304,6 +305,8 @@ NAN_METHOD(Canvas::ToBuffer) {
 
     uv_work_t* req = new uv_work_t;
     req->data = closure;
+    // Make sure the surface exists since we won't have an isolate context in the async block:
+    canvas->surface();
     uv_queue_work(uv_default_loop(), req, ToBufferAsync, (uv_after_work_cb)ToBufferAsyncAfter);
 
     return;

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -822,9 +822,15 @@ NAN_METHOD(Context2d::GetImageData) {
   uint8_t *src = canvas->data();
 
   Local<ArrayBuffer> buffer = ArrayBuffer::New(Isolate::GetCurrent(), size);
-  Local<Uint8ClampedArray> clampedArray = Uint8ClampedArray::New(buffer, 0, size);
+  Local<TypedArray> dataArray;
 
-  Nan::TypedArrayContents<uint8_t> typedArrayContents(clampedArray);
+  if (canvas->backend()->getFormat() == CAIRO_FORMAT_RGB16_565) {
+    dataArray = Uint16Array::New(buffer, 0, size);
+  } else {
+    dataArray = Uint8ClampedArray::New(buffer, 0, size);
+  }
+
+  Nan::TypedArrayContents<uint8_t> typedArrayContents(dataArray);
   uint8_t* dst = *typedArrayContents;
 
   switch (canvas->backend()->getFormat()) {
@@ -919,7 +925,7 @@ NAN_METHOD(Context2d::GetImageData) {
   const int argc = 3;
   Local<Int32> swHandle = Nan::New(sw);
   Local<Int32> shHandle = Nan::New(sh);
-  Local<Value> argv[argc] = { clampedArray, swHandle, shHandle };
+  Local<Value> argv[argc] = { dataArray, swHandle, shHandle };
 
   Local<Function> ctor = Nan::GetFunction(Nan::New(ImageData::constructor)).ToLocalChecked();
   Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -98,6 +98,7 @@ class Context2d: public Nan::ObjectWrap {
     static NAN_METHOD(Arc);
     static NAN_METHOD(ArcTo);
     static NAN_METHOD(GetImageData);
+    static NAN_GETTER(GetFormat);
     static NAN_GETTER(GetPatternQuality);
     static NAN_GETTER(GetGlobalCompositeOperation);
     static NAN_GETTER(GetGlobalAlpha);

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -23,7 +23,6 @@ class ImageData: public Nan::ObjectWrap {
     inline int width() { return _width; }
     inline int height() { return _height; }
     inline uint8_t *data() { return _data; }
-    inline int stride() { return _width * 4; }
     ImageData(uint8_t *data, int width, int height) : _width(width), _height(height), _data(data) {}
 
   private:

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -63,6 +63,28 @@ static void canvas_unpremultiply_data(png_structp png, png_row_infop row_info, p
     }
 }
 
+/* Converts RGB16_565 format data to RGBA32 */
+static void canvas_convert_565_to_888(png_structp png, png_row_infop row_info, png_bytep data) {
+  // Loop in reverse to unpack in-place.
+  for (ptrdiff_t col = row_info->width - 1; col >= 0; col--) {
+    uint8_t* src = &data[col * sizeof(uint16_t)];
+    uint8_t* dst = &data[col * 3];
+    uint16_t pixel;
+
+    memcpy(&pixel, src, sizeof(uint16_t));
+
+    // Convert and rescale to the full 0-255 range
+    // See http://stackoverflow.com/a/29326693
+    const uint8_t red5 = (pixel & 0xF800) >> 11;
+    const uint8_t green6 = (pixel & 0x7E0) >> 5;
+    const uint8_t blue5 = (pixel & 0x001F);
+
+    dst[0] = ((red5 * 255 + 15) / 31);
+    dst[1] = ((green6 * 255 + 31) / 63);
+    dst[2] = ((blue5 * 255 + 15) / 31);
+  }
+}
+
 struct canvas_png_write_closure_t {
     cairo_write_func_t write_func;
     void *closure;
@@ -99,8 +121,9 @@ static cairo_status_t canvas_write_png(cairo_surface_t *surface, png_rw_ptr writ
         return status;
     }
 
+    int stride = cairo_image_surface_get_stride(surface);
     for (i = 0; i < height; i++) {
-	rows[i] = (png_byte *) data + i * cairo_image_surface_get_stride(surface);
+        rows[i] = (png_byte *) data + i * stride;
     }
 
 #ifdef PNG_USER_MEM_SUPPORTED
@@ -162,8 +185,11 @@ static cairo_status_t canvas_write_png(cairo_surface_t *surface, png_rw_ptr writ
         png_set_packswap(png);
 #endif
         break;
-    case CAIRO_FORMAT_INVALID:
     case CAIRO_FORMAT_RGB16_565:
+        bpc = 8; // 565 gets upconverted to 888
+        png_color_type = PNG_COLOR_TYPE_RGB;
+        break;
+    case CAIRO_FORMAT_INVALID:
     default:
         status = CAIRO_STATUS_INVALID_FORMAT;
         png_destroy_write_struct(&png, &info);
@@ -184,6 +210,8 @@ static cairo_status_t canvas_write_png(cairo_surface_t *surface, png_rw_ptr writ
     png_write_info(png, info);
     if (png_color_type == PNG_COLOR_TYPE_RGB_ALPHA) {
         png_set_write_user_transform_fn(png, canvas_unpremultiply_data);
+    } else if (cairo_image_surface_get_format(surface) == CAIRO_FORMAT_RGB16_565) {
+        png_set_write_user_transform_fn(png, canvas_convert_565_to_888);
     } else if (png_color_type == PNG_COLOR_TYPE_RGB) {
         png_set_write_user_transform_fn(png, canvas_convert_data_to_bytes);
         png_set_filler(png, 0, PNG_FILLER_AFTER);

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -29,8 +29,8 @@ cairo_surface_t* Backend::recreateSurface()
 	return this->createSurface();
 }
 
-cairo_surface_t* Backend::getSurface()
-{
+cairo_surface_t* Backend::getSurface() {
+	if (!surface) createSurface();
 	return surface;
 }
 

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -53,6 +53,9 @@ class Backend : public Nan::ObjectWrap
 
     int getHeight();
     virtual void setHeight(int height);
+
+    // Overridden by ImageBackend. SVG and PDF thus always return INVALID.
+    virtual cairo_format_t getFormat() { return CAIRO_FORMAT_INVALID; }
 };
 
 

--- a/src/backend/ImageBackend.cc
+++ b/src/backend/ImageBackend.cc
@@ -4,23 +4,42 @@ using namespace v8;
 
 ImageBackend::ImageBackend(int width, int height)
 	: Backend("image", width, height)
-{
-	createSurface();
-}
+	{}
 
 ImageBackend::~ImageBackend()
 {
 	destroySurface();
 
-	Nan::AdjustExternalMemory(-4 * width * height);
+	Nan::AdjustExternalMemory(-1 * approxBytesPerPixel() * width * height);
+}
+
+// This returns an approximate value only, suitable for Nan::AdjustExternalMemory.
+// The formats that don't map to intrinsic types (RGB30, A1) round up.
+uint32_t ImageBackend::approxBytesPerPixel() {
+  switch (format) {
+  case CAIRO_FORMAT_ARGB32:
+  case CAIRO_FORMAT_RGB24:
+    return 4;
+#ifdef CAIRO_FORMAT_RGB30
+  case CAIRO_FORMAT_RGB30:
+    return 3;
+#endif
+  case CAIRO_FORMAT_RGB16_565:
+    return 2;
+  case CAIRO_FORMAT_A8:
+  case CAIRO_FORMAT_A1:
+    return 1;
+  default:
+    return 0;
+  }
 }
 
 cairo_surface_t* ImageBackend::createSurface()
 {
 	assert(!this->surface);
-	this->surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+	this->surface = cairo_image_surface_create(this->format, width, height);
 	assert(this->surface);
-	Nan::AdjustExternalMemory(4 * width * height);
+	Nan::AdjustExternalMemory(approxBytesPerPixel() * width * height);
 
 	return this->surface;
 }
@@ -28,12 +47,22 @@ cairo_surface_t* ImageBackend::createSurface()
 cairo_surface_t* ImageBackend::recreateSurface()
 {
 	// Re-surface
-	int old_width = cairo_image_surface_get_width(this->surface);
-	int old_height = cairo_image_surface_get_height(this->surface);
-	this->destroySurface();
-	Nan::AdjustExternalMemory(-4 * old_width * old_height);
+	if (this->surface) {
+		int old_width = cairo_image_surface_get_width(this->surface);
+		int old_height = cairo_image_surface_get_height(this->surface);
+		this->destroySurface();
+		Nan::AdjustExternalMemory(-1 * approxBytesPerPixel() * old_width * old_height);
+	}
 
 	return createSurface();
+}
+
+cairo_format_t ImageBackend::getFormat() {
+  return format;
+}
+
+void ImageBackend::setFormat(cairo_format_t _format) {
+	this->format = _format;
 }
 
 Nan::Persistent<FunctionTemplate> ImageBackend::constructor;

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -12,14 +12,21 @@ class ImageBackend : public Backend
   private:
     cairo_surface_t* createSurface();
     cairo_surface_t* recreateSurface();
+    cairo_format_t format = DEFAULT_FORMAT;
 
   public:
     ImageBackend(int width, int height);
     ~ImageBackend();
 
+    cairo_format_t getFormat();
+    void setFormat(cairo_format_t format);
+
+    uint32_t approxBytesPerPixel();
+
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Handle<v8::Object> target);
     static NAN_METHOD(New);
+    const static cairo_format_t DEFAULT_FORMAT = CAIRO_FORMAT_ARGB32;
 };
 
 #endif

--- a/src/closure.h
+++ b/src/closure.h
@@ -34,6 +34,9 @@ typedef struct {
   cairo_status_t status;
   uint32_t compression_level;
   uint32_t filter;
+  uint8_t *palette;
+  size_t nPaletteColors;
+  uint8_t backgroundIndex;
 } closure_t;
 
 /*

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -222,6 +222,54 @@ describe('Canvas', function () {
     assert.equal(ctx, canvas.context, 'canvas.context is not context');
   });
 
+  it('Canvas#getContext("2d", {pixelFormat: string})', function () {
+    var canvas, context;
+
+    // default:
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "RGBA32"});
+    assert.equal(context.pixelFormat, "RGBA32");
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "RGBA32"});
+    assert.equal(context.pixelFormat, "RGBA32");
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "RGB24"});
+    assert.equal(context.pixelFormat, "RGB24");
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "A8"});
+    assert.equal(context.pixelFormat, "A8");
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "A1"});
+    assert.equal(context.pixelFormat, "A1");
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "RGB16_565"});
+    assert.equal(context.pixelFormat, "RGB16_565");
+
+    // Not tested: RGB30
+  });
+
+  it('Canvas#getContext("2d", {alpha: boolean})', function () {
+    var canvas, context;
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {alpha: true});
+    assert.equal(context.pixelFormat, "RGBA32");
+
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {alpha: false});
+    assert.equal(context.pixelFormat, "RGB24");
+
+    // alpha takes priority:
+    canvas = createCanvas(10, 10);
+    context = canvas.getContext("2d", {pixelFormat: "RGBA32", alpha: false});
+    assert.equal(context.pixelFormat, "RGB24");
+  });
+
   it('Canvas#{width,height}=', function () {
     var canvas = createCanvas(100, 200);
     assert.equal(100, canvas.width);
@@ -241,6 +289,8 @@ describe('Canvas', function () {
     var canvas = createCanvas(24, 10);
     assert.ok(canvas.stride >= 24, 'canvas.stride is too short');
     assert.ok(canvas.stride < 1024, 'canvas.stride seems too long');
+
+    // TODO test stride on other formats
   });
 
   it('Canvas#getContext("invalid")', function () {
@@ -605,19 +655,77 @@ describe('Canvas', function () {
     });
   });
 
-  it('Context2d#createImageData(width, height)', function () {
-    var canvas = createCanvas(20, 20)
-      , ctx = canvas.getContext('2d');
+  describe('Context2d#createImageData(width, height)', function () {
+    it("works", function () {
+      var canvas = createCanvas(20, 20)
+        , ctx = canvas.getContext('2d');
 
-    var imageData = ctx.createImageData(2,6);
-    assert.equal(2, imageData.width);
-    assert.equal(6, imageData.height);
-    assert.equal(2 * 6 * 4, imageData.data.length);
+      var imageData = ctx.createImageData(2,6);
+      assert.equal(2, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(2 * 6 * 4, imageData.data.length);
 
-    assert.equal(0, imageData.data[0]);
-    assert.equal(0, imageData.data[1]);
-    assert.equal(0, imageData.data[2]);
-    assert.equal(0, imageData.data[3]);
+      assert.equal(0, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(0, imageData.data[3]);
+    });
+
+    it("works, A8 format", function () {
+      var canvas = createCanvas(20, 20)
+        , ctx = canvas.getContext('2d', {pixelFormat: "A8"});
+
+      var imageData = ctx.createImageData(2,6);
+      assert.equal(2, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(2 * 6 * 1, imageData.data.length);
+
+      assert.equal(0, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(0, imageData.data[3]);
+    });
+
+    it("works, A1 format", function () {
+      var canvas = createCanvas(20, 20)
+        , ctx = canvas.getContext('2d', {pixelFormat: "A1"});
+
+      var imageData = ctx.createImageData(2,6);
+      assert.equal(2, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(Math.ceil(2 * 6 / 8), imageData.data.length);
+
+      assert.equal(0, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+    });
+
+    it("works, RGB24 format", function () {
+      var canvas = createCanvas(20, 20)
+        , ctx = canvas.getContext('2d', {pixelFormat: "RGB24"});
+
+      var imageData = ctx.createImageData(2,6);
+      assert.equal(2, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(2 * 6 * 4, imageData.data.length);
+
+      assert.equal(0, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(0, imageData.data[3]);
+    });
+
+    it("works, RGB16_565 format", function () {
+      var canvas = createCanvas(20, 20)
+        , ctx = canvas.getContext('2d', {pixelFormat: "RGB16_565"});
+
+      var imageData = ctx.createImageData(2,6);
+      assert.equal(2, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(2 * 6 * 2, imageData.data.length);
+
+      assert.equal(0, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+    });
   });
 
   it('Context2d#measureText().width', function () {
@@ -639,64 +747,189 @@ describe('Canvas', function () {
     assert.equal(2 * 6 * 4, imageData.data.length);
   });
 
-  it('Context2d#getImageData()', function () {
-    var canvas = createCanvas(3, 6)
-      , ctx = canvas.getContext('2d');
+  describe('Context2d#getImageData()', function () {
+    function createTestCanvas(useAlpha, attributes) {
+      var canvas = createCanvas(3, 6);
+      var ctx = canvas.getContext('2d', attributes);
 
-    ctx.fillStyle = '#f00';
-    ctx.fillRect(0,0,1,6);
+      ctx.fillStyle = useAlpha ? 'rgba(255,0,0,0.25)' : '#f00';
+      ctx.fillRect(0,0,1,6);
 
-    ctx.fillStyle = '#0f0';
-    ctx.fillRect(1,0,1,6);
+      ctx.fillStyle = useAlpha ? 'rgba(0,255,0,0.5)' : '#0f0';
+      ctx.fillRect(1,0,1,6);
 
-    ctx.fillStyle = '#00f';
-    ctx.fillRect(2,0,1,6);
+      ctx.fillStyle = useAlpha ? 'rgba(0,0,255,0.75)' : '#00f';
+      ctx.fillRect(2,0,1,6);
 
-    // Full width
-    var imageData = ctx.getImageData(0,0,3,6);
-    assert.equal(3, imageData.width);
-    assert.equal(6, imageData.height);
-    assert.equal(3 * 6 * 4, imageData.data.length);
+      return ctx;
+    }
 
-    assert.equal(255, imageData.data[0]);
-    assert.equal(0, imageData.data[1]);
-    assert.equal(0, imageData.data[2]);
-    assert.equal(255, imageData.data[3]);
+    it("works, full width, RGBA32", function () {
+      var ctx = createTestCanvas();
+      var imageData = ctx.getImageData(0,0,3,6);
 
-    assert.equal(0, imageData.data[4]);
-    assert.equal(255, imageData.data[5]);
-    assert.equal(0, imageData.data[6]);
-    assert.equal(255, imageData.data[7]);
+      assert.equal(3, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(3 * 6 * 4, imageData.data.length);
 
-    assert.equal(0, imageData.data[8]);
-    assert.equal(0, imageData.data[9]);
-    assert.equal(255, imageData.data[10]);
-    assert.equal(255, imageData.data[11]);
+      assert.equal(255, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(255, imageData.data[3]);
 
-    // Slice
-    var imageData = ctx.getImageData(0,0,2,1);
-    assert.equal(2, imageData.width);
-    assert.equal(1, imageData.height);
-    assert.equal(8, imageData.data.length);
+      assert.equal(0, imageData.data[4]);
+      assert.equal(255, imageData.data[5]);
+      assert.equal(0, imageData.data[6]);
+      assert.equal(255, imageData.data[7]);
 
-    assert.equal(255, imageData.data[0]);
-    assert.equal(0, imageData.data[1]);
-    assert.equal(0, imageData.data[2]);
-    assert.equal(255, imageData.data[3]);
+      assert.equal(0, imageData.data[8]);
+      assert.equal(0, imageData.data[9]);
+      assert.equal(255, imageData.data[10]);
+      assert.equal(255, imageData.data[11]);
+    });
 
-    assert.equal(0, imageData.data[4]);
-    assert.equal(255, imageData.data[5]);
-    assert.equal(0, imageData.data[6]);
-    assert.equal(255, imageData.data[7]);
+    it("works, full width, RGB24", function () {
+      var ctx = createTestCanvas(false, {pixelFormat: "RGB24"});
+      var imageData = ctx.getImageData(0,0,3,6);
+      assert.equal(3, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(3 * 6 * 4, imageData.data.length);
 
-    // Assignment
-    var data = ctx.getImageData(0,0,5,5).data;
-    data[0] = 50;
-    assert.equal(50, data[0]);
-    data[0] = 280;
-    assert.equal(255, data[0]);
-    data[0] = -4444;
-    assert.equal(0, data[0]);
+      assert.equal(255, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(255, imageData.data[3]);
+
+      assert.equal(0, imageData.data[4]);
+      assert.equal(255, imageData.data[5]);
+      assert.equal(0, imageData.data[6]);
+      assert.equal(255, imageData.data[7]);
+
+      assert.equal(0, imageData.data[8]);
+      assert.equal(0, imageData.data[9]);
+      assert.equal(255, imageData.data[10]);
+      assert.equal(255, imageData.data[11]);
+    });
+
+    it("works, full width, RGB16_565", function () {
+      var ctx = createTestCanvas(false, {pixelFormat: "RGB16_565"});
+      var imageData = ctx.getImageData(0,0,3,6);
+      assert.equal(3, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(3 * 6 * 2, imageData.data.length);
+
+      // TODO should be a Uint16Array already?
+      var uint16data = new Uint16Array(imageData.data.buffer, imageData.data.byteOffset, 18);
+
+      assert.equal((255 & 0b11111) << 11, uint16data[0]);
+      assert.equal((255 & 0b111111) << 5, uint16data[1]);
+      assert.equal((255 & 0b11111), uint16data[2]);
+
+      assert.equal((255 & 0b11111) << 11, uint16data[3]);
+      assert.equal((255 & 0b111111) << 5, uint16data[4]);
+      assert.equal((255 & 0b11111), uint16data[5]);
+    });
+
+    it("works, full width, A8", function () {
+      var ctx = createTestCanvas(true, {pixelFormat: "A8"});
+      var imageData = ctx.getImageData(0,0,3,6);
+      assert.equal(3, imageData.width);
+      assert.equal(6, imageData.height);
+      assert.equal(3 * 6, imageData.data.length);
+
+      assert.equal(63, imageData.data[0]);
+      assert.equal(127, imageData.data[1]);
+      assert.equal(191, imageData.data[2]);
+
+      assert.equal(63, imageData.data[3]);
+      assert.equal(127, imageData.data[4]);
+      assert.equal(191, imageData.data[5]);
+    });
+
+    it("works, full width, A1");
+
+    it("works, full width, RGB30");
+
+    it("works, slice, RGBA32", function () {
+      var ctx = createTestCanvas();
+      var imageData = ctx.getImageData(0,0,2,1);
+      assert.equal(2, imageData.width);
+      assert.equal(1, imageData.height);
+      assert.equal(8, imageData.data.length);
+
+      assert.equal(255, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(255, imageData.data[3]);
+
+      assert.equal(0, imageData.data[4]);
+      assert.equal(255, imageData.data[5]);
+      assert.equal(0, imageData.data[6]);
+      assert.equal(255, imageData.data[7]);
+    });
+
+    it("works, slice, RGB24", function () {
+      var ctx = createTestCanvas(false, {pixelFormat: "RGB24"});
+      var imageData = ctx.getImageData(0,0,2,1);
+      assert.equal(2, imageData.width);
+      assert.equal(1, imageData.height);
+      assert.equal(8, imageData.data.length);
+
+      assert.equal(255, imageData.data[0]);
+      assert.equal(0, imageData.data[1]);
+      assert.equal(0, imageData.data[2]);
+      assert.equal(255, imageData.data[3]);
+
+      assert.equal(0, imageData.data[4]);
+      assert.equal(255, imageData.data[5]);
+      assert.equal(0, imageData.data[6]);
+      assert.equal(255, imageData.data[7]);
+    });
+
+    it("works, slice, RGB16_565", function () {
+      var ctx = createTestCanvas(false, {pixelFormat: "RGB16_565"});
+      var imageData = ctx.getImageData(0,0,2,1);
+      assert.equal(2, imageData.width);
+      assert.equal(1, imageData.height);
+      assert.equal(2 * 1 * 2, imageData.data.length);
+
+      // TODO should be a Uint16Array already?
+      var uint16data = new Uint16Array(imageData.data.buffer, imageData.data.byteOffset, 2);
+
+      assert.equal((255 & 0b11111) << 11, uint16data[0]);
+      assert.equal((255 & 0b111111) << 5, uint16data[1]);
+    });
+
+    it("works, slice, A8", function () {
+      var ctx = createTestCanvas(true, {pixelFormat: "A8"});
+      var imageData = ctx.getImageData(0,0,2,1);
+      assert.equal(2, imageData.width);
+      assert.equal(1, imageData.height);
+      assert.equal(2 * 1, imageData.data.length);
+
+      assert.equal(63, imageData.data[0]);
+      assert.equal(127, imageData.data[1]);
+    });
+
+    it("works, slice, A1");
+
+    it("works, slice, RGB30");
+
+    it("works, assignment", function () {
+      var ctx = createTestCanvas();
+      var data = ctx.getImageData(0,0,5,5).data;
+      data[0] = 50;
+      assert.equal(50, data[0]);
+      data[0] = 280;
+      assert.equal(255, data[0]);
+      data[0] = -4444;
+      assert.equal(0, data[0]);
+    });
+
+    it("throws if indexes are invalid", function () {
+      var ctx = createTestCanvas();
+      assert.throws(function () { ctx.getImageData(0, 0, 0, 0); }, /IndexSizeError/);
+    });
   });
 
   it('Context2d#createPattern(Canvas)', function () {
@@ -834,42 +1067,77 @@ describe('Canvas', function () {
     assert.equal(255, imageData.data[i+3]);
   });
 
-  it('Context2d#getImageData()', function () {
-    var canvas = createCanvas(1, 1)
-      , ctx = canvas.getContext('2d');
+  describe('Context2d#putImageData()', function () {
+    it('throws for invalid arguments', function () {
+      var canvas = createCanvas(2, 1);
+      var ctx = canvas.getContext('2d');
+      assert.throws(function () { ctx.putImageData({}, 0, 0); }, TypeError);
+      assert.throws(function () { ctx.putImageData(undefined, 0, 0); }, TypeError);
+    });
 
-    assert.throws(function () { ctx.getImageData(0, 0, 0, 0); }, /IndexSizeError/);
+    it('works, RGBA32', function () {
+      var canvas = createCanvas(2, 1);
+      var ctx = canvas.getContext('2d');
+      ctx.fillStyle = '#f00';
+      ctx.fillRect(0, 0, 1, 1);
 
-    ctx.fillStyle = '#f00';
-    ctx.fillRect(0, 0, 1, 1);
+      // Copy left pixel to the right pixel
+      ctx.putImageData(ctx.getImageData(0, 0, 1, 1), 1, 0);
 
-    var pixel = ctx.getImageData(0, 0, 1, 1);
+      var pixel = ctx.getImageData(1, 0, 1, 1);
 
-    assert.equal(pixel.data[0], 255);
-    assert.equal(pixel.data[1], 0);
-    assert.equal(pixel.data[2], 0);
-    assert.equal(pixel.data[3], 255);
-  });
+      assert.equal(pixel.data[0], 255);
+      assert.equal(pixel.data[1], 0);
+      assert.equal(pixel.data[2], 0);
+      assert.equal(pixel.data[3], 255);
+    });
 
-  it('Context2d#putImageData()', function () {
-    var canvas = createCanvas(2, 1)
-      , ctx = canvas.getContext('2d');
+    it('works, RGB24/alpha:false', function () {
+      var canvas = createCanvas(2, 1);
+      var ctx = canvas.getContext('2d', {pixelFormat: 'RGB24'});
+      ctx.fillStyle = '#f00';
+      ctx.fillRect(0, 0, 1, 1);
 
-    assert.throws(function () { ctx.putImageData({}, 0, 0); }, TypeError);
-    assert.throws(function () { ctx.putImageData(undefined, 0, 0); }, TypeError);
+      // Copy left pixel to the right pixel
+      ctx.putImageData(ctx.getImageData(0, 0, 1, 1), 1, 0);
 
-    ctx.fillStyle = '#f00';
-    ctx.fillRect(0, 0, 1, 1);
+      var pixel = ctx.getImageData(1, 0, 1, 1);
 
-    // Copy left pixel to the right pixel
-    ctx.putImageData(ctx.getImageData(0, 0, 1, 1), 1, 0);
+      assert.equal(pixel.data[0], 255);
+      assert.equal(pixel.data[1], 0);
+      assert.equal(pixel.data[2], 0);
+      assert.equal(pixel.data[3], 255);
+    });
 
-    var pixel = ctx.getImageData(1, 0, 1, 1);
+    it('works, A8', function () {
+      var canvas = createCanvas(2, 1);
+      var ctx = canvas.getContext('2d', {pixelFormat: 'A8'});
 
-    assert.equal(pixel.data[0], 255);
-    assert.equal(pixel.data[1], 0);
-    assert.equal(pixel.data[2], 0);
-    assert.equal(pixel.data[3], 255);
+      var imgData = ctx.getImageData(0, 0, 2, 1);
+      imgData.data[0] = 4;
+      imgData.data[1] = 21;
+      ctx.putImageData(imgData, 0, 0);
+
+      var pixel = ctx.getImageData(0, 0, 2, 1);
+
+      assert.equal(pixel.data[0], 4);
+      assert.equal(pixel.data[1], 21);
+    });
+
+    xit('works, RGB16_565', function () {
+      var canvas = createCanvas(2, 1);
+      var ctx = canvas.getContext('2d', {pixelFormat: 'RGB16_565'});
+
+      var imgData = ctx.getImageData(0, 0, 2, 1);
+      imgData.data[0] = 65535; // 2**16 - 1
+      imgData.data[1] = 65500;
+      ctx.putImageData(imgData, 0, 0);
+
+      var pixel = ctx.getImageData(0, 0, 2, 1);
+
+      assert.equal(pixel.data[0], 65535);
+      assert.equal(pixel.data[1], 65500);
+    });
   });
 
   it('Canvas#createSyncPNGStream()', function (done) {

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -719,9 +719,10 @@ describe('Canvas', function () {
         , ctx = canvas.getContext('2d', {pixelFormat: "RGB16_565"});
 
       var imageData = ctx.createImageData(2,6);
+      assert(imageData.data instanceof Uint16Array);
       assert.equal(2, imageData.width);
       assert.equal(6, imageData.height);
-      assert.equal(2 * 6 * 2, imageData.data.length);
+      assert.equal(2 * 6, imageData.data.length);
 
       assert.equal(0, imageData.data[0]);
       assert.equal(0, imageData.data[1]);
@@ -818,16 +819,13 @@ describe('Canvas', function () {
       assert.equal(6, imageData.height);
       assert.equal(3 * 6 * 2, imageData.data.length);
 
-      // TODO should be a Uint16Array already?
-      var uint16data = new Uint16Array(imageData.data.buffer, imageData.data.byteOffset, 18);
+      assert.equal((255 & 0b11111) << 11, imageData.data[0]);
+      assert.equal((255 & 0b111111) << 5, imageData.data[1]);
+      assert.equal((255 & 0b11111), imageData.data[2]);
 
-      assert.equal((255 & 0b11111) << 11, uint16data[0]);
-      assert.equal((255 & 0b111111) << 5, uint16data[1]);
-      assert.equal((255 & 0b11111), uint16data[2]);
-
-      assert.equal((255 & 0b11111) << 11, uint16data[3]);
-      assert.equal((255 & 0b111111) << 5, uint16data[4]);
-      assert.equal((255 & 0b11111), uint16data[5]);
+      assert.equal((255 & 0b11111) << 11, imageData.data[3]);
+      assert.equal((255 & 0b111111) << 5, imageData.data[4]);
+      assert.equal((255 & 0b11111), imageData.data[5]);
     });
 
     it("works, full width, A8", function () {
@@ -893,11 +891,8 @@ describe('Canvas', function () {
       assert.equal(1, imageData.height);
       assert.equal(2 * 1 * 2, imageData.data.length);
 
-      // TODO should be a Uint16Array already?
-      var uint16data = new Uint16Array(imageData.data.buffer, imageData.data.byteOffset, 2);
-
-      assert.equal((255 & 0b11111) << 11, uint16data[0]);
-      assert.equal((255 & 0b111111) << 5, uint16data[1]);
+      assert.equal((255 & 0b11111) << 11, imageData.data[0]);
+      assert.equal((255 & 0b111111) << 5, imageData.data[1]);
     });
 
     it("works, slice, A8", function () {
@@ -1124,7 +1119,7 @@ describe('Canvas', function () {
       assert.equal(pixel.data[1], 21);
     });
 
-    xit('works, RGB16_565', function () {
+    it('works, RGB16_565', function () {
       var canvas = createCanvas(2, 1);
       var ctx = canvas.getContext('2d', {pixelFormat: 'RGB16_565'});
 

--- a/test/imageData.test.js
+++ b/test/imageData.test.js
@@ -30,21 +30,37 @@ describe('ImageData', function () {
     // because our ImageData can support different BPPs.
   });
 
-  it('should construct with typed array', function () {
+  it('should construct with Uint8ClampedArray', function () {
     let data, imageData
 
     data = new Uint8ClampedArray(2 * 3 * 4)
     imageData = createImageData(data, 2)
     assert.strictEqual(imageData.width, 2)
     assert.strictEqual(imageData.height, 3)
-    assert.ok(imageData.data instanceof Uint8ClampedArray)
+    assert(imageData.data instanceof Uint8ClampedArray)
     assert.strictEqual(imageData.data.length, 24)
 
     data = new Uint8ClampedArray(3 * 4 * 4)
     imageData = createImageData(data, 3, 4)
     assert.strictEqual(imageData.width, 3)
     assert.strictEqual(imageData.height, 4)
-    assert.ok(imageData.data instanceof Uint8ClampedArray)
+    assert(imageData.data instanceof Uint8ClampedArray)
     assert.strictEqual(imageData.data.length, 48)
-  })
-})
+  });
+
+  it('should construct with Uint16Array', function () {
+    let data = new Uint16Array(2 * 3 * 2)
+    let imagedata = createImageData(data, 2)
+    assert.strictEqual(imagedata.width, 2)
+    assert.strictEqual(imagedata.height, 3)
+    assert(imagedata.data instanceof Uint16Array)
+    assert.strictEqual(imagedata.data.length, 12)
+
+    data = new Uint16Array(3 * 4 * 2)
+    imagedata = createImageData(data, 3, 4)
+    assert.strictEqual(imagedata.width, 3)
+    assert.strictEqual(imagedata.height, 4)
+    assert(imagedata.data instanceof Uint16Array)
+    assert.strictEqual(imagedata.data.length, 24)
+  });
+});

--- a/test/imageData.test.js
+++ b/test/imageData.test.js
@@ -25,10 +25,10 @@ describe('ImageData', function () {
 
   it('should throw with invalid typed array', function () {
     assert.throws(() => { createImageData(new Uint8ClampedArray(0), 0) }, /input data has a zero byte length/)
-    assert.throws(() => { createImageData(new Uint8ClampedArray(3), 0) }, /input data byte length is not a multiple of 4/)
-    assert.throws(() => { createImageData(new Uint8ClampedArray(16), 3) }, RangeError)
-    assert.throws(() => { createImageData(new Uint8ClampedArray(12), 3, 5) }, RangeError)
-  })
+    assert.throws(() => { createImageData(new Uint8ClampedArray(3), 0) }, /source width is zero/)
+    // Note: Some errors thrown by browsers are not thrown by node-canvas
+    // because our ImageData can support different BPPs.
+  });
 
   it('should construct with typed array', function () {
     let data, imageData

--- a/test/public/app.js
+++ b/test/public/app.js
@@ -21,7 +21,12 @@ function pdfLink (name) {
 function localRendering (name) {
   var canvas = create('canvas', { width: 200, height: 200, title: name })
 
-  window.tests[name](canvas.getContext('2d'), function () {})
+  var ctx = canvas.getContext('2d', {alpha: true})
+  var initialFillStyle = ctx.fillStyle
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, 0, 200, 200)
+  ctx.fillStyle = initialFillStyle
+  window.tests[name](ctx, function () {})
 
   return canvas
 }

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1912,8 +1912,10 @@ tests['putImageData() png data'] = function (ctx, done) {
     ctx.drawImage(img, 0, 0, 200, 200)
     var imageData = ctx.getImageData(0, 0, 50, 50)
     var data = imageData.data
-    for (var i = 0, len = data.length; i < len; i += 4) {
-      data[i + 3] = 80
+    if (data instanceof Uint8ClampedArray) {
+      for (var i = 0, len = data.length; i < len; i += 4) {
+        data[i + 3] = 80
+      }
     }
     ctx.putImageData(imageData, 50, 50)
     done(null)
@@ -1933,8 +1935,10 @@ tests['putImageData() png data 2'] = function (ctx, done) {
     ctx.drawImage(img, 0, 0, 200, 200)
     var imageData = ctx.getImageData(0, 0, 50, 50)
     var data = imageData.data
-    for (var i = 0, len = data.length; i < len; i += 4) {
-      data[i + 3] = 80
+    if (data instanceof Uint8ClampedArray) {
+      for (var i = 0, len = data.length; i < len; i += 4) {
+        data[i + 3] = 80
+      }
     }
     ctx.putImageData(imageData, 50, 50, 10, 10, 20, 20)
     done(null)
@@ -1954,10 +1958,12 @@ tests['putImageData() png data 3'] = function (ctx, done) {
     ctx.drawImage(img, 0, 0, 200, 200)
     var imageData = ctx.getImageData(0, 0, 50, 50)
     var data = imageData.data
-    for (var i = 0, len = data.length; i < len; i += 4) {
-      data[i + 0] = data[i + 0] * 0.2
-      data[i + 1] = data[i + 1] * 0.2
-      data[i + 2] = data[i + 2] * 0.2
+    if (data instanceof Uint8ClampedArray) {
+      for (var i = 0, len = data.length; i < len; i += 4) {
+        data[i + 0] = data[i + 0] * 0.2
+        data[i + 1] = data[i + 1] * 0.2
+        data[i + 2] = data[i + 2] * 0.2
+      }
     }
     ctx.putImageData(imageData, 50, 50)
     done(null)

--- a/test/server.js
+++ b/test/server.js
@@ -12,10 +12,15 @@ function renderTest (canvas, name, cb) {
     throw new Error('Unknown test: ' + name)
   }
 
+  var ctx = canvas.getContext('2d', {pixelFormat: 'RGBA32'})
+  var initialFillStyle = ctx.fillStyle
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, 0, 200, 200)
+  ctx.fillStyle = initialFillStyle
   if (tests[name].length === 2) {
-    tests[name](canvas.getContext('2d'), cb)
+    tests[name](ctx, cb)
   } else {
-    tests[name](canvas.getContext('2d'))
+    tests[name](ctx)
     cb(null)
   }
 }


### PR DESCRIPTION
This is an amped-up version of most of #678. ("Most" because it doesn't add the `flush` function or allow passing a buffer as that PR adds. "Amped-up" because all of the APIs work AFAICT, with the caveats noted in the docs.) My priority was to support indexed PNG encoding, but a lot of stuff came with it. I'm happy to split the 1st/2nd commits from the 3rd and 4th. Indexed PNG encoding is maybe out of scope and is something that could be extracted into a separate C++ addon, but the first two support the standard.

Docs for the major addition: https://github.com/zbjornson/node-canvas/tree/formats#image-pixel-formats-experimental

* Adds support for the [standard](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) `alpha` attribute: `canvas.getContext("2d", {alpha: false})`. In the browser tests, node-canvas matches Firefox as well as ever, and Chrome seems to have a few bugs in which canvases randomly *do* get an alpha channel.

* Adds support for the [proposed](https://github.com/WICG/canvas-color-space/blob/master/CanvasColorSpaceProposal.md) `pixelFormat` attribute: `canvas.getContext("2d", {pixelFormat: <format>})`. The color space proposal is still fairly early, and in particular the format names look like they'll change (see the open issues), but adding aliases for other formats for backwards compatibility in the future will be trivial. Even if that proposal doesn't move forward, this is nice functionality to have and a clean API (i.e. it adds options to the standard `contextOptions` object instead of positional args to the Canvas constructor).
    * `RGBA32`, `RGB24` and `A8` have full support: `getImageData`/`putImageData`/`createImageData` all work.
    * `RGB16_565` also has full support, but note: The `ImageData.data` property is a `Uint16Array` instead of a `Uint8ClampedArray` because it doesn't make sense as a uint8. This follows the linked proposal AFAICT -- `ImageData` has multiple storage types there, but [it's not specified how bit widths like 5-6-5 map to integral types](https://github.com/WICG/canvas-color-space/issues/18). This commit is easy to drop if there's any disagreement.
    * `A1` and `RGB30` have partial support: `getImageData`/`putImageData`/`createImageData` don't work because I wasn't sure how the data should be represented. Cairo packs pixels together but also has a padded stride (e.g. an A1 canvas with width 10 has a stride of 4 bytes). We could either pack all pixels together or keep them padded. This is a ton of bit manipulation given that these APIs can work on regions of a canvas. :sweat:

* Adds support (non-standard) for indexed PNG encoding. :tada: See the two new files in `examples/`. That particular image fits losslessly into 474 bytes when indexed (left), vs 1.92 kB when RGBA32 (right).

    ![indexed](https://user-images.githubusercontent.com/469365/27773482-7d8c5ccc-5f2f-11e7-986f-29fe034dfcad.png) ![rgb](https://user-images.githubusercontent.com/469365/27773483-7f386fde-5f2f-11e7-96fe-db393c511a1f.png)
    Note that it's sorta hard to specify an exact palette index using the 0-1 value in `rgba()` syntax. Adding [`#rgba` and `#rrggbbaa` support](https://www.chromestatus.com/feature/5685348285808640) will allow integers to be provided.

    Right now only `pngStream` supports this, but if this PR lands, then `toBuffer` and maybe `toDataURL` should support it also. For the former, I'd propose moving all of the `toBuffer` options into an object since the current API is awkward (see #934).

---

No breaking API changes.
Fixes #332 