### PR TITLE
Add prebuilds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+install:
+  - npm install --build-from-source
 node_js:
   - '8'
   - '6'

--- a/Readme.md
+++ b/Readme.md
@@ -27,9 +27,13 @@
 $ npm install canvas
 ```
 
-Unless previously installed you'll _need_ __Cairo__ and __Pango__. For system-specific installation view the [Wiki](https://github.com/Automattic/node-canvas/wiki/_pages).
+By default, binaries for macOS, Linux and Windows will be downloaded. If you want to build from source, use `npm install --build-from-source`.
 
 Currently the minimum version of node required is __4.0.0__
+
+### Compiling
+
+If you don't have a supported OS or processor architecture, or you use `--build-from-source`, the module will be compiled on your system. Unless previously installed you'll _need_ __Cairo__ and __Pango__. For system-specific installation view the [Wiki](https://github.com/Automattic/node-canvas/wiki/_pages).
 
 You can quickly install the dependencies by using the command for your OS:
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Canvas graphics API backed by Cairo",
   "version": "2.0.0-alpha.5",
   "author": "TJ Holowaychuk <tj@learnboost.com>",
+  "main": "index.js",
   "browser": "browser.js",
   "contributors": [
     "Nathan Rajlich <nathan@tootallnate.net>",
@@ -27,9 +28,17 @@
     "pretest": "node-gyp build",
     "test": "standard examples/*.js test/server.js test/public/*.js benchmark/run.js util/has_lib.js browser.js index.js && mocha test/*.test.js",
     "pretest-server": "node-gyp build",
-    "test-server": "node test/server.js"
+    "test-server": "node test/server.js",
+    "install": "node-pre-gyp install"
+  },
+  "binary": {
+    "module_name": "canvas-prebuilt",
+    "module_path": "build/Release",
+    "host": "https://github.com/node-gfx/node-canvas-prebuilt/releases/download/",
+    "remote_path": "v{version}"
   },
   "dependencies": {
+    "node-pre-gyp": "^0.6.36",
     "nan": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`canvas-prebuilt` has been working for a year now, and the latest version of the Linux build has broad compatibility. This would try to download the binaries from the prebuilt repo before `node-gyp` and hopefully cut down on a lot of installation issues.

You can check out this branch and `npm install` to try it out.

If we do go forward with this I can give access to @LinusU and @zbjornson and maybe others to the prebuilt repo, and document the release process better. It basically involves setting environment variables to indicate which version you want to build and release, and then you re-build the latest commit on AppVeyor/Travis.

(We could also use `prebuild-install`, it has half the dependencies which is nice. But (1) `node-pre-gyp` is more popular and thus more likely to already be installed and (2) `prebuild-install` is not compatible with `canvas-prebuilt`'s tarball structure (fixable for later versions)).

edit: ~~Forgot this affects CI too, will fix that soon~~ fixed, ~~but CI is stalled now~~ CI fixed