### PR TITLE
Fix: textBaseline consider current scale.

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1901,9 +1901,12 @@ void
 Context2d::setTextPath(const char *str, double x, double y) {
   PangoRectangle ink_rect, logical_rect;
   PangoFontMetrics *metrics = NULL;
+  cairo_matrix_t matrix;
 
   pango_layout_set_text(_layout, str, -1);
   pango_cairo_update_layout(_context, _layout);
+
+  cairo_get_matrix(_context, &matrix);
 
   switch (state->textAlignment) {
     // center
@@ -1921,15 +1924,15 @@ Context2d::setTextPath(const char *str, double x, double y) {
   switch (state->textBaseline) {
     case TEXT_BASELINE_ALPHABETIC:
       metrics = PANGO_LAYOUT_GET_METRICS(_layout);
-      y -= pango_font_metrics_get_ascent(metrics) / PANGO_SCALE;
+      y -= (pango_font_metrics_get_ascent(metrics) / PANGO_SCALE) * matrix.yy;
       break;
     case TEXT_BASELINE_MIDDLE:
       metrics = PANGO_LAYOUT_GET_METRICS(_layout);
-      y -= (pango_font_metrics_get_ascent(metrics) + pango_font_metrics_get_descent(metrics))/(2.0 * PANGO_SCALE);
+      y -= ((pango_font_metrics_get_ascent(metrics) + pango_font_metrics_get_descent(metrics))/(2.0 * PANGO_SCALE)) * matrix.yy;
       break;
     case TEXT_BASELINE_BOTTOM:
       metrics = PANGO_LAYOUT_GET_METRICS(_layout);
-      y -= (pango_font_metrics_get_ascent(metrics) + pango_font_metrics_get_descent(metrics)) / PANGO_SCALE;
+      y -= ((pango_font_metrics_get_ascent(metrics) + pango_font_metrics_get_descent(metrics)) / PANGO_SCALE) * matrix.yy;
       break;
   }
 

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -2058,3 +2058,26 @@ tests['fillStyle=\'hsla(...)\''] = function (ctx) {
     }
   }
 }
+
+tests['textBaseline and scale'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 50)
+  ctx.lineTo(200, 50)
+  ctx.stroke()
+  ctx.beginPath()
+  ctx.lineTo(0, 150)
+  ctx.lineTo(200, 150)
+  ctx.stroke()
+
+  ctx.font = 'normal 20px Arial'
+  ctx.textBaseline = 'bottom'
+  ctx.textAlign = 'center'
+  ctx.fillText('bottom', 100, 50)
+
+  ctx.scale(0.1, 0.1)
+  ctx.font = 'normal 200px Arial'
+  ctx.textBaseline = 'bottom'
+  ctx.textAlign = 'center'
+  ctx.fillText('bottom', 1000, 1500)
+}


### PR DESCRIPTION
textBaseline is odd with scale() context.

Added visual test:

<img width="722" alt="invalid place" src="https://user-images.githubusercontent.com/3092/28762744-e53355f8-75f3-11e7-916d-120aa6eac006.png">

Fix: consider current context scale and apply it to font metrics.