### PR TITLE
Add /usr/lib64 to the list of system paths

### DIFF
--- a/util/has_lib.js
+++ b/util/has_lib.js
@@ -5,6 +5,7 @@ var childProcess = require('child_process')
 var SYSTEM_PATHS = [
   '/lib',
   '/usr/lib',
+  '/usr/lib64',
   '/usr/local/lib',
   '/opt/local/lib',
   '/usr/lib/x86_64-linux-gnu',


### PR DESCRIPTION
**Problem:** On CentOS, node-canvas is not supporting jpeg images (we were getting the `Image given has not completed loading` error discussed in other issues (such as https://github.com/Automattic/node-canvas/issues/289)

**Cause:** The cause of the particular error that we were experiencing was that, on CentOS, the `libjpeg-turbo-devel` library is installed in the `/usr/lib64` folder, which is not listed among the paths for lib checking.

**Solution:** This PR adds `/usr/lib64` to the list of paths that are checked for the presence of system libs.