### PR TITLE
Support disabling chroma subsampling in JPEG output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -177,6 +177,7 @@ var stream = canvas.jpegStream({
     bufsize: 4096 // output buffer size in bytes, default: 4096
   , quality: 75 // JPEG quality (0-100) default: 75
   , progressive: false // true for progressive compression, default: false
+  , disableChromaSubsampling: false // true to disable 2x2 subsampling of the chroma components, default: false
 });
 ```
 

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -94,6 +94,8 @@ Canvas.prototype.createJPEGStream = function(options){
       bufsize: clampedBufSize
     , quality: options.quality || 75
     , progressive: options.progressive || false
+    , chromaHSampFactor: options.disableChromaSubsampling ? 1 : 2
+    , chromaVSampFactor: options.disableChromaSubsampling ? 1 : 2
   });
 };
 

--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -54,7 +54,9 @@ JPEGStream.prototype._read = function _read() {
   var bufsize = this.options.bufsize;
   var quality = this.options.quality;
   var progressive = this.options.progressive;
-  self.canvas.streamJPEGSync(bufsize, quality, progressive, function(err, chunk){
+  var chromaHSampFactor = this.options.chromaHSampFactor;
+  var chromaVSampFactor = this.options.chromaVSampFactor;
+  self.canvas.streamJPEGSync(bufsize, quality, progressive, chromaHSampFactor, chromaVSampFactor, function(err, chunk){
     if (err) {
       self.emit('error', err);
     } else if (chunk) {

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -565,15 +565,19 @@ NAN_METHOD(Canvas::StreamJPEGSync) {
     return Nan::ThrowTypeError("quality setting required");
   if (!info[2]->IsBoolean())
     return Nan::ThrowTypeError("progressive setting required");
-  if (!info[3]->IsFunction())
+  if (!info[3]->IsNumber())
+    return Nan::ThrowTypeError("chromaHSampFactor required");
+  if (!info[4]->IsNumber())
+    return Nan::ThrowTypeError("chromaVSampFactor required");
+  if (!info[5]->IsFunction())
     return Nan::ThrowTypeError("callback function required");
 
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
   closure_t closure;
-  closure.fn = Local<Function>::Cast(info[3]);
+  closure.fn = Local<Function>::Cast(info[5]);
 
   Nan::TryCatch try_catch;
-  write_to_jpeg_stream(canvas->surface(), info[0]->NumberValue(), info[1]->NumberValue(), info[2]->BooleanValue(), &closure);
+  write_to_jpeg_stream(canvas->surface(), info[0]->NumberValue(), info[1]->NumberValue(), info[2]->BooleanValue(), info[3]->NumberValue(), info[4]->NumberValue(), &closure);
 
   if (try_catch.HasCaught()) {
     try_catch.ReThrow();

--- a/src/JPEGStream.h
+++ b/src/JPEGStream.h
@@ -99,7 +99,7 @@ jpeg_closure_dest(j_compress_ptr cinfo, closure_t * closure, int bufsize){
 }
 
 void
-write_to_jpeg_stream(cairo_surface_t *surface, int bufsize, int quality, bool progressive, closure_t *closure){
+write_to_jpeg_stream(cairo_surface_t *surface, int bufsize, int quality, bool progressive, int chromaHSampFactor, int chromaVSampFactor, closure_t *closure){
   int w = cairo_image_surface_get_width(surface);
   int h = cairo_image_surface_get_height(surface);
   struct jpeg_compress_struct cinfo;
@@ -116,6 +116,9 @@ write_to_jpeg_stream(cairo_surface_t *surface, int bufsize, int quality, bool pr
   if (progressive)
      jpeg_simple_progression(&cinfo);
   jpeg_set_quality(&cinfo, quality, (quality<25)?0:1);
+  cinfo.comp_info[0].h_samp_factor = chromaHSampFactor;
+  cinfo.comp_info[0].v_samp_factor = chromaVSampFactor;
+
   jpeg_closure_dest(&cinfo, closure, bufsize);
 
   jpeg_start_compress(&cinfo, TRUE);


### PR DESCRIPTION
This gives significant quality improvements for images with fine colourful details (mostly seen on synthetic images, most photos won't benefit).

Test program:

```js
const fs = require('fs')
const { createCanvas, loadImage } = require('canvas')

const canvas = createCanvas(230, 200)
const ctx = canvas.getContext('2d')

ctx.fillStyle = 'white';
ctx.fillRect(0, 0, canvas.width, canvas.height)

loadImage('test.png')
	.then((image) => {
		ctx.drawImage(image, 0, 0)
	})
	.then(() => new Promise((resolve, reject) => {
		var
			out = fs.createWriteStream(__dirname + '/test-default.jpg'),
			stream = canvas.jpegStream({
				quality: 94 // Chosen to make both images about the same final filesize
			})
		
		out.on('finish', function () {
			resolve()
		});
		
		stream.pipe(out);
	}))
	.then(() => new Promise((resolve, reject) => {
		var
			out = fs.createWriteStream(__dirname + '/test-no-chroma-subsample.jpg'),
			stream = canvas.jpegStream({
				quality: 90,
				disableChromaSubsampling: true
			})
		
		out.on('finish', function () {
			resolve()
		});
		
		stream.pipe(out);
	}))
```

The test.png input file:

![test](https://user-images.githubusercontent.com/1921411/36082565-9843e756-100f-11e8-9f3b-20c6a9048a79.png)

The output with the default node-canvas options (2x2 chroma subsampling, the current default on the master branch) (25kB):
![test-default](https://user-images.githubusercontent.com/1921411/36082563-97ef8c56-100f-11e8-980a-fd37d6c223b1.jpg)

The output with chroma subsampling disabled (25kB):
![test-no-chroma-subsample](https://user-images.githubusercontent.com/1921411/36082564-981a689a-100f-11e8-8cb1-cdec3878a597.jpg)

Here are those two images blown up and shown side-by-side, notice how the colourful details are much better preserved even with the same filesize (at the red tail feathers, for example):

![comparison](https://user-images.githubusercontent.com/1921411/36082659-54168646-1010-11e8-9e92-dfa9861c56ae.png)
