### PR TITLE
Fix text baselines and measureText

### DIFF
--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -746,13 +746,37 @@ describe('Canvas', function () {
     });
   });
 
-  it('Context2d#measureText().width', function () {
-    var canvas = createCanvas(20, 20)
-      , ctx = canvas.getContext('2d');
+  describe('Context2d#measureText()', function () {
+    it('Context2d#measureText().width', function () {
+      var canvas = createCanvas(20, 20)
+        , ctx = canvas.getContext('2d');
 
-    assert.ok(ctx.measureText('foo').width);
-    assert.ok(ctx.measureText('foo').width != ctx.measureText('foobar').width);
-    assert.ok(ctx.measureText('foo').width != ctx.measureText('  foo').width);
+      assert.ok(ctx.measureText('foo').width);
+      assert.ok(ctx.measureText('foo').width != ctx.measureText('foobar').width);
+      assert.ok(ctx.measureText('foo').width != ctx.measureText('  foo').width);
+    });
+
+    it('works', function () {
+      var canvas = createCanvas(20, 20)
+      var ctx = canvas.getContext('2d')
+      ctx.font = "20px Arial"
+
+      ctx.textBaseline = "alphabetic"
+      var metrics = ctx.measureText("Alphabet")
+      // Zero if the given baseline is the alphabetic baseline
+      assert.equal(metrics.alphabeticBaseline, 0)
+      // Positive = going up from the baseline
+      assert.ok(metrics.actualBoundingBoxAscent > 0)
+      // Positive = going down from the baseline
+      assert.ok(metrics.actualBoundingBoxDescent > 0) // ~4-5
+
+      ctx.textBaseline = "bottom"
+      metrics = ctx.measureText("Alphabet")
+      assert.ok(metrics.alphabeticBaseline > 0) // ~4-5
+      assert.ok(metrics.actualBoundingBoxAscent > 0)
+      // On the baseline or slightly above
+      assert.ok(metrics.actualBoundingBoxDescent <= 0)
+    });
   });
 
   it('Context2d#createImageData(ImageData)', function () {

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -2163,3 +2163,95 @@ tests['textBaseline and scale'] = function (ctx) {
   ctx.textAlign = 'center'
   ctx.fillText('bottom', 1000, 1500)
 }
+
+tests['rotated baseline'] = function (ctx) {
+  ctx.font = '12px Arial'
+  ctx.fillStyle = 'black'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'bottom'
+  ctx.translate(100, 100)
+
+  for (var i = 0; i < 16; i++) {
+    ctx.fillText('Hello world!', -50, -50)
+    ctx.rotate(-Math.PI / 8)
+  }
+}
+
+tests['rotated and scaled baseline'] = function (ctx) {
+  ctx.font = '120px Arial'
+  ctx.fillStyle = 'black'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'bottom'
+  ctx.translate(100, 100)
+  ctx.scale(0.1, 0.2)
+
+  for (var i = 0; i < 16; i++) {
+    ctx.fillText('Hello world!', -50 / 0.1, -50 / 0.2)
+    ctx.rotate(-Math.PI / 8)
+  }
+}
+
+tests['rotated and skewed baseline'] = function (ctx) {
+  ctx.font = '12px Arial'
+  ctx.fillStyle = 'black'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'bottom'
+  ctx.translate(100, 100)
+  ctx.transform(1, 1, 0, 1, 1, 1)
+
+  for (var i = 0; i < 16; i++) {
+    ctx.fillText('Hello world!', -50, -50)
+    ctx.rotate(-Math.PI / 8)
+  }
+}
+
+tests['rotated, scaled and skewed baseline'] = function (ctx) {
+  // Known issue: we don't have a way to decompose the cairo matrix into the
+  // skew and rotation separately.
+  ctx.font = '120px Arial'
+  ctx.fillStyle = 'black'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'bottom'
+  ctx.translate(100, 100)
+  ctx.scale(0.1, 0.2)
+  ctx.transform(1, 1, 0, 1, 1, 1)
+
+  for (var i = 0; i < 16; i++) {
+    ctx.fillText('Hello world!', -50 / 0.1, -50 / 0.2)
+    ctx.rotate(-Math.PI / 8)
+  }
+}
+
+tests['measureText()'] = function (ctx) {
+  // Note: As of Sep 2017, Chrome is the only browser with advanced TextMetrics,
+  // and they're behind a flag, and a few of them are missing and others are
+  // wrong.
+  function drawWithBBox (text, x, y) {
+    ctx.fillText(text, x, y)
+    ctx.strokeStyle = 'red'
+    ctx.beginPath(); ctx.moveTo(0, y + 0.5); ctx.lineTo(200, y + 0.5); ctx.stroke()
+    var metrics = ctx.measureText(text)
+    ctx.strokeStyle = 'blue'
+    ctx.strokeRect(
+      x - metrics.actualBoundingBoxLeft + 0.5,
+      y - metrics.actualBoundingBoxAscent + 0.5,
+      metrics.width,
+      metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent
+    )
+  }
+
+  ctx.font = '20px Arial'
+  ctx.textBaseline = 'alphabetic'
+  drawWithBBox('Alphabet alphabetic', 20, 50)
+
+  drawWithBBox('weruoasnm', 50, 175) // no ascenders/descenders
+
+  drawWithBBox(',', 100, 125) // tiny height
+
+  ctx.textBaseline = 'bottom'
+  drawWithBBox('Alphabet bottom', 20, 90)
+
+  ctx.textBaseline = 'alphabetic'
+  ctx.rotate(Math.PI / 8)
+  drawWithBBox('Alphabet', 50, 100)
+}


### PR DESCRIPTION
* Fixes text baseline adjustment (`fillText`, `strokeText`, `measureText`), including when rotation and scale transforms are active. (Fixes #983)
* Fixes `measureText` results. Some had the wrong signs and/or weren't adjusting for the baseline properly.

tl;dr: Fixes stuff, no regressions, still not perfect.

---

### Baselines
*The good* - these are fixed:
![image](https://user-images.githubusercontent.com/469365/29992990-22be2532-8f5e-11e7-8d22-a04782393210.png)

*The bad* - this still doesn't work:
![image](https://user-images.githubusercontent.com/469365/29992988-15c61696-8f5e-11e7-8f2d-99e2445c2ac4.png)
Known issue: all we have is the current transformation matrix, and it's impossible to uniquely decompose that matrix into the scale, rotation and skew matrices. (We need the scale matrix only to adjust the pango metrics.) See https://math.stackexchange.com/questions/1415854/decompose-affine-transformation-including-shear-in-x-and-y and the linked questions. Given that the Canvas spec defines `context.transform(a, b, c, d, e, f)` which thus lets you define a skew, scale and rotation simultaneously, I don't know what to do ... but I think skew is relatively rare, and this PR is an improvement over what it was. Haven't looked what browsers do; they might have tighter integration of their text and graphics libraries that avoids this problem.

---

### `measureText`
Also tricky because there's nothing to compare against. Chrome is the only browser with any support right now, but I think some of their values and [test assertions](https://chromium.googlesource.com/chromium/src/+/master/third_party/WebKit/LayoutTests/fast/canvas/canvas-textMetrics-all.html) are wrong as I noted in [my comment](https://bugs.chromium.org/p/chromium/issues/detail?id=277215). (Definitions in the spec are [here](https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-width-2). There's also an [older polyfill](https://github.com/motiz88/canvas-text-metrics-polyfill) with [visual tests](https://rawgit.com/motiz88/canvas-text-metrics-polyfill/master/tests/visual-test.html) -- the logic for drawing the bounding box in the new `tests['measureText()']` test matches [the logic from the polyfill's tests](https://github.com/motiz88/canvas-text-metrics-polyfill/blob/master/tests/visual-test.js#L39-L42) so I feel reasonably comfortable that the metrics are now correct.)

![image](https://user-images.githubusercontent.com/469365/29992992-2dfd7eb6-8f5e-11e7-85b6-453d3ab00027.png)
(left is node-canvas, right is Chrome with the experimental canvas flag enabled)