### PR TITLE
Update font example to mention Fontname

### DIFF
--- a/examples/font.js
+++ b/examples/font.js
@@ -9,7 +9,7 @@ function fontFile (name) {
 // Pass each font, including all of its individual variants if there are any, to
 // `registerFont`. When you set `ctx.font`, refer to the styles and the family
 // name as it is embedded in the TTF. If you aren't sure, open the font in
-// FontForge and visit Element -> Font Information and copy the Family Name
+// FontForge and visit Element -> Font Information and copy the 'Fontname'
 Canvas.registerFont(fontFile('Pfennig.ttf'), {family: 'pfennigFont'})
 Canvas.registerFont(fontFile('PfennigBold.ttf'), {family: 'pfennigFont', weight: 'bold'})
 Canvas.registerFont(fontFile('PfennigItalic.ttf'), {family: 'pfennigFont', style: 'italic'})


### PR DESCRIPTION
Inside of FontForge, the `Fontname` property is what should be referenced and then used as the `family` value for `registerfont`, not `Family Name`.