### PR TITLE
Support currentTransform

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const fs = require('fs')
 const PNGStream = require('./lib/pngstream')
 const PDFStream = require('./lib/pdfstream')
 const JPEGStream = require('./lib/jpegstream')
+const DOMMatrix = require('./lib/DOMMatrix').DOMMatrix
+const DOMPoint = require('./lib/DOMMatrix').DOMPoint
 
 function createCanvas (width, height, type) {
   return new Canvas(width, height, type)
@@ -56,6 +58,8 @@ module.exports = {
   PNGStream,
   PDFStream,
   JPEGStream,
+  DOMMatrix,
+  DOMPoint,
 
   registerFont,
   parseFont,

--- a/lib/DOMMatrix.js
+++ b/lib/DOMMatrix.js
@@ -1,0 +1,479 @@
+'use strict'
+
+// DOMMatrix per https://drafts.fxtf.org/geometry/#DOMMatrix
+
+function DOMPoint(x, y, z, w) {
+  if (!(this instanceof DOMPoint)) {
+    throw new TypeError("Class constructors cannot be invoked without 'new'")
+  }
+
+  if (typeof x === 'object') {
+    w = x.w
+    z = x.z
+    y = x.y
+    x = x.x
+  }
+  this.x = typeof x === 'number' ? x : 0
+  this.y = typeof y === 'number' ? y : 0
+  this.z = typeof z === 'number' ? z : 0
+  this.w = typeof w === 'number' ? w : 1
+}
+
+// Constants to index into _values (col-major)
+const M11 = 0, M12 = 1, M13 = 2, M14 = 3
+const M21 = 4, M22 = 5, M23 = 6, M24 = 7
+const M31 = 8, M32 = 9, M33 = 10, M34 = 11
+const M41 = 12, M42 = 13, M43 = 14, M44 = 15
+
+const DEGREE_PER_RAD = 180 / Math.PI
+const RAD_PER_DEGREE = Math.PI / 180
+
+function parseMatrix(init) {
+  var parsed = init.replace(/matrix\(/, '')
+  parsed = parsed.split(/,/, 7) // 6 + 1 to handle too many params
+  if (parsed.length !== 6) throw new Error(`Failed to parse ${init}`)
+  parsed = parsed.map(parseFloat)
+  return [
+    parsed[0], parsed[1], 0, 0,
+    parsed[2], parsed[3], 0, 0,
+    0, 0, 1, 0,
+    parsed[4], parsed[5], 0, 1
+  ]
+}
+
+function parseMatrix3d(init) {
+  var parsed = init.replace(/matrix3d\(/, '')
+  parsed = parsed.split(/,/, 17) // 16 + 1 to handle too many params
+  if (parsed.length !== 16) throw new Error(`Failed to parse ${init}`)
+  return parsed.map(parseFloat)
+}
+
+function parseTransform(tform) {
+  var type = tform.split(/\(/, 1)[0]
+  switch (type) {
+    case 'matrix':
+      return parseMatrix(tform)
+    case 'matrix3d':
+      return parseMatrix3d(tform)
+    // TODO This is supposed to support any CSS transform value.
+    default:
+      throw new Error(`${type} parsing not implemented`)
+  }
+}
+
+function DOMMatrix (init) {
+  if (!(this instanceof DOMMatrix)) {
+    throw new TypeError("Class constructors cannot be invoked without 'new'")
+  }
+
+  this._is2D = true
+  this._values = new Float64Array([
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  ])
+
+  var i
+
+  if (typeof init === 'string') { // parse CSS transformList
+    if (init === '') return // default identity matrix
+    var tforms = init.split(/\)\s+/, 20).map(parseTransform)
+    if (tforms.length === 0) return
+    init = tforms[0]
+    for (i = 1; i < tforms.length; i++) init = multiply(tforms[i], init)
+  }
+
+  i = 0
+  if (init && init.length === 6) {
+    setNumber2D(this, M11, init[i++])
+    setNumber2D(this, M12, init[i++])
+    setNumber2D(this, M21, init[i++])
+    setNumber2D(this, M22, init[i++])
+    setNumber2D(this, M41, init[i++])
+    setNumber2D(this, M42, init[i++])
+  } else if (init && init.length === 16) {
+    setNumber2D(this, M11, init[i++])
+    setNumber2D(this, M12, init[i++])
+    setNumber3D(this, M13, init[i++])
+    setNumber3D(this, M14, init[i++])
+    setNumber2D(this, M21, init[i++])
+    setNumber2D(this, M22, init[i++])
+    setNumber3D(this, M23, init[i++])
+    setNumber3D(this, M24, init[i++])
+    setNumber3D(this, M31, init[i++])
+    setNumber3D(this, M32, init[i++])
+    setNumber3D(this, M33, init[i++])
+    setNumber3D(this, M34, init[i++])
+    setNumber2D(this, M41, init[i++])
+    setNumber2D(this, M42, init[i++])
+    setNumber3D(this, M43, init[i++])
+    setNumber3D(this, M44, init[i])
+  } else if (init !== undefined) {
+    throw new TypeError('Expected string or array.')
+  }
+}
+
+DOMMatrix.fromMatrix = function (init) {
+  if (!(init instanceof DOMMatrix)) throw new TypeError('Expected DOMMatrix')
+  return new DOMMatrix(init._values)
+}
+DOMMatrix.fromFloat32Array = function (init) {
+  if (!(init instanceof Float32Array)) throw new TypeError('Expected Float32Array')
+  return new DOMMatrix(init)
+}
+DOMMatrix.fromFloat64Array = function (init) {
+  if (!(init instanceof Float64Array)) throw new TypeError('Expected Float64Array')
+  return new DOMMatrix(init)
+}
+
+DOMMatrix.prototype.inspect = function (depth, options) {
+  if (depth < 0) return '[DOMMatrix]'
+
+  return `DOMMatrix [
+    a: ${this.a}
+    b: ${this.b}
+    c: ${this.c}
+    d: ${this.d}
+    e: ${this.e}
+    f: ${this.f}
+    m11: ${this.m11}
+    m12: ${this.m12}
+    m13: ${this.m13}
+    m14: ${this.m14}
+    m21: ${this.m21}
+    m22: ${this.m22}
+    m23: ${this.m23}
+    m23: ${this.m23}
+    m31: ${this.m31}
+    m32: ${this.m32}
+    m33: ${this.m33}
+    m34: ${this.m34}
+    m41: ${this.m41}
+    m42: ${this.m42}
+    m43: ${this.m43}
+    m44: ${this.m44}
+    is2D: ${this.is2D}
+    isIdentity: ${this.isIdentity} ]`
+}
+
+DOMMatrix.prototype.toString = function () {
+  return this.is2D ?
+    `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.e}, ${this.f})` :
+    `matrix3d(${this._values.join(', ')})`
+}
+
+/**
+ * Checks that `value` is a number and sets the value.
+ */
+function setNumber2D(receiver, index, value) {
+  if (typeof value !== 'number') throw new TypeError('Expected number')
+  return receiver._values[index] = value
+}
+
+/**
+ * Checks that `value` is a number, sets `_is2D = false` if necessary and sets
+ * the value.
+ */
+function setNumber3D(receiver, index, value) {
+  if (typeof value !== 'number') throw new TypeError('Expected number')
+  if (index === M33 || index === M44) {
+    if (value !== 1) receiver._is2D = false
+  } else if (value !== 0) receiver._is2D = false
+  return receiver._values[index] = value
+}
+
+Object.defineProperties(DOMMatrix.prototype, {
+  m11: {get: function () { return this._values[M11] }, set: function (v) { return setNumber2D(this, M11, v) }},
+  m12: {get: function () { return this._values[M12] }, set: function (v) { return setNumber2D(this, M12, v) }},
+  m13: {get: function () { return this._values[M13] }, set: function (v) { return setNumber3D(this, M13, v) }},
+  m14: {get: function () { return this._values[M14] }, set: function (v) { return setNumber3D(this, M14, v) }},
+  m21: {get: function () { return this._values[M21] }, set: function (v) { return setNumber2D(this, M21, v) }},
+  m22: {get: function () { return this._values[M22] }, set: function (v) { return setNumber2D(this, M22, v) }},
+  m23: {get: function () { return this._values[M23] }, set: function (v) { return setNumber3D(this, M23, v) }},
+  m24: {get: function () { return this._values[M24] }, set: function (v) { return setNumber3D(this, M24, v) }},
+  m31: {get: function () { return this._values[M31] }, set: function (v) { return setNumber3D(this, M31, v) }},
+  m32: {get: function () { return this._values[M32] }, set: function (v) { return setNumber3D(this, M32, v) }},
+  m33: {get: function () { return this._values[M33] }, set: function (v) { return setNumber3D(this, M33, v) }},
+  m34: {get: function () { return this._values[M34] }, set: function (v) { return setNumber3D(this, M34, v) }},
+  m41: {get: function () { return this._values[M41] }, set: function (v) { return setNumber2D(this, M41, v) }},
+  m42: {get: function () { return this._values[M42] }, set: function (v) { return setNumber2D(this, M42, v) }},
+  m43: {get: function () { return this._values[M43] }, set: function (v) { return setNumber3D(this, M43, v) }},
+  m44: {get: function () { return this._values[M44] }, set: function (v) { return setNumber3D(this, M44, v) }},
+
+  a: {get: function () { return this.m11 }, set: function (v) { return this.m11 = v }},
+  b: {get: function () { return this.m12 }, set: function (v) { return this.m12 = v }},
+  c: {get: function () { return this.m21 }, set: function (v) { return this.m21 = v }},
+  d: {get: function () { return this.m22 }, set: function (v) { return this.m22 = v }},
+  e: {get: function () { return this.m41 }, set: function (v) { return this.m41 = v }},
+  f: {get: function () { return this.m42 }, set: function (v) { return this.m42 = v }},
+
+  is2D: {get: function () { return this._is2D }}, // read-only
+
+  isIdentity: {
+    get: function () {
+      var values = this._values
+      return values[M11] === 1 && values[M12] === 0 && values[M13] === 0 && values[M14] === 0 &&
+             values[M21] === 0 && values[M22] === 1 && values[M23] === 0 && values[M24] === 0 &&
+             values[M31] === 0 && values[M32] === 0 && values[M33] === 1 && values[M34] === 0 &&
+             values[M41] === 0 && values[M42] === 0 && values[M43] === 0 && values[M44] === 1
+    }
+  }
+})
+
+/**
+ * Instantiates a DOMMatrix, bypassing the constructor.
+ * @param {Float64Array} values Value to assign to `_values`. This is assigned
+ *   without copying (okay because all usages are followed by a  multiply).
+ */
+function newInstance(values) {
+  var instance = Object.create(DOMMatrix.prototype)
+  instance.constructor = DOMMatrix
+  instance._is2D = true
+  instance._values = values
+  return instance
+}
+
+function multiply(A, B) {
+  var dest = new Float64Array(16)
+  for (var i = 0; i < 4; i++) {
+    for (var j = 0; j < 4; j++) {
+      var sum = 0
+      for (var k = 0; k < 4; k++) {
+        sum += A[i * 4 + k] * B[k * 4 + j]
+      }
+      dest[i * 4 + j] = sum
+    }
+  }
+  return dest
+}
+
+DOMMatrix.prototype.multiply = function (other) {
+  return newInstance(this._values).multiplySelf(other)
+}
+DOMMatrix.prototype.multiplySelf = function (other) {
+  this._values = multiply(other._values, this._values)
+  if (!other.is2D) this._is2D = false
+  return this
+}
+DOMMatrix.prototype.preMultiplySelf = function (other) {
+  this._values = multiply(this._values, other._values)
+  if (!other.is2D) this._is2D = false
+  return this
+}
+
+DOMMatrix.prototype.translate = function (tx, ty, tz) {
+  return newInstance(this._values).translateSelf(tx, ty, tz)
+}
+DOMMatrix.prototype.translateSelf = function (tx, ty, tz) {
+  if (typeof tx !== 'number') tx = 0
+  if (typeof ty !== 'number') ty = 0
+  if (typeof tz !== 'number') tz = 0
+  this._values = multiply([
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    tx, ty, tz, 1
+  ], this._values)
+  if (tz !== 0) this._is2D = false
+  return this
+}
+
+DOMMatrix.prototype.scale = function (scaleX, scaleY, scaleZ, originX, originY, originZ) {
+  return newInstance(this._values).scaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ)
+}
+DOMMatrix.prototype.scale3d = function (scale, originX, originY, originZ) {
+  return newInstance(this._values).scale3dSelf(scale, originX, originY, originZ)
+}
+DOMMatrix.prototype.scale3dSelf = function (scale, originX, originY, originZ) {
+  return this.scaleSelf(scale, scale, scale, originX, originY, originZ)
+}
+DOMMatrix.prototype.scaleSelf = function (scaleX, scaleY, scaleZ, originX, originY, originZ) {
+  // Not redundant with translate's checks because we need to negate the values later.
+  if (typeof originX !== 'number') originX = 0
+  if (typeof originY !== 'number') originY = 0
+  if (typeof originZ !== 'number') originZ = 0
+  this.translateSelf(originX, originY, originZ)
+  if (typeof scaleX !== 'number') scaleX = 1
+  if (typeof scaleY !== 'number') scaleY = scaleX
+  if (typeof scaleZ !== 'number') scaleZ = 1
+  this._values = multiply([
+    scaleX, 0, 0, 0,
+    0, scaleY, 0, 0,
+    0, 0, scaleZ, 0,
+    0, 0, 0, 1
+  ], this._values)
+  this.translateSelf(-originX, -originY, -originZ)
+  if (scaleZ !== 1 || originZ !== 0) this._is2D = false
+  return this
+}
+
+DOMMatrix.prototype.rotateFromVector = function (x, y) {
+  return newInstance(this._values).rotateFromVectorSelf(x, y)
+}
+DOMMatrix.prototype.rotateFromVectorSelf = function (x, y) {
+  if (typeof x !== 'number') x = 0
+  if (typeof y !== 'number') y = 0
+  var theta = (x === 0 && y === 0) ? 0 : Math.atan2(y, x) * DEGREE_PER_RAD
+  return this.rotateSelf(theta)
+}
+DOMMatrix.prototype.rotate = function (rotX, rotY, rotZ) {
+  return newInstance(this._values).rotateSelf(rotX, rotY, rotZ)
+}
+DOMMatrix.prototype.rotateSelf = function (rotX, rotY, rotZ) {
+  if (rotY === undefined && rotZ === undefined) {
+    rotZ = rotX
+    rotX = rotY = 0
+  }
+  if (typeof rotY !== 'number') rotY = 0
+  if (typeof rotZ !== 'number') rotZ = 0
+  if (rotX !== 0 || rotY !== 0) this._is2D = false
+  rotX *= RAD_PER_DEGREE
+  rotY *= RAD_PER_DEGREE
+  rotZ *= RAD_PER_DEGREE
+  var c, s
+  c = Math.cos(rotZ)
+  s = Math.sin(rotZ)
+  this._values = multiply([
+    c, s, 0, 0,
+    -s, c, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  ], this._values)
+  c = Math.cos(rotY)
+  s = Math.sin(rotY)
+  this._values = multiply([
+    c, 0, -s, 0,
+    0, 1, 0, 0,
+    s, 0, c, 0,
+    0, 0, 0, 1
+  ], this._values)
+  c = Math.cos(rotX)
+  s = Math.sin(rotX)
+  this._values = multiply([
+    1, 0, 0, 0,
+    0, c, s, 0,
+    0, -s, c, 0,
+    0, 0, 0, 1
+  ], this._values)
+  return this
+}
+
+DOMMatrix.prototype.rotateAxisAngle = function (x, y, z, angle) {
+  return newInstance(this._values).rotateAxisAngleSelf(x, y, z, angle)
+}
+DOMMatrix.prototype.rotateAxisAngleSelf = function (x, y, z, angle) {
+  if (typeof x !== 'number') x = 0
+  if (typeof y !== 'number') y = 0
+  if (typeof z !== 'number') z = 0
+  // Normalize axis
+  var length = Math.sqrt(x * x + y * y + z * z)
+  if (length === 0) return this
+  if (length !== 1) {
+    x /= length
+    y /= length
+    z /= length
+  }
+  angle *= RAD_PER_DEGREE
+  var c = Math.cos(angle)
+  var s = Math.sin(angle)
+  var t = 1 - c
+  var tx = t * x
+  var ty = t * y
+  // NB: This is the generic transform. If the axis is a major axis, there are
+  // faster transforms.
+  this._values = multiply([
+    tx * x + c,      tx * y + s * z,  tx * z - s * y,  0,
+    tx * y - s * z,  ty * y + c,      ty * z + s * x,  0,
+    tx * z + s * y,  ty * z - s * x,  t * z * z + c,   0,
+    0,               0,               0,               1
+  ], this._values)
+  if (x !== 0 || y !== 0) this._is2D = false
+  return this
+}
+
+DOMMatrix.prototype.skewX = function (sx) {
+  return newInstance(this._values).skewXSelf(sx)
+}
+DOMMatrix.prototype.skewXSelf = function (sx) {
+  if (typeof sx !== 'number') return this
+  var t = Math.tan(sx * RAD_PER_DEGREE)
+  this._values = multiply([
+    1, 0, 0, 0,
+    t, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  ], this._values)
+  return this
+}
+
+DOMMatrix.prototype.skewY = function (sy) {
+  return newInstance(this._values).skewYSelf(sy)
+}
+DOMMatrix.prototype.skewYSelf = function (sy) {
+  if (typeof sy !== 'number') return this
+  var t = Math.tan(sy * RAD_PER_DEGREE)
+  this._values = multiply([
+    1, t, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  ], this._values)
+  return this
+}
+
+DOMMatrix.prototype.flipX = function () { 
+  return newInstance(multiply([
+    -1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  ], this._values))
+}
+DOMMatrix.prototype.flipY = function () {
+  return newInstance(multiply([
+    1, 0, 0, 0,
+    0, -1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  ], this._values))
+}
+
+DOMMatrix.prototype.inverse = function () {
+  return newInstance(this._values).invertSelf()
+}
+DOMMatrix.prototype.invertSelf = function () {
+  // If not invertible, set all attributes to NaN and is2D to false
+  throw new Error('Not implemented')
+}
+
+DOMMatrix.prototype.setMatrixValue = function (transformList) {
+  var temp = new DOMMatrix(transformList)
+  this._values = temp._values
+  this._is2D = temp._is2D
+  return this
+}
+
+DOMMatrix.prototype.transformPoint = function (point) {
+  point = new DOMPoint(point)
+  var x = point.x
+  var y = point.y
+  var z = point.z
+  var w = point.w
+  var values = this._values
+  var nx = values[M11] * x + values[M21] * y + values[M31] * z + values[M41] * w
+  var ny = values[M12] * x + values[M22] * y + values[M32] * z + values[M42] * w
+  var nz = values[M13] * x + values[M23] * y + values[M33] * z + values[M43] * w
+  var nw = values[M14] * x + values[M24] * y + values[M34] * z + values[M44] * w
+  return new DOMPoint(nx, ny, nz, nw)
+}
+
+DOMMatrix.prototype.toFloat32Array = function () { 
+  return Float32Array.from(this._values)
+}
+
+DOMMatrix.prototype.toFloat64Array = function () { 
+  return this._values.slice(0)
+}
+
+module.exports = {DOMMatrix, DOMPoint}

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -16,6 +16,7 @@ const Context2d = module.exports = bindings.CanvasRenderingContext2d
 const CanvasGradient = bindings.CanvasGradient
 const CanvasPattern = bindings.CanvasPattern
 const ImageData = bindings.ImageData
+const DOMMatrix = require('./DOMMatrix')
 
 /**
  * Text baselines.
@@ -102,6 +103,20 @@ Context2d.prototype.setTransform = function(){
   this.resetTransform();
   this.transform.apply(this, arguments);
 };
+
+Object.defineProperty(Context2d.prototype, 'currentTransform', {
+  get: function () {
+    var values = new Float64Array(6)
+    this._getMatrix(values)
+    return new DOMMatrix(values)
+  },
+  set: function (m) {
+    if (!(m instanceof DOMMatrix)) {
+      throw new TypeError('Expected DOMMatrix')
+    }
+    this.setTransform(m.a, m.b, m.c, m.d, m.e, m.f)
+  }
+})
 
 /**
  * Set the fill style with the given css color string.

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -126,6 +126,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   Nan::SetPrototypeMethod(ctor, "_setStrokePattern", SetStrokePattern);
   Nan::SetPrototypeMethod(ctor, "_setTextBaseline", SetTextBaseline);
   Nan::SetPrototypeMethod(ctor, "_setTextAlignment", SetTextAlignment);
+  Nan::SetPrototypeMethod(ctor, "_getMatrix", GetMatrix);
   Nan::SetAccessor(proto, Nan::New("pixelFormat").ToLocalChecked(), GetFormat);
   Nan::SetAccessor(proto, Nan::New("patternQuality").ToLocalChecked(), GetPatternQuality, SetPatternQuality);
   Nan::SetAccessor(proto, Nan::New("globalCompositeOperation").ToLocalChecked(), GetGlobalCompositeOperation, SetGlobalCompositeOperation);
@@ -1789,6 +1790,22 @@ NAN_METHOD(Context2d::Transform) {
 NAN_METHOD(Context2d::ResetTransform) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_identity_matrix(context->context());
+}
+
+NAN_METHOD(Context2d::GetMatrix) {
+  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+  // Accept a receiver array to avoid an alloc (this small array will be
+  // a view of a larger, shared ArrayBuffer).
+  Local<Float64Array> destTa = info[0].As<Float64Array>();
+  Nan::TypedArrayContents<double> dest(destTa);
+  cairo_matrix_t matrix;
+  cairo_get_matrix(context->context(), &matrix);
+  (*dest)[0] = matrix.xx;
+  (*dest)[1] = matrix.yx;
+  (*dest)[2] = matrix.xy;
+  (*dest)[3] = matrix.yy;
+  (*dest)[4] = matrix.x0;
+  (*dest)[5] = matrix.y0;
 }
 
 /*

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -99,6 +99,7 @@ class Context2d: public Nan::ObjectWrap {
     static NAN_METHOD(ArcTo);
     static NAN_METHOD(Ellipse);
     static NAN_METHOD(GetImageData);
+    static NAN_METHOD(GetMatrix);
     static NAN_GETTER(GetFormat);
     static NAN_GETTER(GetPatternQuality);
     static NAN_GETTER(GetGlobalCompositeOperation);

--- a/test/dommatrix.test.js
+++ b/test/dommatrix.test.js
@@ -1,0 +1,469 @@
+/* eslint-env mocha */
+
+'use stricit'
+
+const DOMMatrix = require('../').DOMMatrix
+
+const assert = require('assert')
+
+// This doesn't need to be precise; we're not testing the engine's trig
+// implementations.
+const TOLERANCE = 0.001
+function assertApprox(actual, expected, tolerance) {
+  if (typeof tolerance !== 'number') tolerance = TOLERANCE
+  assert.ok(expected > actual - tolerance && expected < actual + tolerance,
+    `Expected ${expected} to equal ${actual} +/- ${tolerance}`)
+}
+function assertApproxDeep(actual, expected, tolerance) {
+  expected.forEach(function (value, index) {
+    assertApprox(actual[index], value)
+  })
+}
+
+describe('DOMMatrix', function () {
+  var Avals = [4,5,1,8, 0,3,6,1, 3,5,0,9, 2,4,6,1]
+  var Bvals = [1,5,1,0, 0,3,6,1, 3,5,7,2, 2,0,6,1]
+  var AxB   = [7,25,31,22, 20,43,24,58, 37,73,45,94, 28,44,8,71]
+  var BxA   = [23,40,89,15, 20,39,66,16, 21,30,87,14, 22,52,74,17]
+
+  describe('constructor, general', function () {
+    it('aliases a,b,c,d,e,f properly', function () {
+      var y = new DOMMatrix(Avals)
+      assert.strictEqual(y.a, y.m11)
+      assert.strictEqual(y.b, y.m12)
+      assert.strictEqual(y.c, y.m21)
+      assert.strictEqual(y.d, y.m22)
+      assert.strictEqual(y.e, y.m41)
+      assert.strictEqual(y.f, y.m42)
+    })
+
+    it('parses lists of transforms per spec', function () {
+      var y = new DOMMatrix('matrix(1, -2, 3.2, 4.5e2, 3.5E-1, +2) matrix(1, 2, 4, 1, 0, 0)')
+      assert.strictEqual(y.a, 7.4)
+      assert.strictEqual(y.b, 898)
+      assert.strictEqual(y.c, 7.2)
+      assert.strictEqual(y.d, 442)
+      assert.strictEqual(y.e, 0.35)
+      assert.strictEqual(y.f, 2)
+      assert.strictEqual(y.is2D, true)
+    })
+
+    it('parses matrix2d(<16 numbers>) per spec', function () {
+      var y = new DOMMatrix('matrix3d(1, -0, 0, 0, -2.12, 1, 0, 0, 3e2, 0, +1, 1.252, 0, 0, 0, 1)')
+      assert.deepEqual(y.toFloat64Array(), [
+        1, 0, 0, 0,
+        -2.12, 1, 0, 0,
+        300, 0, 1, 1.252,
+        0, 0, 0, 1
+      ])
+      assert.strictEqual(y.is2D, false)
+    })
+
+    it('sets is2D to true if matrix2d(<16 numbers>) is 2D', function () {
+      var y = new DOMMatrix('matrix3d(1, 2, 0, 0, 3, 4, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)')
+      assert.deepEqual(y.toFloat64Array(), [
+        1, 2, 0, 0,
+        3, 4, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+      assert.strictEqual(y.is2D, true)
+    })
+  })
+
+  describe('fromMatrix', function () {})
+  describe('fromFloat32Array', function () {})
+  describe('fromFloat64Array', function () {})
+
+  describe('multiply', function () {
+    it('performs self.other, returning a new DOMMatrix', function () {
+      var A = new DOMMatrix(Avals)
+      var B = new DOMMatrix(Bvals)
+      var C = B.multiply(A)
+      assert.deepEqual(C.toFloat64Array(), BxA)
+      assert.notStrictEqual(A, C)
+      assert.notStrictEqual(B, C)
+    })
+  })
+
+  describe('multiplySelf', function () {
+    it('performs self.other, mutating self', function () {
+      var A = new DOMMatrix(Avals)
+      var B = new DOMMatrix(Bvals)
+      var C = B.multiplySelf(A)
+      assert.deepEqual(C.toFloat64Array(), BxA)
+      assert.strictEqual(C, B)
+    })
+  })
+
+  describe('preMultiplySelf', function () {
+    it('performs other.self, mutating self', function () {
+      var A = new DOMMatrix(Avals)
+      var B = new DOMMatrix(Bvals)
+      var C = B.preMultiplySelf(A)
+      assert.deepEqual(C.toFloat64Array(), AxB)
+      assert.strictEqual(C, B)
+    })
+  })
+
+  describe('translate', function () {})
+
+  describe('translateSelf', function () {
+    it('works, 1 arg', function () {
+      var A = new DOMMatrix()
+      A.translateSelf(1)
+      assert.deepEqual(A.toFloat64Array(), [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        1, 0, 0, 1
+      ])
+    })
+
+    it('works, 2 args', function () {
+      var A = new DOMMatrix(Avals)
+      var C = A.translateSelf(2, 5)
+      assert.deepEqual(C.toFloat64Array(), [
+        4, 5, 1, 8,
+        0, 3, 6, 1,
+        3, 5, 0, 9,
+        10, 29, 38, 22
+      ])
+    })
+
+    it('works, 3 args', function () {
+      var A = new DOMMatrix()
+      A.translateSelf(1, 2, 3)
+      assert.deepEqual(A.toFloat64Array(), [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        1, 2, 3, 1
+      ])
+    })
+  })
+
+  describe('scale', function () {
+    var x = new DOMMatrix()
+    it('works, 1 arg', function () {
+      assert.deepEqual(x.scale(2).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 2, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+    })
+
+    it('works, 2 args', function () {
+      assert.deepEqual(x.scale(2, 3).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 3, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+    })
+
+    it('works, 3 args', function () {
+      assert.deepEqual(x.scale(2, 3, 4).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 3, 0, 0,
+        0, 0, 4, 0,
+        0, 0, 0, 1
+      ])
+    })
+
+    it('works, 4 args', function () {
+      assert.deepEqual(x.scale(2, 3, 4, 5).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 3, 0, 0,
+        0, 0, 4, 0,
+        -5, 0, 0, 1
+      ])
+    })
+
+    it('works, 5 args', function () {
+      assert.deepEqual(x.scale(2, 3, 4, 5, 6).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 3, 0, 0,
+        0, 0, 4, 0,
+        -5, -12, 0, 1
+      ])
+    })
+
+    it('works, 6 args', function () {
+      assert.deepEqual(x.scale(2, 1, 1, 0, 0, 0).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+
+      assert.deepEqual(x.scale(2, 3, 2, 0, 0, 0).toFloat64Array(), [
+        2, 0, 0, 0,
+        0, 3, 0, 0,
+        0, 0, 2, 0,
+        0, 0, 0, 1
+      ])
+
+      assert.deepEqual(x.scale(5, -1, 2, 1, 3, 2).toFloat64Array(), [
+        5, 0, 0, 0,
+        0, -1, 0, 0,
+        0, 0, 2, 0,
+        -4, 6, -2, 1
+      ])
+    })
+  })
+
+  describe('scaleSelf', function () {})
+
+  describe('scale3d', function () {
+    var x = new DOMMatrix(Avals)
+
+    it('works, 0 args', function () {
+      assert.deepEqual(x.scale3d().toFloat64Array(), Avals)
+    })
+
+    it('works, 1 arg', function () {
+      assert.deepEqual(x.scale3d(2).toFloat64Array(), [
+        8, 10, 2, 16,
+        0, 6, 12, 2,
+        6, 10, 0, 18,
+        2, 4, 6, 1
+      ])
+    })
+
+    it('works, 2 args', function () {
+      assert.deepEqual(x.scale3d(2, 3).toFloat64Array(), [
+        8, 10, 2, 16,
+        0, 6, 12, 2,
+        6, 10, 0, 18,
+        -10, -11, 3, -23
+      ])
+    })
+
+    it('works, 3 args', function () {
+      assert.deepEqual(x.scale3d(2, 3, 4).toFloat64Array(), [
+        8, 10, 2, 16,
+        0, 6, 12, 2,
+        6, 10, 0, 18,
+        -10, -23, -21, -27
+      ])
+    })
+
+    it('works, 4 args', function () {
+      assert.deepEqual(x.scale3d(2, 3, 4, 5).toFloat64Array(), [
+        8, 10, 2, 16,
+        0, 6, 12, 2,
+        6, 10, 0, 18,
+        -25, -48, -21, -72
+      ])
+    })
+  })
+
+  describe('scale3dSelf', function () {})
+
+  describe('rotate', function () {
+    it('works, 1 arg', function () {
+      var x = new DOMMatrix()
+      var y = x.rotate(70)
+      assertApproxDeep(y.toFloat64Array(), [
+        0.3420201, 0.9396926, 0, 0,
+        -0.939692, 0.3420201, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+    })
+
+    it('works, 2 args', function () {
+      var x = new DOMMatrix()
+      var y = x.rotate(70, 30)
+      assertApproxDeep(y.toFloat64Array(), [
+        0.8660254, 0, -0.5, 0,
+        0.4698463, 0.3420201, 0.8137976, 0,
+        0.1710100, -0.9396926, 0.2961981, 0,
+        0, 0, 0, 1
+      ])
+      assert.strictEqual(y.is2D, false)
+    })
+
+    it('works, 3 args', function () {
+      var x = new DOMMatrix()
+      var y = x.rotate(70, 30, 50)
+      assertApproxDeep(y.toFloat64Array(), [
+        0.5566703, 0.6634139, -0.5, 0,
+        0.0400087, 0.5797694, 0.8137976, 0,
+        0.8297694, -0.4730214, 0.2961981, 0,
+        0, 0, 0, 1])
+    })
+  })
+
+  describe('rotateSelf', function () {})
+
+  describe('rotateFromVector', function () {
+    var x = new DOMMatrix(Avals)
+    it('works, no args and x/y=0', function () {
+      assert.deepEqual(x.rotateFromVector().toFloat64Array(), Avals)
+      assert.deepEqual(x.rotateFromVector(5).toFloat64Array(), Avals)
+      assert.deepEqual(x.rotateFromVector(0, 0).toFloat64Array(), Avals)
+    })
+
+    it('works', function () {
+      var y = x.rotateFromVector(4, 2).toFloat64Array()
+      var expect = [
+        3.5777087, 5.8137767, 3.5777087, 7.6026311,
+        -1.7888543, 0.4472135, 4.9193495, -2.6832815,
+        3, 5, 0, 9,
+        2, 4, 6, 1
+      ]
+      assertApproxDeep(expect, y)
+    })
+  })
+
+  describe('rotateFromVectorSelf', function () {})
+
+  describe('rotateAxisAngle', function () {
+    it('works, 0 args', function () {
+      var x = new DOMMatrix(Avals)
+      var y = x.rotateAxisAngle().toFloat64Array()
+      assert.deepEqual(y, Avals)
+    })
+
+    it('works, 4 args', function () {
+      var x = new DOMMatrix(Avals)
+      var y = x.rotateAxisAngle(2, 4, 1, 35).toFloat64Array()
+      var expect = [
+        1.9640922, 2.4329989, 2.0179538, 2.6719387,
+        0.6292488, 4.0133545, 5.6853755, 3.0697681,
+        4.5548203, 6.0805840, -0.7774101, 11.3770500,
+        2, 4, 6, 1
+      ]
+      assertApproxDeep(expect, y)
+    })
+  })
+
+  describe('rotateFromAngleSelf', function () {})
+
+  describe('skewX', function () {
+    it('works', function () {
+      var x = new DOMMatrix(Avals)
+      var y = x.skewX(30).toFloat64Array()
+      var expect = [
+        4, 5, 1, 8,
+        2.3094010, 5.8867513, 6.5773502, 5.6188021,
+        3, 5, 0, 9,
+        2, 4, 6, 1
+      ]
+      assertApproxDeep(expect, y)
+    })
+  })
+
+  describe('skewXSelf', function () {})
+
+  describe('skewY', function () {
+    it('works', function () {
+      var x = new DOMMatrix(Avals)
+      var y = x.skewY(30).toFloat64Array()
+      var expect = [
+        4, 6.7320508, 4.4641016, 8.5773502,
+        0, 3, 6, 1,
+        3, 5, 0, 9,
+        2, 4, 6, 1
+      ]
+      assertApproxDeep(expect, y)
+    })
+  })
+
+  describe('skewYSelf', function () {})
+  
+  describe('flipX', function () {
+    it('works', function () {
+      var x = new DOMMatrix()
+      x.rotateSelf(70)
+      var y = x.flipX()
+      assertApprox(y.a, -0.34202)
+      assertApprox(y.b, -0.93969)
+      assertApprox(y.c, -0.93969)
+      assertApprox(y.d, 0.34202)
+      assert.strictEqual(y.e, 0)
+      assert.strictEqual(y.f, 0)
+    })
+  })
+
+  describe('flipY', function () {
+    it('works', function () {
+      var x = new DOMMatrix()
+      x.rotateSelf(70)
+      var y = x.flipY()
+      assertApprox(y.a, 0.34202)
+      assertApprox(y.b, 0.93969)
+      assertApprox(y.c, 0.93969)
+      assertApprox(y.d, -0.34202)
+      assert.strictEqual(y.e, 0)
+      assert.strictEqual(y.f, 0)
+    })
+  })
+
+  describe('inverse', function () {})
+  describe('invertSelf', function () {})
+
+  describe('transformPoint', function () {
+    it('works', function () {
+      var x = new DOMMatrix()
+      var r = x.transformPoint({x: 1, y: 2, z: 3})
+      assert.strictEqual(r.x, 1)
+      assert.strictEqual(r.y, 2)
+      assert.strictEqual(r.z, 3)
+      assert.strictEqual(r.w, 1)
+
+      x.rotateSelf(70)
+      r = x.transformPoint({x: 2, y: 3, z: 4})
+      assertApprox(r.x, -2.13503)
+      assertApprox(r.y, 2.905445)
+      assert.strictEqual(r.z, 4)
+      assert.strictEqual(r.w, 1)
+    })
+  })
+
+  describe('toFloat32Array', function () {
+    it('works', function () {
+      var x = new DOMMatrix()
+      var y = x.toFloat32Array()
+      assert.ok(y instanceof Float32Array)
+      assert.deepEqual(y, [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+    })
+  })
+  
+  describe('toFloat64Array', function () {
+    it('works', function () {
+      var x = new DOMMatrix()
+      var y = x.toFloat64Array()
+      assert.ok(y instanceof Float64Array)
+      assert.deepEqual(y, [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ])
+    })
+  })
+
+  describe('toString', function () {
+    it('works, 2d', function () {
+      var x = new DOMMatrix()
+      assert.equal(x.toString(), 'matrix(1, 0, 0, 1, 0, 0)')
+    })
+
+    it('works, 3d', function () {
+      var x = new DOMMatrix()
+      x.m31 = 1
+      assert.equal(x.is2D, false)
+      assert.equal(x.toString(),
+        'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1)')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #658

---

I maybe went overboard by (almost) fully implementing `DOMPoint` and `DOMMatrix` (almost: skipped `invertSelf`/`inverse` and most of the CSS transforms that should be accepted in the constructor). If you want to keep the code base small, I could replace it with just an object exposing the matrix values, with none of the methods. (Would put the rest of the implementation in a separate module or donate it to jsdom if they want it.)

Also, this isn't super optimized since I don't expect the methods will get used much.

**Edit** Option 3 could be putting `DOMMatrix` in a separate optional module, and if it's present, `currentTransform` will return an instance of that; otherwise it'll be a plain object or a minimal implementation with just the a/b/c/d/e/f/mXY properties. Sort of like how jsdom integrates with canvas.