### PR TITLE
fix incorrect path to cairo

### DIFF
--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -7,12 +7,7 @@
 #include <exception>
 
 #include <nan.h>
-
-#if HAVE_PANGO
-  #include <pango/pangocairo.h>
-#else
-  #include <cairo/cairo.h>
-#endif
+#include <cairo.h>
 
 class Canvas;
 


### PR DESCRIPTION
I'm not sure what's going on here, but

* `HAVE_PANGO` is not a thing anymore
* `cairo/cario.h` is not the correct path to Cairo

Not sure how it was building successfully, but one time it failed on me and this fixed it