### PR TITLE
node-pre-gyp should fallback to node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "standard examples/*.js test/server.js test/public/*.js benchmark/run.js util/has_lib.js browser.js index.js && mocha test/*.test.js",
     "pretest-server": "node-gyp build",
     "test-server": "node test/server.js",
-    "install": "node-pre-gyp install"
+    "install": "node-pre-gyp install --fallback-to-build"
   },
   "binary": {
     "module_name": "canvas-prebuilt",


### PR DESCRIPTION
This matches what other libraries like [bcrypt](https://github.com/kelektiv/node.bcrypt.js/blob/master/package.json#L29) do, and it worked when I used `yarn add`/`npm install` on the `node-canvas` directory.

Fixes #1108