### PR TITLE
Add ARM support to SYSTEM_PATHS

### DIFF
--- a/util/has_lib.js
+++ b/util/has_lib.js
@@ -9,7 +9,9 @@ var SYSTEM_PATHS = [
   '/usr/local/lib',
   '/opt/local/lib',
   '/usr/lib/x86_64-linux-gnu',
-  '/usr/lib/i386-linux-gnu'
+  '/usr/lib/i386-linux-gnu',
+  '/usr/lib/arm-linux-gnueabihf',
+  '/usr/lib/arm-linux-gnueabi'
 ]
 
 /**


### PR DESCRIPTION
On a Raspi - Kept getting issues with loading a JPEG image from disk. After some digging, I found out the has_lib util kept returning false for jpeg lib (probably for other libs too). Added these lines and re-configured and rebuilt the module. It works fine after that. 

System: Raspi 3 Model B (ARMv7)