### PR TITLE
Fix memory leak when img onerror/onload callbacks reference img

### DIFF
--- a/src/Image.h
+++ b/src/Image.h
@@ -40,14 +40,10 @@ class Image: public Nan::ObjectWrap {
     char *filename;
     int width, height;
     int naturalWidth, naturalHeight;
-    Nan::Callback *onload;
-    Nan::Callback *onerror;
     static Nan::Persistent<FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetSource);
-    static NAN_GETTER(GetOnload);
-    static NAN_GETTER(GetOnerror);
     static NAN_GETTER(GetComplete);
     static NAN_GETTER(GetWidth);
     static NAN_GETTER(GetHeight);
@@ -55,8 +51,6 @@ class Image: public Nan::ObjectWrap {
     static NAN_GETTER(GetNaturalHeight);
     static NAN_GETTER(GetDataMode);
     static NAN_SETTER(SetSource);
-    static NAN_SETTER(SetOnload);
-    static NAN_SETTER(SetOnerror);
     static NAN_SETTER(SetDataMode);
     static NAN_SETTER(SetWidth);
     static NAN_SETTER(SetHeight);


### PR DESCRIPTION
Storing the `onerror`/`onload` callback functions in Persistent handles (here, as `Nan::Callback`s) means they will never be GC'ed automatically; only when the Image destructor runs, which explicitly resets them. But, if those functions have references to the image, then the image will never be GC'ed. --> leak

I'm annoyed that I can't figure out how to do this from C++ after thinking about it all day. I have an [open message on the v8-users list](https://groups.google.com/forum/#!topic/v8-users/QtTwdok_MeQ) to see if there's a way, but this method also removes 87 lines of code. The only benefit to doing it in C++ is that we can type check the value and only set it if it's a function. Up to you if you want to wait a bit to see if someone responds.

Fixes #785
Fixes #150 (for real)

---

Code that repros the leak:

```js
const fs = require("fs");
const Canvas = require(".");

const imgsrc = fs.readFileSync("./test/fixtures/clock.png");

const canvas = new Canvas.Canvas(15000, 15000);
const ctx = canvas.getContext("2d");

var invocations = 0;

// Causes leak:
for (var k = 0; k < 5; k++) {
  gc();
  console.log(process.memoryUsage().rss);
  for (var i = 0; i < 1000; i++) {
    const img = new Canvas.Image();
    img.onload = _ => {
      if (img.width > 0) invocations++;
      // img.src= null; // frees a bunch of memory but doesn't actually invoke ~Image
    }
    img.src = imgsrc;
  }
}

// Doesn't cause leak:
// for (var k = 0; k < 5; k++) {
//   gc();
//   console.log(process.memoryUsage().rss);
//   for (var i = 0; i < 10000; i++) {
//     const img = new Canvas.Image();
//     img.onload = _ => invocations++;
//     img.src = imgsrc;
//   }
// }
```

In master:
24535040
466857984
908058624
1347592192

This PR:
24571904
26157056
26300416
25919488
24920064