### PR TITLE
Define CAIRO_FORMAT_INVALID for old Cairo versions

### DIFF
--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -50,7 +50,14 @@ class Backend : public Nan::ObjectWrap
     virtual void setHeight(int height);
 
     // Overridden by ImageBackend. SVG and PDF thus always return INVALID.
-    virtual cairo_format_t getFormat() { return CAIRO_FORMAT_INVALID; }
+    virtual cairo_format_t getFormat() {
+#ifndef CAIRO_FORMAT_INVALID
+      // For old Cairo (CentOS) support
+      return static_cast<cairo_format_t>(-1);
+#else
+      return CAIRO_FORMAT_INVALID;
+#endif
+    }
 };
 
 


### PR DESCRIPTION
Fixes #1067
Fixes #1039
Fixes #1012?
Fixes #1051 

CentOS 6.x includes Cairo 1.8.8, which doesn't have this defined.