### PR TITLE
Fixed the stream instructions.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -134,13 +134,7 @@ var fs = require('fs')
   , out = fs.createWriteStream(__dirname + '/text.png')
   , stream = canvas.pngStream();
 
-stream.on('data', function(chunk){
-  out.write(chunk);
-});
-
-stream.on('end', function(){
-  console.log('The PNG stream ended');
-});
+stream.pipe(out);
 
 out.on('finish', function(){
   console.log('The PNG file was created.');


### PR DESCRIPTION
The pngStream README instructions have been updated to use stream.pipe(out) and now the out.on('finish'... event is actually called.

This was documented in #1142

Thanks for contributing!

- [ ] Have you updated CHANGELOG.md?
