### PR TITLE
Restore original exports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@ Still having problems, found a bug or want a feature? Fill out the form below.
 <!--- For bugs, provide a short, complete code example to reproduce the issue. -->
 ```js
 var Canvas = require('canvas');
-var canvas = new Canvas(200, 200);
+var canvas = Canvas.createCanvas(200, 200);
 var ctx = canvas.getContext('2d');
 // etc.
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -84,6 +84,7 @@ loadImage('examples/images/lime-cat.jpg').then((image) => {
  node-canvas adds `Image#src=Buffer` support, allowing you to read images from disc, redis, etc and apply them via `ctx.drawImage()`. Below we draw scaled down squid png by reading it from the disk with node's I/O.
 
 ```javascript
+const { Image } = require('canvas');
 fs.readFile(__dirname + '/images/squid.png', function(err, squid){
   if (err) throw err;
   img = new Image;
@@ -95,6 +96,7 @@ fs.readFile(__dirname + '/images/squid.png', function(err, squid){
  Below is an example of a canvas drawing it-self as the source several time:
 
 ```javascript
+const { Image } = require('canvas');
 var img = new Image;
 img.src = canvas.toBuffer();
 ctx.drawImage(img, 0, 0, 50, 50);
@@ -109,7 +111,8 @@ node-canvas adds `Image#dataMode` support, which can be used to opt-in to mime d
 When mime data is tracked, in PDF mode JPEGs can be embedded directly into the output, rather than being re-encoded into PNG. This can drastically reduce filesize, and speed up rendering.
 
 ```javascript
-var img = new Image;
+const { Image } = require('canvas');
+var img = new Image();
 img.dataMode = Image.MODE_IMAGE; // Only image data tracked
 img.dataMode = Image.MODE_MIME; // Only mime data tracked
 img.dataMode = Image.MODE_MIME | Image.MODE_IMAGE; // Both are tracked
@@ -214,18 +217,19 @@ canvas.toDataURL('image/jpeg', {opts...}, function(err, jpeg){ }); // see Canvas
 canvas.toDataURL('image/jpeg', quality, function(err, jpeg){ }); // spec-following; quality from 0 to 1
 ```
 
-### Canvas.registerFont for bundled fonts
+### `registerFont` for bundled fonts
 
 It can be useful to use a custom font file if you are distributing code that uses node-canvas and a specific font. Or perhaps you are using it to do automated tests and you want the renderings to be the same across operating systems regardless of what fonts are installed.
 
-To do that, you should use `Canvas.registerFont`.
+To do that, you should use `registerFont()`.
 
 **You need to call it before the Canvas is created**
 
 ```javascript
-Canvas.registerFont('comicsans.ttf', {family: 'Comic Sans'});
+const { registerFont, createCanvas } = require('canvas');
+registerFont('comicsans.ttf', {family: 'Comic Sans'});
 
-var canvas = new Canvas(500, 500),
+var canvas = createCanvas(500, 500),
   ctx = canvas.getContext('2d');
 
 ctx.font = '12px "Comic Sans"';
@@ -297,7 +301,7 @@ ctx.antialias = 'none';
   a PDF on initialization, using the "pdf" string:
 
 ```js
-var canvas = new Canvas(200, 500, 'pdf');
+var canvas = createCanvas(200, 500, 'pdf');
 ```
 
  An additional method `.addPage()` is then available to create
@@ -323,7 +327,7 @@ ctx.addPage();
  You also need to tell node-canvas that it is working on SVG upon its initialization:
 
 ```js
-var canvas = new Canvas(200, 500, 'svg');
+var canvas = createCanvas(200, 500, 'svg');
 // Use the normal primitives.
 fs.writeFile('out.svg', canvas.toBuffer());
 ```
@@ -344,7 +348,7 @@ node-canvas has experimental support for additional pixel formats, roughly
 following the [Canvas color space proposal](https://github.com/WICG/canvas-color-space/blob/master/CanvasColorSpaceProposal.md).
 
 ```js
-var canvas = new Canvas(200, 200);
+var canvas = createCanvas(200, 200);
 var ctx = canvas.getContext('2d', {pixelFormat: 'A8'});
 ```
 

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -4,9 +4,9 @@
  * milliseconds to complete.
  */
 
-var Canvas = require('../')
-var canvas = new Canvas(200, 200)
-var largeCanvas = new Canvas(1000, 1000)
+var createCanvas = require('../').createCanvas
+var canvas = createCanvas(200, 200)
+var largeCanvas = createCanvas(1000, 1000)
 var ctx = canvas.getContext('2d')
 
 var initialTimes = 10

--- a/examples/backends.js
+++ b/examples/backends.js
@@ -5,7 +5,7 @@ var Canvas = require('..')
 
 var imagebackend = new Canvas.backends.ImageBackend(800, 600)
 
-var canvas = new Canvas(imagebackend)
+var canvas = new Canvas.Canvas(imagebackend)
 var ctx = canvas.getContext('2d')
 
 console.log('Width: ' + canvas.width + ', Height: ' + canvas.height)

--- a/examples/clock.js
+++ b/examples/clock.js
@@ -104,7 +104,7 @@ function clock (ctx) {
 module.exports = clock
 
 if (require.main === module) {
-  var canvas = new Canvas(320, 320)
+  var canvas = Canvas.createCanvas(320, 320)
   var ctx = canvas.getContext('2d')
 
   clock(ctx)

--- a/examples/crop.js
+++ b/examples/crop.js
@@ -1,8 +1,7 @@
 var fs = require('fs')
 var path = require('path')
-var Canvas = require('..')
+var {createCanvas, Image} = require('..')
 
-var Image = Canvas.Image
 var img = new Image()
 
 img.onerror = function (err) {
@@ -12,7 +11,7 @@ img.onerror = function (err) {
 img.onload = function () {
   var w = img.width / 2
   var h = img.height / 2
-  var canvas = new Canvas(w, h)
+  var canvas = createCanvas(w, h)
   var ctx = canvas.getContext('2d')
 
   ctx.drawImage(img, 0, 0, w, h, 0, 0, w, h)

--- a/examples/fill-evenodd.js
+++ b/examples/fill-evenodd.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(100, 100)
+var canvas = Canvas.createCanvas(100, 100)
 var ctx = canvas.getContext('2d')
 
 ctx.fillStyle = '#f00'

--- a/examples/font.js
+++ b/examples/font.js
@@ -15,7 +15,7 @@ Canvas.registerFont(fontFile('PfennigBold.ttf'), {family: 'pfennigFont', weight:
 Canvas.registerFont(fontFile('PfennigItalic.ttf'), {family: 'pfennigFont', style: 'italic'})
 Canvas.registerFont(fontFile('PfennigBoldItalic.ttf'), {family: 'pfennigFont', weight: 'bold', style: 'italic'})
 
-var canvas = new Canvas(320, 320)
+var canvas = Canvas.createCanvas(320, 320)
 var ctx = canvas.getContext('2d')
 
 ctx.font = 'normal normal 50px Helvetica'

--- a/examples/globalAlpha.js
+++ b/examples/globalAlpha.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(150, 150)
+var canvas = Canvas.createCanvas(150, 150)
 var ctx = canvas.getContext('2d')
 
 ctx.fillStyle = '#FD0'

--- a/examples/gradients.js
+++ b/examples/gradients.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(320, 320)
+var canvas = Canvas.createCanvas(320, 320)
 var ctx = canvas.getContext('2d')
 
 // Create gradients

--- a/examples/grayscale-image.js
+++ b/examples/grayscale-image.js
@@ -3,7 +3,7 @@ var path = require('path')
 var Canvas = require('..')
 
 var Image = Canvas.Image
-var canvas = new Canvas(288, 288)
+var canvas = Canvas.createCanvas(288, 288)
 var ctx = canvas.getContext('2d')
 
 var img = new Image()

--- a/examples/image-src.js
+++ b/examples/image-src.js
@@ -3,7 +3,7 @@ var path = require(path)
 var Canvas = require('..')
 
 var Image = Canvas.Image
-var canvas = new Canvas(200, 200)
+var canvas = Canvas.createCanvas(200, 200)
 var ctx = canvas.getContext('2d')
 
 ctx.fillRect(0, 0, 150, 150)

--- a/examples/indexed-png-alpha.js
+++ b/examples/indexed-png-alpha.js
@@ -1,7 +1,7 @@
 var Canvas = require('..')
 var fs = require('fs')
 var path = require('path')
-var canvas = new Canvas(200, 200)
+var canvas = Canvas.createCanvas(200, 200)
 var ctx = canvas.getContext('2d', {pixelFormat: 'A8'})
 
 // Matches the "fillStyle" browser test, made by using alpha fillStyle value

--- a/examples/indexed-png-image-data.js
+++ b/examples/indexed-png-image-data.js
@@ -1,7 +1,7 @@
 var Canvas = require('..')
 var fs = require('fs')
 var path = require('path')
-var canvas = new Canvas(200, 200)
+var canvas = Canvas.createCanvas(200, 200)
 var ctx = canvas.getContext('2d', {pixelFormat: 'A8'})
 
 // Matches the "fillStyle" browser test, made by manipulating imageData

--- a/examples/kraken.js
+++ b/examples/kraken.js
@@ -3,7 +3,7 @@ var path = require('path')
 var Canvas = require('..')
 
 var Image = Canvas.Image
-var canvas = new Canvas(400, 267)
+var canvas = Canvas.createCanvas(400, 267)
 var ctx = canvas.getContext('2d')
 
 var img = new Image()

--- a/examples/live-clock.js
+++ b/examples/live-clock.js
@@ -3,7 +3,7 @@ var Canvas = require('..')
 
 var clock = require('./clock')
 
-var canvas = new Canvas(320, 320)
+var canvas = Canvas.createCanvas(320, 320)
 var ctx = canvas.getContext('2d')
 
 http.createServer(function (req, res) {

--- a/examples/multi-page-pdf.js
+++ b/examples/multi-page-pdf.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var Canvas = require('..')
 
-var canvas = new Canvas(500, 500, 'pdf')
+var canvas = Canvas.createCanvas(500, 500, 'pdf')
 var ctx = canvas.getContext('2d')
 
 var x, y

--- a/examples/pango-glyphs.js
+++ b/examples/pango-glyphs.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(400, 100)
+var canvas = Canvas.createCanvas(400, 100)
 var ctx = canvas.getContext('2d')
 
 ctx.globalAlpha = 1

--- a/examples/pdf-images.js
+++ b/examples/pdf-images.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var Canvas = require('..')
 
 var Image = Canvas.Image
-var canvas = new Canvas(500, 500, 'pdf')
+var canvas = Canvas.createCanvas(500, 500, 'pdf')
 var ctx = canvas.getContext('2d')
 
 var x, y

--- a/examples/ray.js
+++ b/examples/ray.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(243 * 4, 243)
+var canvas = Canvas.createCanvas(243 * 4, 243)
 var ctx = canvas.getContext('2d')
 
 function render (level) {

--- a/examples/resize.js
+++ b/examples/resize.js
@@ -14,7 +14,7 @@ img.onerror = function (err) {
 img.onload = function () {
   var width = 100
   var height = 100
-  var canvas = new Canvas(width, height)
+  var canvas = Canvas.createCanvas(width, height)
   var ctx = canvas.getContext('2d')
   var out = fs.createWriteStream(path.join(__dirname, 'resize.png'))
 

--- a/examples/small-pdf.js
+++ b/examples/small-pdf.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var Canvas = require('..')
 
-var canvas = new Canvas(400, 200, 'pdf')
+var canvas = Canvas.createCanvas(400, 200, 'pdf')
 var ctx = canvas.getContext('2d')
 
 var y = 80

--- a/examples/small-svg.js
+++ b/examples/small-svg.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var Canvas = require('..')
 
-var canvas = new Canvas(400, 200, 'svg')
+var canvas = Canvas.createCanvas(400, 200, 'svg')
 var ctx = canvas.getContext('2d')
 
 var y = 80

--- a/examples/spark.js
+++ b/examples/spark.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(40, 15)
+var canvas = Canvas.createCanvas(40, 15)
 var ctx = canvas.getContext('2d')
 
 function spark (ctx, data) {

--- a/examples/state.js
+++ b/examples/state.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(150, 150)
+var canvas = Canvas.createCanvas(150, 150)
 var ctx = canvas.getContext('2d')
 
 ctx.fillRect(0, 0, 150, 150)   // Draw a rectangle with default settings

--- a/examples/text.js
+++ b/examples/text.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var Canvas = require('..')
 
-var canvas = new Canvas(200, 200)
+var canvas = Canvas.createCanvas(200, 200)
 var ctx = canvas.getContext('2d')
 
 ctx.globalAlpha = 0.2

--- a/examples/voronoi.js
+++ b/examples/voronoi.js
@@ -1,7 +1,7 @@
 var http = require('http')
 var Canvas = require('..')
 
-var canvas = new Canvas(1920, 1200)
+var canvas = Canvas.createCanvas(1920, 1200)
 var ctx = canvas.getContext('2d')
 
 var voronoiFactory = require('./rhill-voronoi-core-min')

--- a/index.js
+++ b/index.js
@@ -1,19 +1,25 @@
 const Canvas = require('./lib/canvas')
+const Image = require('./lib/image')
+const CanvasRenderingContext2D = require('./lib/context2d')
 const parseFont = require('./lib/parse-font')
+const packageJson = require('./package.json')
+const bindings = require('./lib/bindings')
+const fs = require('fs')
+const PNGStream = require('./lib/pngstream')
+const PDFStream = require('./lib/pdfstream')
+const JPEGStream = require('./lib/jpegstream')
 
-exports.parseFont = parseFont
-
-exports.createCanvas = function (width, height, type) {
+function createCanvas(width, height, type) {
   return new Canvas(width, height, type)
 }
 
-exports.createImageData = function (array, width, height) {
-  return new Canvas.ImageData(array, width, height)
+function createImageData(array, width, height) {
+  return new bindings.ImageData(array, width, height)
 }
 
-exports.loadImage = function (src) {
+function loadImage(src) {
   return new Promise((resolve, reject) => {
-    const image = new Canvas.Image()
+    const image = new Image()
 
     function cleanup () {
       image.onload = null
@@ -25,4 +31,48 @@ exports.loadImage = function (src) {
 
     image.src = src
   })
+}
+
+/**
+ * Resolve paths for registerFont. Must be called *before* creating a Canvas
+ * instance.
+ * @param src {string} Path to font file.
+ * @param fontFace {{family: string, weight?: string, style?: string}} Object
+ * specifying font information. `weight` and `style` default to `"normal"`.
+ */
+function registerFont(src, fontFace){
+  return bindings._registerFont(fs.realpathSync(src), fontFace)
+}
+
+module.exports = {
+  Canvas,
+  Context2d: CanvasRenderingContext2D, // Legacy/compat export
+  CanvasRenderingContext2D,
+  CanvasPattern: bindings.CanvasPattern,
+  Image,
+  ImageData: bindings.ImageData,
+  PNGStream,
+  PDFStream,
+  JPEGStream,
+
+  registerFont,
+  parseFont,
+
+  createCanvas,
+  createImageData,
+  loadImage,
+
+  backends: bindings.Backends,
+
+  /** Library version. */
+  version: packageJson.version,
+  /** Cairo version. */
+  cairoVersion: bindings.cairoVersion,
+  /** jpeglib version. */
+  jpegVersion: bindings.jpegVersion,
+  /** gif_lib version. */
+  gifVersion: bindings.gifVersion ?
+    bindings.gifVersion.replace(/[^.\d]/g, '') : undefined,
+  /** freetype version. */
+  freetypeVersion: bindings.freetypeVersion,
 }

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -10,93 +10,13 @@
  * Module dependencies.
  */
 
-var canvas = require('./bindings')
-  , Backends = canvas.Backends
-  , Canvas = canvas.Canvas
-  , Image = canvas.Image
-  , cairoVersion = canvas.cairoVersion
-  , Context2d = require('./context2d')
-  , PNGStream = require('./pngstream')
-  , PDFStream = require('./pdfstream')
-  , JPEGStream = require('./jpegstream')
-  , fs = require('fs')
-  , packageJson = require("../package.json")
-  , FORMATS = ['image/png', 'image/jpeg'];
-
-/**
- * Export `Canvas` as the module.
- */
-
-var Canvas = exports = module.exports = Canvas;
-
-exports.backends = Backends;
-
-/**
- * Library version.
- */
-
-exports.version = packageJson.version;
-
-/**
- * Cairo version.
- */
-
-exports.cairoVersion = cairoVersion;
-
-/**
- * jpeglib version.
- */
-
-if (canvas.jpegVersion) {
-  exports.jpegVersion = canvas.jpegVersion;
-}
-
-/**
- * gif_lib version.
- */
-
-if (canvas.gifVersion) {
-  exports.gifVersion = canvas.gifVersion.replace(/[^.\d]/g, '');
-}
-
-/**
- * freetype version.
- */
-
-if (canvas.freetypeVersion) {
-  exports.freetypeVersion = canvas.freetypeVersion;
-}
-
-/**
- * Expose constructors.
- */
-
-exports.Context2d = Context2d;
-exports.PNGStream = PNGStream;
-exports.PDFStream = PDFStream;
-exports.JPEGStream = JPEGStream;
-exports.Image = Image;
-exports.ImageData = canvas.ImageData;
-
-/**
- * Resolve paths for registerFont
- */
-
-Canvas.registerFont = function(src, fontFace){
-  return Canvas._registerFont(fs.realpathSync(src), fontFace);
-};
-
-/**
- * Context2d implementation.
- */
-
-require('./context2d');
-
-/**
- * Image implementation.
- */
-
-require('./image');
+const bindings = require('./bindings')
+const Canvas = module.exports = bindings.Canvas
+const Context2d = require('./context2d')
+const PNGStream = require('./pngstream')
+const PDFStream = require('./pdfstream')
+const JPEGStream = require('./jpegstream')
+const FORMATS = ['image/png', 'image/jpeg']
 
 /**
  * Inspect canvas.

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -10,18 +10,12 @@
  * Module dependencies.
  */
 
-var canvas = require('./bindings')
-  , parseFont = require('./parse-font')
-  , Context2d = canvas.CanvasRenderingContext2d
-  , CanvasGradient = canvas.CanvasGradient
-  , CanvasPattern = canvas.CanvasPattern
-  , ImageData = canvas.ImageData;
-
-/**
- * Export `Context2d` as the module.
- */
-
-var Context2d = exports = module.exports = Context2d;
+const bindings = require('./bindings')
+const parseFont = require('./parse-font')
+const Context2d = module.exports = bindings.CanvasRenderingContext2d
+const CanvasGradient = bindings.CanvasGradient
+const CanvasPattern = bindings.CanvasPattern
+const ImageData = bindings.ImageData
 
 /**
  * Text baselines.

--- a/lib/image.js
+++ b/lib/image.js
@@ -10,8 +10,8 @@
  * Module dependencies.
  */
 
-var Canvas = require('./bindings')
-  , Image = Canvas.Image;
+const bindings = require('./bindings')
+const Image = module.exports = bindings.Image
 
 /**
  * Src setter.


### PR DESCRIPTION
Restores all of the previously exported functions and properties. See https://github.com/Automattic/node-canvas/pull/929#issuecomment-314305548.

NB: `parseFont` is a new export added in #929. I think `parseFont` is a private, internal API. Should it be exported?