### PR TITLE
Sanitize some parameters before HasInstance calls

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -552,6 +552,8 @@ NAN_METHOD(Context2d::New) {
     return Nan::ThrowTypeError("Class constructors cannot be invoked without 'new'");
   }
 
+  if (!info[0]->IsObject())
+    return Nan::ThrowTypeError("Canvas expected");
   Local<Object> obj = info[0]->ToObject();
   if (!Nan::New(Canvas::constructor)->HasInstance(obj))
     return Nan::ThrowTypeError("Canvas expected");
@@ -816,6 +818,10 @@ NAN_METHOD(Context2d::GetImageData) {
 NAN_METHOD(Context2d::DrawImage) {
   if (info.Length() < 3)
     return Nan::ThrowTypeError("invalid arguments");
+  if (!info[0]->IsObject()
+    || !info[1]->IsNumber()
+    || !info[2]->IsNumber())
+    return Nan::ThrowTypeError("Expected object, number and number");
 
   float sx = 0
     , sy = 0
@@ -1424,6 +1430,8 @@ NAN_METHOD(Context2d::IsPointInPath) {
  */
 
 NAN_METHOD(Context2d::SetFillPattern) {
+  if (!info[0]->IsObject())
+    return Nan::ThrowTypeError("Gradient or Pattern expected");
   Local<Object> obj = info[0]->ToObject();
   if (Nan::New(Gradient::constructor)->HasInstance(obj)){
     Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
@@ -1443,6 +1451,8 @@ NAN_METHOD(Context2d::SetFillPattern) {
  */
 
 NAN_METHOD(Context2d::SetStrokePattern) {
+  if (!info[0]->IsObject())
+    return Nan::ThrowTypeError("Gradient or Pattern expected");
   Local<Object> obj = info[0]->ToObject();
   if (Nan::New(Gradient::constructor)->HasInstance(obj)){
     Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());


### PR DESCRIPTION
Some parameters were passed to HasInstance without being checked first.
If they were null, this would crash the entire nodejs engine.
Throw a proper exception instead.

I actually had my tests fail on this, and I had a hard time finding where this was from, because the output was actually not very explicit:
```
% jest tests/unit/classification-pane.spec.js

 RUNS  tests/unit/classification-pane.spec.js
zsh: segmentation fault (core dumped)  node_modules/.bin/jest 
```

It seems that fetching an image resulted in an error because of the test environment, and that my code resulted in calling `DrawImage` with a `null` (or `undefined`?) image.
This patch fixes the issue, and prevents it for a few other functions.
Hope it helps someone not having my gdb-fu 😉 