### PR TITLE
Update node-pre-gyp to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "remote_path": "v{version}"
   },
   "dependencies": {
-    "node-pre-gyp": "^0.6.36",
+    "node-pre-gyp": "^0.9.0",
     "nan": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Simple update of the `node-pre-gyp` dependency, so that canvas can be without the `request` library and begin the dependency count cut-down.

- [ ] Have you updated CHANGELOG.md?
