### PR TITLE
Updated examples/crop.js

### DIFF
--- a/examples/crop.js
+++ b/examples/crop.js
@@ -1,8 +1,8 @@
 var fs = require('fs')
 var path = require('path')
-var {createCanvas, Image} = require('..')
+var Canvas = require('canvas')
 
-var img = new Image()
+var img = new Canvas.Image()
 
 img.onerror = function (err) {
   throw err
@@ -11,12 +11,12 @@ img.onerror = function (err) {
 img.onload = function () {
   var w = img.width / 2
   var h = img.height / 2
-  var canvas = createCanvas(w, h)
+  var canvas = Canvas.createCanvas(w, h)
   var ctx = canvas.getContext('2d')
 
   ctx.drawImage(img, 0, 0, w, h, 0, 0, w, h)
 
-  var out = fs.createWriteStream(path.join(__dirname, 'crop.png'))
+  var out = fs.createWriteStream(path.join(__dirname, 'crop.jpg'))
   var stream = canvas.createJPEGStream({
     bufsize: 2048,
     quality: 80


### PR DESCRIPTION
`var {createCanvas, Image}  = require('canvas')` was replaced.

jpg format was added to a stream that was initiated with a jpeg stream.