### PR TITLE
Make Context2d's currentTransform configurable

### DIFF
--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -115,7 +115,8 @@ Object.defineProperty(Context2d.prototype, 'currentTransform', {
       throw new TypeError('Expected DOMMatrix')
     }
     this.setTransform(m.a, m.b, m.c, m.d, m.e, m.f)
-  }
+  },
+  configurable: true
 })
 
 /**


### PR DESCRIPTION
This allows the library to be used with the jest test runner.

See https://github.com/targos/canvas-jest for a simple repro.
