### PR TITLE
Add install instructions for MacPorts on OS X

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ You can quickly install the dependencies by using the command for your OS:
 
 OS | Command
 ----- | -----
-OS X | `brew install pkg-config cairo pango libpng jpeg giflib`
+OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib`<br/><br/>Using [MacPorts](https://www.macports.org/):<br/>`port install pkgconfig cairo pango libpng jpeg giflib`
 Ubuntu | `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
 Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
 Solaris | `pkgin install cairo pango pkg-config xproto renderproto kbproto xextproto`


### PR DESCRIPTION
Also adds a link for MacPorts/Homebrew sites for those not already familiar with these package managers.