### PR TITLE
Prevent segfault caused by invalid fonts

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -758,6 +758,11 @@ Canvas::ResolveFontDescription(const PangoFontDescription *desc) {
     for (; it != _font_face_list.end(); ++it) {
       if (g_ascii_strcasecmp(families[i], pango_font_description_get_family(it->user_desc)) == 0) {
         char *name = g_strdup(pango_font_description_get_family(it->sys_desc));
+
+        if (!name) {
+          name = g_strdup("");
+        }
+
         bool unseen = g_hash_table_lookup(seen_families, name) == NULL;
 
         // Avoid sending duplicate SFNT font names due to a bug in Pango for macOS:

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -758,11 +758,6 @@ Canvas::ResolveFontDescription(const PangoFontDescription *desc) {
     for (; it != _font_face_list.end(); ++it) {
       if (g_ascii_strcasecmp(families[i], pango_font_description_get_family(it->user_desc)) == 0) {
         char *name = g_strdup(pango_font_description_get_family(it->sys_desc));
-
-        if (!name) {
-          name = g_strdup("");
-        }
-
         bool unseen = g_hash_table_lookup(seen_families, name) == NULL;
 
         // Avoid sending duplicate SFNT font names due to a bug in Pango for macOS:

--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -206,7 +206,15 @@ get_pango_font_description(unsigned char* filepath) {
     if (table) {
       char *family = get_family_name(face);
 
-      if (family) pango_font_description_set_family_static(desc, family);
+      if (!family) {
+        pango_font_description_free(desc);
+        FT_Done_Face(face);
+        FT_Done_FreeType(library);
+
+        return NULL;
+      }
+
+      pango_font_description_set_family_static(desc, family);
       pango_font_description_set_weight(desc, get_pango_weight(table->usWeightClass));
       pango_font_description_set_stretch(desc, get_pango_stretch(table->usWidthClass));
       pango_font_description_set_style(desc, get_pango_style(face->style_flags));


### PR DESCRIPTION
Fix https://github.com/Automattic/node-canvas/issues/1091

Pango is unable to parse the font attached in the issue, so probably the best we can do is to allow pango to properly display the message and use fallback font.