### PR TITLE
old-style stdint #include to support macOS + node < 7

### DIFF
--- a/src/color.h
+++ b/src/color.h
@@ -9,7 +9,7 @@
 #define __COLOR_PARSER_H__
 
 #include <cstdio>
-#include <cstdint>
+#include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
 #include <cstring>
 #include <cstddef>
 


### PR DESCRIPTION
Fixes #1134

The issue doesn't exist in a non-alpha release, so I didn't update the changelog