### PR TITLE
Fix reading fillStyle after setting it from gradient to color

### DIFF
--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -187,6 +187,7 @@ Context2d.prototype.__defineSetter__('fillStyle', function(val){
     this.lastFillStyle = val;
     this._setFillPattern(val);
   } else if ('string' == typeof val) {
+    this.lastFillStyle = undefined;
     this._setFillColor(val);
   }
 });

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -387,6 +387,10 @@ tests['createLinearGradient()'] = function(ctx){
 
   ctx.fillRect(10,10,130,130);
   ctx.strokeRect(50,50,50,50);
+
+  ctx.fillStyle = '#13b575';
+  ctx.fillStyle = ctx.fillStyle;
+  ctx.fillRect(65,65,20,20);
 };
 
 tests['createRadialGradient()'] = function(ctx){


### PR DESCRIPTION
The getter for `fillStyle` in context2d.js prioritizes `this.lastFillStyle` over `this.fillColor`, so it needs to be cleared when we set `fillStyle` to a color.

I modified the linear gradient test so that it shows the behavior.