### PR TITLE
Add support for context globalAlpha for gradients and patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas",
   "description": "Canvas graphics API backed by Cairo",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "author": "TJ Holowaychuk <tj@learnboost.com>",
   "contributors": [
     "Nathan Rajlich <nathan@tootallnate.net>",

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -70,7 +70,7 @@ NAN_METHOD(Pattern::New) {
 
 
 /*
- * Initialize linear gradient.
+ * Initialize pattern.
  */
 
 Pattern::Pattern(cairo_surface_t *surface) {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -341,12 +341,10 @@ create_transparent_pattern(cairo_pattern_t *source, float alpha) {
     height);
   cairo_t *mask_context = cairo_create(mask_surface);
   if (cairo_status(mask_context) != CAIRO_STATUS_SUCCESS) {
-    // context creation failed. Return the original source and destroy the surface
     Nan::ThrowError("Failed to initialize context");
   }
   cairo_set_source(mask_context, source);
   cairo_paint_with_alpha(mask_context, alpha);
-  // remove the context, but not the surface since is owned by the pattern
   cairo_destroy(mask_context);
   cairo_pattern_t* newPattern = cairo_pattern_create_for_surface(mask_surface);
   cairo_surface_destroy(mask_surface);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -370,7 +370,7 @@ Context2d::setFillRule(v8::Local<v8::Value> value) {
 
 void
 Context2d::fill(bool preserve) {
-  cairo_pattern_t *new_pattern = nullptr;
+  cairo_pattern_t *new_pattern = NULL;
   if (state->fillPattern) {
     if (state->globalAlpha < 1) {
       new_pattern = create_transparent_pattern(state->fillPattern, state->globalAlpha);
@@ -402,7 +402,7 @@ Context2d::fill(bool preserve) {
       ? shadow(cairo_fill)
       : cairo_fill(_context);
   }
-  if (new_pattern != state->fillPattern && new_pattern != nullptr) {
+  if (new_pattern != state->fillPattern && new_pattern != NULL) {
     cairo_pattern_destroy(new_pattern);
   }
 }
@@ -413,7 +413,7 @@ Context2d::fill(bool preserve) {
 
 void
 Context2d::stroke(bool preserve) {
-  cairo_pattern_t *new_pattern = nullptr;
+  cairo_pattern_t *new_pattern = NULL;
   if (state->strokePattern) {
     if (state->globalAlpha < 1) {
       new_pattern = create_transparent_pattern(state->strokePattern, state->globalAlpha);
@@ -444,7 +444,7 @@ Context2d::stroke(bool preserve) {
       ? shadow(cairo_stroke)
       : cairo_stroke(_context);
   }
-  if (new_pattern != state->strokePattern && new_pattern != nullptr) {
+  if (new_pattern != state->strokePattern && new_pattern != NULL) {
     cairo_pattern_destroy(new_pattern);
   }
 }

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -321,6 +321,7 @@ create_transparent_gradient(cairo_pattern_t *source, float alpha) {
     newGradient = cairo_pattern_create_radial(x0, y0, r0, x1, y1, r1);
   } else {
     Nan::ThrowError("Unexpected gradient type");
+    return source;
   }
   for ( i = 0; i < count; i++ ) {
     cairo_pattern_get_color_stop_rgba(source, i, &offset, &r, &g, &b, &a);
@@ -342,6 +343,7 @@ create_transparent_pattern(cairo_pattern_t *source, float alpha) {
   cairo_t *mask_context = cairo_create(mask_surface);
   if (cairo_status(mask_context) != CAIRO_STATUS_SUCCESS) {
     Nan::ThrowError("Failed to initialize context");
+    return source;
   }
   cairo_set_source(mask_context, source);
   cairo_paint_with_alpha(mask_context, alpha);
@@ -374,7 +376,9 @@ Context2d::fill(bool preserve) {
     if (state->globalAlpha < 1) {
       new_pattern = create_transparent_pattern(state->fillPattern, state->globalAlpha);
       cairo_set_source(_context, new_pattern);
-      cairo_pattern_destroy(new_pattern);
+      if (new_pattern != state->fillPattern) {
+        cairo_pattern_destroy(new_pattern);
+      }
     } else {
       cairo_set_source(_context, state->fillPattern);
     }
@@ -386,7 +390,9 @@ Context2d::fill(bool preserve) {
       new_pattern = create_transparent_gradient(state->fillGradient, state->globalAlpha);
       cairo_pattern_set_filter(new_pattern, state->patternQuality);
       cairo_set_source(_context, new_pattern);
-      cairo_pattern_destroy(new_pattern);
+      if (new_pattern != state->fillGradient) {
+        cairo_pattern_destroy(new_pattern);
+      }
     } else {
       cairo_pattern_set_filter(state->fillGradient, state->patternQuality);
       cairo_set_source(_context, state->fillGradient);
@@ -416,7 +422,9 @@ Context2d::stroke(bool preserve) {
     if (state->globalAlpha < 1) {
       new_pattern = create_transparent_pattern(state->strokePattern, state->globalAlpha);
       cairo_set_source(_context, new_pattern);
-      cairo_pattern_destroy(new_pattern);
+      if (new_pattern != state->strokePattern) {
+        cairo_pattern_destroy(new_pattern);
+      }
     } else {
       cairo_set_source(_context, state->strokePattern);
     }
@@ -426,7 +434,9 @@ Context2d::stroke(bool preserve) {
       new_pattern = create_transparent_gradient(state->strokeGradient, state->globalAlpha);
       cairo_pattern_set_filter(new_pattern, state->patternQuality);
       cairo_set_source(_context, new_pattern);
-      cairo_pattern_destroy(new_pattern);
+      if (new_pattern != state->strokeGradient) {
+        cairo_pattern_destroy(new_pattern);
+      }
     } else {
       cairo_pattern_set_filter(state->strokeGradient, state->patternQuality);
       cairo_set_source(_context, state->strokeGradient);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -375,10 +375,12 @@ Context2d::fill(bool preserve) {
   if (state->fillPattern) {
     if (state->globalAlpha < 1) {
       new_pattern = create_transparent_pattern(state->fillPattern, state->globalAlpha);
-      cairo_set_source(_context, new_pattern);
-      if (new_pattern != state->fillPattern) {
-        cairo_pattern_destroy(new_pattern);
+      if (new_pattern == state->fillPattern) {
+        // failed to allocate; Nan::ThrowError has already been called, so return from this fn.
+        return;
       }
+      cairo_set_source(_context, new_pattern);
+      cairo_pattern_destroy(new_pattern);
     } else {
       cairo_set_source(_context, state->fillPattern);
     }
@@ -421,10 +423,12 @@ Context2d::stroke(bool preserve) {
   if (state->strokePattern) {
     if (state->globalAlpha < 1) {
       new_pattern = create_transparent_pattern(state->strokePattern, state->globalAlpha);
-      cairo_set_source(_context, new_pattern);
-      if (new_pattern != state->strokePattern) {
-        cairo_pattern_destroy(new_pattern);
+      if (new_pattern == state->strokePattern) {
+        // failed to allocate; Nan::ThrowError has already been called, so return from this fn.
+        return;
       }
+      cairo_set_source(_context, new_pattern);
+      cairo_pattern_destroy(new_pattern);
     } else {
       cairo_set_source(_context, state->strokePattern);
     }

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -465,6 +465,7 @@ tests['createLinearGradient() and transforms'] = function(ctx){
   ctx.lineTo(100, 100);
   ctx.lineTo(-100, 100);
   ctx.closePath();
+  ctx.globalAlpha = 0.5;
   ctx.rotate(1.570795);
   ctx.scale(0.6, 0.6);
   ctx.fill();

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -371,6 +371,18 @@ tests['clip() 2'] = function(ctx){
   }
 };
 
+tests['createPattern()'] = function(ctx, done) {
+  var img = new Image;
+  img.onload = function(){
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.scale(0.1, 0.1)
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 2000, 2000);
+    done();
+  };
+  img.src = 'face.jpeg';
+};
+
 tests['createLinearGradient()'] = function(ctx){
   var lingrad = ctx.createLinearGradient(0,0,0,150);
   lingrad.addColorStop(0, '#00ABEB');
@@ -385,6 +397,25 @@ tests['createLinearGradient()'] = function(ctx){
   ctx.fillStyle = lingrad;
   ctx.strokeStyle = lingrad2;
 
+  ctx.fillRect(10,10,130,130);
+  ctx.strokeRect(50,50,50,50);
+};
+
+tests['createLinearGradient() with opacity'] = function(ctx){
+  ctx.globalAlpha = 0.2;
+  var lingrad = ctx.createLinearGradient(0,0,0,150);
+  lingrad.addColorStop(0, '#00ABEB');
+  lingrad.addColorStop(0.5, '#fff');
+  lingrad.addColorStop(0.5, '#26C000');
+  lingrad.addColorStop(1, '#fff');
+
+  var lingrad2 = ctx.createLinearGradient(0,50,0,95);
+  lingrad2.addColorStop(0.5, '#000');
+  lingrad2.addColorStop(1, 'rgba(0,0,0,0)');
+
+  ctx.fillStyle = lingrad;
+  ctx.strokeStyle = lingrad2;
+  ctx.globalAlpha = 0.2;
   ctx.fillRect(10,10,130,130);
   ctx.strokeRect(50,50,50,50);
 };
@@ -426,6 +457,17 @@ tests['globalAlpha'] = function(ctx){
   ctx.globalAlpha = 0.5;
   ctx.fillStyle = 'rgba(0,0,0,0.5)';
   ctx.strokeRect(0,0,50,50);
+  ctx.fillRect(70,0,50,50);
+
+  ctx.globalAlpha = 0.25;
+  ctx.fillStyle = 'rgba(0,0,0,1)';
+  ctx.fillRect(70,70,50,50);
+
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = 'rgba(0,0,0,0.25)';
+  ctx.fillRect(70,140,50,50);
+
+
 
   ctx.globalAlpha = 0.8;
   ctx.fillRect(20,20,20,20);

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -375,9 +375,29 @@ tests['createPattern()'] = function(ctx, done) {
   var img = new Image;
   img.onload = function(){
     var pattern = ctx.createPattern(img, 'repeat');
-    ctx.scale(0.1, 0.1)
+    ctx.scale(0.1, 0.1);
     ctx.fillStyle = pattern;
-    ctx.fillRect(0, 0, 2000, 2000);
+    ctx.fillRect(100, 100, 800, 800);
+    ctx.strokeStyle = pattern;
+    ctx.lineWidth = 200
+    ctx.strokeRect(1100, 1100, 800, 800);
+    done();
+  };
+  img.src = 'face.jpeg';
+};
+
+tests['createPattern() with globalAlpha'] = function(ctx, done) {
+  var img = new Image;
+  img.onload = function(){
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.scale(0.1, 0.1);
+    ctx.globalAlpha = 0.6;
+    ctx.fillStyle = pattern;
+    ctx.fillRect(100, 100, 800, 800);
+    ctx.globalAlpha = 0.2;
+    ctx.strokeStyle = pattern;
+    ctx.lineWidth = 200
+    ctx.strokeRect(1100, 1100, 800, 800);
     done();
   };
   img.src = 'face.jpeg';
@@ -399,25 +419,55 @@ tests['createLinearGradient()'] = function(ctx){
 
   ctx.fillRect(10,10,130,130);
   ctx.strokeRect(50,50,50,50);
+
+  var lingrad = ctx.createLinearGradient(0,0,200,0);
+  lingrad.addColorStop(0, 'rgba(0,255,0,0.5)');
+  lingrad.addColorStop(0.33, 'rgba(255,255,0,0.5)');
+  lingrad.addColorStop(0.66, 'rgba(0,255,255,0.5)');
+  lingrad.addColorStop(1, 'rgba(255,0,255,0.5)');
+  ctx.fillStyle = lingrad;
+  ctx.fillRect(0,170,200,30);
 };
 
 tests['createLinearGradient() with opacity'] = function(ctx){
-  ctx.globalAlpha = 0.2;
-  var lingrad = ctx.createLinearGradient(0,0,0,150);
-  lingrad.addColorStop(0, '#00ABEB');
-  lingrad.addColorStop(0.5, '#fff');
-  lingrad.addColorStop(0.5, '#26C000');
-  lingrad.addColorStop(1, '#fff');
-
-  var lingrad2 = ctx.createLinearGradient(0,50,0,95);
-  lingrad2.addColorStop(0.5, '#000');
-  lingrad2.addColorStop(1, 'rgba(0,0,0,0)');
-
+  var lingrad = ctx.createLinearGradient(0,0,0,200);
+  lingrad.addColorStop(0, '#00FF00');
+  lingrad.addColorStop(0.33, '#FF0000');
+  lingrad.addColorStop(0.66, '#0000FF');
+  lingrad.addColorStop(1, '#00FFFF');
   ctx.fillStyle = lingrad;
-  ctx.strokeStyle = lingrad2;
-  ctx.globalAlpha = 0.2;
-  ctx.fillRect(10,10,130,130);
-  ctx.strokeRect(50,50,50,50);
+  ctx.strokeStyle = lingrad;
+  ctx.lineWidth = 10;
+  ctx.globalAlpha = 0.4;
+  ctx.strokeRect(5,5,190,190);
+  ctx.fillRect(0,0,50,50);
+  ctx.globalAlpha = 0.6;
+  ctx.strokeRect(35,35,130,130);
+  ctx.fillRect(50,50,50,50);
+  ctx.globalAlpha = 0.8;
+  ctx.strokeRect(65,65,70,70);
+  ctx.fillRect(100,100,50,50);
+  ctx.globalAlpha = 0.95;
+  ctx.fillRect(150,150,50,50);
+};
+
+tests['createLinearGradient() and transforms'] = function(ctx){
+  var lingrad = ctx.createLinearGradient(0,-100,0,100);
+  lingrad.addColorStop(0, '#00FF00');
+  lingrad.addColorStop(0.33, '#FF0000');
+  lingrad.addColorStop(0.66, '#0000FF');
+  lingrad.addColorStop(1, '#00FFFF');
+  ctx.fillStyle = lingrad;
+  ctx.translate(100, 100);
+  ctx.beginPath();
+  ctx.moveTo(-100, -100);
+  ctx.lineTo(100, -100);
+  ctx.lineTo(100, 100);
+  ctx.lineTo(-100, 100);
+  ctx.closePath();
+  ctx.rotate(1.570795);
+  ctx.scale(0.6, 0.6);
+  ctx.fill();
 };
 
 tests['createRadialGradient()'] = function(ctx){


### PR DESCRIPTION
close #1061

So this is another discrepancy i found out inspecting differences between browser canvas and node-canvas.

Pattern and gradients are always solid.

Now i added those tests here:
Pattern fil and stroke, with and without opacity
![image](https://user-images.githubusercontent.com/1194048/34250013-dee1b150-e63b-11e7-9f13-beeceeb54097.png)

Gradients with rgba, gradients and globalAlpha and gradients and trasnforms
![image](https://user-images.githubusercontent.com/1194048/34250028-ee5c6a26-e63b-11e7-973b-52415c5ee27b.png)


The code is a bit ... meh ...
The point of the fix for patterns i think is ok, i pick up the chosen pattern, i create a new surface that is as big as the pattern surface, i paint it with alpha, i create a new pattern from that surface.
This is the only thing that was working for me.

For Gradients i do same, create a new gradient, multiply alpha and move on,

I just created 2 functions in the the code, i did not make them class method, i m not a C++ or node-gyp dev, so this is what i could do, i m open to suggestion to improve it.

I also think i have to destroy some resources after this process, any hint how/where?