### PR TITLE
Update readme to use libjpeg-dev dummy package

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ You can quickly install the dependencies by using the command for your OS:
 OS | Command
 ----- | -----
 OS X | `brew install pkg-config cairo libpng jpeg giflib`
-Ubuntu | `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
+Ubuntu | `sudo apt-get install libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++`
 Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
 Solaris | `pkgin install cairo pkg-config xproto renderproto kbproto xextproto`
 Windows | [Instructions on our wiki](https://github.com/Automattic/node-canvas/wiki/Installation---Windows)


### PR DESCRIPTION
Resolves to libjpeg8 for pre-Jessie and libjpeg62-turbo for Jessie+