### PR TITLE
Support toBuffer("image/jpeg") and unify export configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 **Upgrading from 1.x**
 ```js
-// (1) The quality argument for canvas.jpegStream now goes from 0 to 1 instead
-//     of from 0 to 100:
-canvas.jpegStream({quality: 50}) // old
-canvas.jpegStream({quality: 0.5}) // new
+// (1) The quality argument for canvas.createJPEGStream/canvas.jpegStream now
+//     goes from 0 to 1 instead of from 0 to 100:
+canvas.createJPEGStream({quality: 50}) // old
+canvas.createJPEGStream({quality: 0.5}) // new
 
 // (2) The ZLIB compression level and PNG filter options for canvas.toBuffer are
 //     now named instead of positional arguments:
@@ -29,10 +29,12 @@ canvas.pngStream({compressionLevel: 3, filters: canvas.PNG_FILTER_NONE}) // new
 
 // (4) canvas.syncPNGStream() and canvas.syncJPEGStream() have been removed:
 canvas.syncPNGStream() // old
-canvas.pngStream() // new
+canvas.createSyncPNGStream() // old
+canvas.createPNGStream() // new
 
 canvas.syncJPEGStream() // old
-canvas.jpegStream() // new
+canvas.createSyncJPEGStream() // old
+canvas.createJPEGStream() // new
 ```
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,43 @@ project adheres to [Semantic Versioning](http://semver.org/).
 2.0.0 (unreleased -- encompasses all alpha versions)
 ==================
 
+**Upgrading from 1.x**
+```js
+// (1) The quality argument for canvas.jpegStream now goes from 0 to 1 instead
+//     of from 0 to 100:
+canvas.jpegStream({quality: 50}) // old
+canvas.jpegStream({quality: 0.5}) // new
+
+// (2) The ZLIB compression level and PNG filter options for canvas.toBuffer are
+//     now named instead of positional arguments:
+canvas.toBuffer(undefined, 3, canvas.PNG_FILTER_NONE) // old
+canvas.toBuffer(undefined, {compressionLevel: 3, filters: canvas.PNG_FILTER_NONE}) // new
+// or specify the mime type explicitly:
+canvas.toBuffer("image/png", {compressionLevel: 3, filters: canvas.PNG_FILTER_NONE}) // new
+
+// (3) #2 also applies for canvas.pngStream, although these arguments were not
+//     documented:
+canvas.pngStream(3, canvas.PNG_FILTER_NONE) // old
+canvas.pngStream({compressionLevel: 3, filters: canvas.PNG_FILTER_NONE}) // new
+
+// (4) canvas.syncPNGStream() and canvas.syncJPEGStream() have been removed:
+canvas.syncPNGStream() // old
+canvas.pngStream() // new
+
+canvas.syncJPEGStream() // old
+canvas.jpegStream() // new
+```
+
 ### Breaking
  * Drop support for Node.js <4.x
- * Remove sync streams (bc53059). Note that all or most streams are still
-   synchronous to some degree; this change just removed `syncPNGStream` and
-   friends.
+ * Remove sync stream functions (bc53059). Note that most streams are still
+   synchronous (run in the main thread); this change just removed `syncPNGStream`
+   and `syncJPEGStream`.
  * Pango is now *required* on all platforms (7716ae4).
+ * Make the `quality` argument for JPEG output go from 0 to 1 to match HTML spec.
+ * Make the `compressionLevel` and `filters` arguments for `canvas.toBuffer()`
+   named instead of positional. Same for `canvas.pngStream()`, although these
+   arguments were not documented.
 
 ### Fixed
  * Prevent segfaults caused by loading invalid fonts (#1105)
@@ -35,8 +66,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
  * Prebuilds (#992) with different libc versions to the prebuilt binary (#1140)
- * Support canvas.getContext("2d", {alpha: boolean}) and
-   canvas.getContext("2d", {pixelFormat: "..."})
+ * Support `canvas.getContext("2d", {alpha: boolean})` and
+   `canvas.getContext("2d", {pixelFormat: "..."})`
  * Support indexed PNG encoding.
  * Support `currentTransform` (d6714ee)
  * Export `CanvasGradient` (6a4c0ab)
@@ -48,6 +79,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
  * Browser-compatible API (6a29a23)
  * Support for jpeg on Windows (42e9a74)
  * Support for backends (1a6dffe)
+ * Support for `canvas.toBuffer("image/jpeg")`
+ * Unified configuration options for `canvas.toBuffer()`, `canvas.pngStream()`
+   and `canvas.jpegStream()`
 
 1.6.x (unreleased)
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -201,12 +201,12 @@ const myCanvas = createCanvas(w, h, 'pdf')
 myCanvas.toBuffer() // returns a buffer containing a PDF-encoded canvas
 ```
 
-### Canvas#pngStream(options)
+### Canvas#createPNGStream(options)
 
 Creates a [`ReadableStream`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 that emits PNG-encoded data.
 
-> `canvas.pngStream([config]) => ReadableStream`
+> `canvas.createPNGStream([config]) => ReadableStream`
 
 * `config` An object specifying the ZLIB compression level (between 0 and 9),
   the compression filter(s), the palette (indexed PNGs only) and/or the
@@ -219,7 +219,7 @@ that emits PNG-encoded data.
 ```javascript
 const fs = require('fs')
 const out = fs.createWriteStream(__dirname + '/test.png')
-const stream = canvas.pngStream()
+const stream = canvas.createPNGStream()
 stream.pipe(out)
 out.on('finish', () =>  console.log('The PNG file was created.'))
 ```
@@ -234,21 +234,21 @@ const palette = new Uint8ClampedArray([
   127, 127, 255, 255
   // ...
 ])
-canvas.pngStream({
+canvas.createPNGStream({
   palette: palette,
   backgroundIndex: 0 // optional, defaults to 0
 })
 ```
 
-### Canvas#jpegStream()
+### Canvas#createJPEGStream()
 
-Creates a [`ReadableStream`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+Creates a [`createJPEGStream`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 that emits JPEG-encoded data.
 
-_Note: At the moment, `jpegStream()` is synchronous under the hood. That is, it
+_Note: At the moment, `createJPEGStream()` is synchronous under the hood. That is, it
 runs in the main thread, not in the libuv threadpool._
 
-> `canvas.pngStream([config]) => ReadableStream`
+> `canvas.createJPEGStream([config]) => ReadableStream`
 
 * `config` an object specifying the quality (0 to 1), if progressive compression
   should be used and/or if chroma subsampling should be used:
@@ -260,12 +260,12 @@ runs in the main thread, not in the libuv threadpool._
 ```javascript
 const fs = require('fs')
 const out = fs.createWriteStream(__dirname + '/test.jpeg')
-const stream = canvas.jpegStream()
+const stream = canvas.createJPEGStream()
 stream.pipe(out)
 out.on('finish', () =>  console.log('The JPEG file was created.'))
 
 // Disable 2x2 chromaSubsampling for deeper colors and use a higher quality
-const stream = canvas.jpegStream({
+const stream = canvas.createJPEGStream({
   quality: 95,
   chromaSubsampling: false
 })
@@ -281,7 +281,7 @@ var dataUrl = canvas.toDataURL('image/png');
 canvas.toDataURL(function(err, png){ }); // defaults to PNG
 canvas.toDataURL('image/png', function(err, png){ });
 canvas.toDataURL('image/jpeg', function(err, jpeg){ }); // sync JPEG is not supported
-canvas.toDataURL('image/jpeg', {opts...}, function(err, jpeg){ }); // see Canvas#jpegStream for valid options
+canvas.toDataURL('image/jpeg', {opts...}, function(err, jpeg){ }); // see Canvas#createJPEGStream for valid options
 canvas.toDataURL('image/jpeg', quality, function(err, jpeg){ }); // spec-following; quality from 0 to 1
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -171,7 +171,7 @@ var stream = canvas.jpegStream({
     bufsize: 4096 // output buffer size in bytes, default: 4096
   , quality: 75 // JPEG quality (0-100) default: 75
   , progressive: false // true for progressive compression, default: false
-  , disableChromaSubsampling: false // true to disable 2x2 subsampling of the chroma components, default: false
+  , chromaSubsampling: true // false to disable 2x2 subsampling of the chroma components, default: true
 });
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,9 @@
 ## This is the documentation for version 2.0.0-alpha
 Alpha versions of 2.0 can be installed using `npm install canvas@next`.
 
+See the [changelog](https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md)
+for a guide to upgrading from 1.x to 2.x.
+
 **For version 1.x documentation, see [the v1.x branch](https://github.com/Automattic/node-canvas/tree/v1.x)**
 
 -----
@@ -80,9 +83,11 @@ loadImage('examples/images/lime-cat.jpg').then((image) => {
 })
 ```
 
-## Non-Standard API
+## Non-Standard APIs
 
- node-canvas extends the canvas API to provide interfacing with node, for example streaming PNG data, converting to a `Buffer` instance, etc. Among the interfacing API, in some cases the drawing API has been extended for SSJS image manipulation / creation usage, however keep in mind these additions may fail to render properly within browsers.
+node-canvas implements the [HTML Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) as closely as possible.
+(See [Compatibility Status](https://github.com/Automattic/node-canvas/wiki/Compatibility-Status)
+for the current API compliance.) All non-standard APIs are documented below.
 
 ### Image#src=Buffer
 
@@ -125,84 +130,145 @@ img.dataMode = Image.MODE_MIME | Image.MODE_IMAGE; // Both are tracked
 
 If image data is not tracked, and the Image is drawn to an image rather than a PDF canvas, the output will be junk. Enabling mime data tracking has no benefits (only a slow down) unless you are generating a PDF.
 
-### Canvas#pngStream(options)
+### Canvas#toBuffer()
 
-  To create a `PNGStream` simply call `canvas.pngStream()`, and the stream will start to emit _data_ events, emitting _end_ when the data stream ends. If an exception occurs the _error_ event is emitted.
+Creates a [`Buffer`](https://nodejs.org/api/buffer.html) object representing the
+image contained in the canvas.
+
+> `canvas.toBuffer((err: Error|null, result: Buffer) => void[, mimeType[, config]]) => void`
+> `canvas.toBuffer([mimeType[, config]]) => Buffer`
+
+* **callback** If provided, the buffer will be provided in the callback instead
+  of being returned by the function. Invoked with an error as the first argument
+  if encoding failed, or the resulting buffer as the second argument if it
+  succeeded. Not supported for mimeType `raw` or for PDF or SVG canvases (there
+  is no async work to do in those cases).
+* **mimeType** A string indicating the image format. Valid options are `image/png`,
+  `image/jpeg` (if node-canvas was built with JPEG support) and `raw` (unencoded
+  ARGB32 data in native-endian byte order, top-to-bottom). Defaults to
+  `image/png`. If the canvas is a PDF or SVG canvas, this argument is ignored
+  and a PDF or SVG is returned always.
+* **config**
+  * For `image/jpeg` an object specifying the quality (0 to 1), if progressive
+    compression should be used and/or if chroma subsampling should be used:
+    `{quality: 0.75, progressive: false, chromaSubsampling: true}`. All
+    properties are optional.
+  * For `image/png`, an object specifying the ZLIB compression level (between 0
+    and 9), the compression filter(s), the palette (indexed PNGs only) and/or
+    the background palette index (indexed PNGs only):
+    `{compressionLevel: 6, filters: canvas.PNG_ALL_FILTERS, palette: undefined, backgroundIndex: 0}`.
+    All properties are optional.
+
+**Return value**
+
+If no callback is provided, a [`Buffer`](https://nodejs.org/api/buffer.html).
+If a callback is provided, none.
+
+#### Examples
 
 ```javascript
-var fs = require('fs')
-  , out = fs.createWriteStream(__dirname + '/text.png')
-  , stream = canvas.pngStream();
+// Default: buf contains a PNG-encoded image
+const buf = canvas.toBuffer()
 
-stream.pipe(out);
+// PNG-encoded, zlib compression level 3 for faster compression but bigger files, no filtering
+const buf2 = canvas.toBuffer('image/png', {compressionLevel: 3, filters: canvas.PNG_FILTER_NONE})
 
-out.on('finish', function(){
-  console.log('The PNG file was created.');
-});
+// JPEG-encoded, 50% quality
+const buf3 = canvas.toBuffer('image/jpeg', {quality: 0.5})
+
+// Asynchronous PNG
+canvas.toBuffer((err, buf) => {
+  if (err) throw err; // encoding failed
+  // buf is PNG-encoded image
+})
+
+canvas.toBuffer((err, buf) => {
+  if (err) throw err; // encoding failed
+  // buf is JPEG-encoded image at 95% quality
+}, 'image/jpeg', {quality: 0.95})
+
+// ARGB32 pixel values, native-endian
+const buf4 = canvas.toBuffer('raw')
+const {stride, width} = canvas
+// In memory, this is `canvas.height * canvas.stride` bytes long.
+// The top row of pixels, in ARGB order, left-to-right, is:
+const topPixelsARGBLeftToRight = buf4.slice(0, width * 4)
+// And the third row is:
+const row3 = buf4.slice(2 * stride, 2 * stride + width * 4)
+
+// SVG and PDF canvases ignore the mimeType argument
+const myCanvas = createCanvas(w, h, 'pdf')
+myCanvas.toBuffer() // returns a buffer containing a PDF-encoded canvas
+```
+
+### Canvas#pngStream(options)
+
+Creates a [`ReadableStream`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+that emits PNG-encoded data.
+
+> `canvas.pngStream([config]) => ReadableStream`
+
+* `config` An object specifying the ZLIB compression level (between 0 and 9),
+  the compression filter(s), the palette (indexed PNGs only) and/or the
+  background palette index (indexed PNGs only):
+  `{compressionLevel: 6, filters: canvas.PNG_ALL_FILTERS, palette: undefined, backgroundIndex: 0}`.
+  All properties are optional.
+
+#### Examples
+
+```javascript
+const fs = require('fs')
+const out = fs.createWriteStream(__dirname + '/test.png')
+const stream = canvas.pngStream()
+stream.pipe(out)
+out.on('finish', () =>  console.log('The PNG file was created.'))
 ```
 
 To encode indexed PNGs from canvases with `pixelFormat: 'A8'` or `'A1'`, provide an options object:
 
 ```js
-var palette = new Uint8ClampedArray([
+const palette = new Uint8ClampedArray([
   //r    g    b    a
     0,  50,  50, 255, // index 1
    10,  90,  90, 255, // index 2
   127, 127, 255, 255
   // ...
-]);
+])
 canvas.pngStream({
   palette: palette,
   backgroundIndex: 0 // optional, defaults to 0
 })
 ```
 
-### Canvas#jpegStream() and Canvas#syncJPEGStream()
+### Canvas#jpegStream()
 
-You can likewise create a `JPEGStream` by calling `canvas.jpegStream()` with
-some optional parameters; functionality is otherwise identical to
-`pngStream()`. See `examples/crop.js` for an example.
+Creates a [`ReadableStream`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+that emits JPEG-encoded data.
 
-_Note: At the moment, `jpegStream()` is the same as `syncJPEGStream()`, both
-are synchronous_
+_Note: At the moment, `jpegStream()` is synchronous under the hood. That is, it
+runs in the main thread, not in the libuv threadpool._
 
-```javascript
-var stream = canvas.jpegStream({
-    bufsize: 4096 // output buffer size in bytes, default: 4096
-  , quality: 75 // JPEG quality (0-100) default: 75
-  , progressive: false // true for progressive compression, default: false
-  , chromaSubsampling: true // false to disable 2x2 subsampling of the chroma components, default: true
-});
-```
+> `canvas.pngStream([config]) => ReadableStream`
 
-### Canvas#toBuffer()
+* `config` an object specifying the quality (0 to 1), if progressive compression
+  should be used and/or if chroma subsampling should be used:
+  `{quality: 0.75, progressive: false, chromaSubsampling: true}`. All properties
+  are optional.
 
-A call to `Canvas#toBuffer()` will return a node `Buffer` instance containing image data.
+#### Examples
 
 ```javascript
-// PNG Buffer, default settings
-var buf = canvas.toBuffer();
+const fs = require('fs')
+const out = fs.createWriteStream(__dirname + '/test.jpeg')
+const stream = canvas.jpegStream()
+stream.pipe(out)
+out.on('finish', () =>  console.log('The JPEG file was created.'))
 
-// PNG Buffer, zlib compression level 3 (from 0-9), faster but bigger
-var buf2 = canvas.toBuffer(undefined, 3, canvas.PNG_FILTER_NONE);
-
-// ARGB32 Buffer, native-endian
-var buf3 = canvas.toBuffer('raw');
-var stride = canvas.stride;
-// In memory, this is `canvas.height * canvas.stride` bytes long.
-// The top row of pixels, in ARGB order, left-to-right, is:
-var topPixelsARGBLeftToRight = buf3.slice(0, canvas.width * 4);
-var row3 = buf3.slice(2 * canvas.stride, 2 * canvas.stride + canvas.width * 4);
-```
-
-### Canvas#toBuffer() async
-
-Optionally we may pass a callback function to `Canvas#toBuffer()`, and this process will be performed asynchronously, and will `callback(err, buf)`.
-
-```javascript
-canvas.toBuffer(function(err, buf){
-
-});
+// Disable 2x2 chromaSubsampling for deeper colors and use a higher quality
+const stream = canvas.jpegStream({
+  quality: 95,
+  chromaSubsampling: false
+})
 ```
 
 ### Canvas#toDataURL() sync and async

--- a/binding.gyp
+++ b/binding.gyp
@@ -135,7 +135,14 @@
             '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
             '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
             '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)'
-          ]
+          ],
+          'cflags!': ['-fno-exceptions'],
+          'cflags_cc!': ['-fno-exceptions']
+        }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+          }
         }],
         ['with_jpeg=="true"', {
           'defines': [

--- a/examples/ray.js
+++ b/examples/ray.js
@@ -82,4 +82,4 @@ render(1)
 
 console.log('Rendered in %s seconds', (new Date() - start) / 1000)
 
-canvas.pngStream().pipe(fs.createWriteStream(path.join(__dirname, 'ray.png')))
+canvas.createPNGStream().pipe(fs.createWriteStream(path.join(__dirname, 'ray.png')))

--- a/examples/resize.js
+++ b/examples/resize.js
@@ -21,7 +21,7 @@ img.onload = function () {
   ctx.imageSmoothingEnabled = true
   ctx.drawImage(img, 0, 0, width, height)
 
-  canvas.pngStream().pipe(out)
+  canvas.createPNGStream().pipe(out)
 
   out.on('finish', function () {
     console.log('Resized and saved in %dms', new Date() - start)

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -50,27 +50,32 @@ Canvas.prototype.getContext = function (contextType, contextAttributes) {
 /**
  * Create a `PNGStream` for `this` canvas.
  *
- * @param {Object} options
- * @param {Uint8ClampedArray} options.palette Provide for indexed PNG encoding.
- *   entries should be R-G-B-A values.
- * @param {Number} options.backgroundIndex Optional index of background color
+ * @param {Object} [options]
+ * @param {number} [options.compressionLevel] Number from 0 to 9 corresponding
+ *   to the ZLIB compression level. Defaults to 6.
+ * @param {number} [options.filters] Any bitwise combination of
+ *   `PNG_FILTER_NONE`, `PNG_FITLER_SUB`, `PNG_FILTER_UP`, `PNG_FILTER_AVG`,
+ *   `PNG_FILTER_PATETH`; or one of `PNG_ALL_FILTERS` or `PNG_NO_FILTERS`. These
+ *   specify which filters *may* be used by libpng. During encoding, libpng will
+ *   select the best filter from this list of allowed filters.
+ * @param {Uint8ClampedArray} [options.palette] Provide for indexed PNG
+ *   encoding. Entries should be R-G-B-A values.
+ * @param {number} [options.backgroundIndex] Optional index of background color
  *   for indexed PNGs. Defaults to 0.
  * @return {PNGStream}
- * @api public
+ * @public
  */
-
 Canvas.prototype.pngStream =
 Canvas.prototype.createPNGStream = function(options){
-  return new PNGStream(this, false, options);
+  return new PNGStream(this, options);
 };
 
 /**
  * Create a `PDFStream` for `this` canvas.
  *
  * @return {PDFStream}
- * @api public
+ * @public
  */
-
 Canvas.prototype.pdfStream =
 Canvas.prototype.createPDFStream = function(){
   return new PDFStream(this);
@@ -79,33 +84,18 @@ Canvas.prototype.createPDFStream = function(){
 /**
  * Create a `JPEGStream` for `this` canvas.
  *
- * @param {Object} options
+ * @param {Object} [options]
+ * @param {number} [options.quality] Number from 0 to 1. Defaults to 0.75.
+ * @param {boolean|1|2} [options.chromaSubsampling] Enables 2x2 chroma
+ *   subsampling. `true` is equivalent to `2`, `false` is equivalent to `1`.
+ * @param {boolean} [options.progressive] Enables progressive encoding. Defautls
+ *   to false.
  * @return {JPEGStream}
- * @api public
+ * @public
  */
-
 Canvas.prototype.jpegStream =
 Canvas.prototype.createJPEGStream = function(options){
-  options = options || {};
-  // Don't allow the buffer size to exceed the size of the canvas (#674)
-  var maxBufSize = this.width * this.height * 4;
-  var clampedBufSize = Math.min(options.bufsize || 4096, maxBufSize);
-  var chromaFactor;
-  if (typeof options.chromaSubsampling === "number") {
-    // libjpeg-turbo seems to complain about values above 2, but hopefully this
-    // can be supported in the future. For now 1 and 2 are valid.
-    // https://github.com/Automattic/node-canvas/pull/1092#issuecomment-366558028
-    chromaFactor = options.chromaSubsampling;
-  } else {
-    chromaFactor = options.chromaSubsampling === false ? 1 : 2;
-  }
-  return new JPEGStream(this, {
-      bufsize: clampedBufSize
-    , quality: options.quality || 75
-    , progressive: options.progressive || false
-    , chromaHSampFactor: chromaFactor
-    , chromaVSampFactor: chromaFactor
-  });
+  return new JPEGStream(this, options);
 };
 
 /**

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -90,12 +90,21 @@ Canvas.prototype.createJPEGStream = function(options){
   // Don't allow the buffer size to exceed the size of the canvas (#674)
   var maxBufSize = this.width * this.height * 4;
   var clampedBufSize = Math.min(options.bufsize || 4096, maxBufSize);
+  var chromaFactor;
+  if (typeof options.chromaSubsampling === "number") {
+    // libjpeg-turbo seems to complain about values above 2, but hopefully this
+    // can be supported in the future. For now 1 and 2 are valid.
+    // https://github.com/Automattic/node-canvas/pull/1092#issuecomment-366558028
+    chromaFactor = options.chromaSubsampling;
+  } else {
+    chromaFactor = options.chromaSubsampling === false ? 1 : 2;
+  }
   return new JPEGStream(this, {
       bufsize: clampedBufSize
     , quality: options.quality || 75
     , progressive: options.progressive || false
-    , chromaHSampFactor: options.disableChromaSubsampling ? 1 : 2
-    , chromaVSampFactor: options.disableChromaSubsampling ? 1 : 2
+    , chromaHSampFactor: chromaFactor
+    , chromaVSampFactor: chromaFactor
   });
 };
 

--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -26,7 +26,7 @@ var util = require('util');
  *     stream.pipe(out);
  *
  * @param {Canvas} canvas
- * @api public
+ * @private
  */
 
 var JPEGStream = module.exports = function JPEGStream(canvas, options) {
@@ -36,7 +36,6 @@ var JPEGStream = module.exports = function JPEGStream(canvas, options) {
 
   Readable.call(this);
 
-  var self = this;
   this.options = options;
   this.canvas = canvas;
 };
@@ -50,13 +49,7 @@ JPEGStream.prototype._read = function _read() {
   // call canvas.streamJPEGSync once and let it emit data at will.
   this._read = noop;
   var self = this;
-  var method = this.method;
-  var bufsize = this.options.bufsize;
-  var quality = this.options.quality;
-  var progressive = this.options.progressive;
-  var chromaHSampFactor = this.options.chromaHSampFactor;
-  var chromaVSampFactor = this.options.chromaVSampFactor;
-  self.canvas.streamJPEGSync(bufsize, quality, progressive, chromaHSampFactor, chromaVSampFactor, function(err, chunk){
+  self.canvas.streamJPEGSync(this.options, function(err, chunk){
     if (err) {
       self.emit('error', err);
     } else if (chunk) {

--- a/lib/pngstream.js
+++ b/lib/pngstream.js
@@ -14,26 +14,10 @@ var Readable = require('stream').Readable;
 var util = require('util');
 
 /**
- * Initialize a `PNGStream` with the given `canvas`.
- *
- * "data" events are emitted with `Buffer` chunks, once complete the
- * "end" event is emitted. The following example will stream to a file
- * named "./my.png".
- *
- *     var out = fs.createWriteStream(__dirname + '/my.png')
- *       , stream = canvas.createPNGStream();
- *
- *     stream.pipe(out);
- *
  * @param {Canvas} canvas
  * @param {Object} options
- * @param {Uint8ClampedArray} options.palette Provide for indexed PNG encoding.
- *   entries should be R-G-B-A values.
- * @param {Number} options.backgroundIndex Optional index of background color
- *   for indexed PNGs. Defaults to 0.
- * @api public
+ * @private
  */
-
 var PNGStream = module.exports = function PNGStream(canvas, options) {
   if (!(this instanceof PNGStream)) {
     throw new TypeError("Class constructors cannot be invoked without 'new'");
@@ -41,7 +25,11 @@ var PNGStream = module.exports = function PNGStream(canvas, options) {
 
   Readable.call(this);
 
-  var self = this;
+  if (options &&
+    options.palette instanceof Uint8ClampedArray &&
+    options.palette.length % 4 !== 0) {
+    throw new Error("Palette length must be a multiple of 4.");
+  }
   this.canvas = canvas;
   this.options = options || {};
 };

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "scripts": {
     "prebenchmark": "node-gyp build",
     "benchmark": "node benchmarks/run.js",
-    "pretest": "node-gyp build",
-    "test": "standard examples/*.js test/server.js test/public/*.js benchmark/run.js util/has_lib.js browser.js index.js && mocha test/*.test.js",
+    "pretest": "standard examples/*.js test/server.js test/public/*.js benchmark/run.js util/has_lib.js browser.js index.js && node-gyp build",
+    "test": "mocha test/*.test.js",
     "pretest-server": "node-gyp build",
     "test-server": "node test/server.js",
     "install": "node-pre-gyp install --fallback-to-build"

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -63,7 +63,8 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_METHOD(StreamJPEGSync);
     static NAN_METHOD(RegisterFont);
     static Local<Value> Error(cairo_status_t status);
-    static void ToBufferAsync(uv_work_t *req);
+    static void ToPngBufferAsync(uv_work_t *req);
+    static void ToJpegBufferAsync(uv_work_t *req);
     static void ToBufferAsyncAfter(uv_work_t *req);
     static PangoWeight GetWeightFromCSSString(const char *weight);
     static PangoStyle GetStyleFromCSSString(const char *style);

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -89,7 +89,7 @@ static void canvas_convert_565_to_888(png_structp png, png_row_infop row_info, p
 
 struct canvas_png_write_closure_t {
     cairo_write_func_t write_func;
-    closure_t *closure;
+    PngClosure* closure;
 };
 
 #ifdef PNG_SETJMP_SUPPORTED
@@ -164,8 +164,8 @@ static cairo_status_t canvas_write_png(cairo_surface_t *surface, png_rw_ptr writ
 #endif
 
     png_set_write_fn(png, closure, write_func, canvas_png_flush);
-    png_set_compression_level(png, closure->closure->compression_level);
-    png_set_filter(png, 0, closure->closure->filter);
+    png_set_compression_level(png, closure->closure->compressionLevel);
+    png_set_filter(png, 0, closure->closure->filters);
 
     cairo_format_t format = cairo_image_surface_get_format(surface);
 
@@ -279,7 +279,7 @@ static void canvas_stream_write_func(png_structp png, png_bytep data, png_size_t
     }
 }
 
-static cairo_status_t canvas_write_to_png_stream(cairo_surface_t *surface, cairo_write_func_t write_func, closure_t *closure) {
+static cairo_status_t canvas_write_to_png_stream(cairo_surface_t *surface, cairo_write_func_t write_func, PngClosure* closure) {
     struct canvas_png_write_closure_t png_closure;
 
     if (cairo_surface_status(surface)) {

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -7,7 +7,6 @@ Backend::Backend(string name, int width, int height)
   , height(height)
   , surface(NULL)
   , canvas(NULL)
-  , _closure(NULL)
 {}
 
 Backend::~Backend()

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -30,10 +30,6 @@ class Backend : public Nan::ObjectWrap
   public:
     virtual ~Backend();
 
-    // TODO Used only by SVG and PDF, move there
-    void* _closure;
-    inline void* closure(){ return _closure; }
-
     void setCanvas(Canvas* canvas);
 
     virtual cairo_surface_t* createSurface() = 0;

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -11,63 +11,50 @@
 using namespace v8;
 
 PdfBackend::PdfBackend(int width, int height)
-	: Backend("pdf", width, height)
-{
-	_closure = malloc(sizeof(closure_t));
-	assert(_closure);
-	createSurface();
+  : Backend("pdf", width, height) {
+  createSurface();
 }
 
-PdfBackend::~PdfBackend()
-{
-	cairo_surface_finish(this->surface);
-	closure_destroy((closure_t*)_closure);
-	free(_closure);
-
-	destroySurface();
+PdfBackend::~PdfBackend() {
+  cairo_surface_finish(surface);
+  if (_closure) delete _closure;
+  destroySurface();
 }
 
 
-cairo_surface_t* PdfBackend::createSurface()
-{
-	cairo_status_t status = closure_init((closure_t*)_closure, this->canvas, 0, PNG_NO_FILTERS);
-	assert(status == CAIRO_STATUS_SUCCESS);
-
-	this->surface = cairo_pdf_surface_create_for_stream(toBuffer, _closure, width, height);
-
-	return this->surface;
+cairo_surface_t* PdfBackend::createSurface() {
+  if (!_closure) _closure = new PdfSvgClosure(canvas);
+  surface = cairo_pdf_surface_create_for_stream(toBuffer, _closure, width, height);
+  return surface;
 }
 
-cairo_surface_t* PdfBackend::recreateSurface()
-{
-	cairo_pdf_surface_set_size(this->surface, width, height);
+cairo_surface_t* PdfBackend::recreateSurface() {
+  cairo_pdf_surface_set_size(surface, width, height);
 
-	return this->surface;
+  return surface;
 }
 
 
 Nan::Persistent<FunctionTemplate> PdfBackend::constructor;
 
-void PdfBackend::Initialize(Handle<Object> target)
-{
-	Nan::HandleScope scope;
+void PdfBackend::Initialize(Handle<Object> target) {
+  Nan::HandleScope scope;
 
-	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New);
-	PdfBackend::constructor.Reset(ctor);
-	ctor->InstanceTemplate()->SetInternalFieldCount(1);
-	ctor->SetClassName(Nan::New<String>("PdfBackend").ToLocalChecked());
-	target->Set(Nan::New<String>("PdfBackend").ToLocalChecked(), ctor->GetFunction());
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New);
+  PdfBackend::constructor.Reset(ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(Nan::New<String>("PdfBackend").ToLocalChecked());
+  target->Set(Nan::New<String>("PdfBackend").ToLocalChecked(), ctor->GetFunction());
 }
 
-NAN_METHOD(PdfBackend::New)
-{
-	int width  = 0;
-	int height = 0;
-	if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
-	if (info[1]->IsNumber()) height = info[1]->Uint32Value();
+NAN_METHOD(PdfBackend::New) {
+  int width  = 0;
+  int height = 0;
+  if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
+  if (info[1]->IsNumber()) height = info[1]->Uint32Value();
 
-	PdfBackend* backend = new PdfBackend(width, height);
+  PdfBackend* backend = new PdfBackend(width, height);
 
-	backend->Wrap(info.This());
-	info.GetReturnValue().Set(info.This());
+  backend->Wrap(info.This());
+  info.GetReturnValue().Set(info.This());
 }

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -3,6 +3,7 @@
 
 #include <v8.h>
 
+#include "../closure.h"
 #include "Backend.h"
 
 using namespace std;
@@ -14,6 +15,9 @@ class PdfBackend : public Backend
     cairo_surface_t* recreateSurface();
 
   public:
+    PdfSvgClosure* _closure = NULL;
+    inline PdfSvgClosure* closure() { return _closure; }
+
     PdfBackend(int width, int height);
     ~PdfBackend();
 

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -11,65 +11,52 @@
 using namespace v8;
 
 SvgBackend::SvgBackend(int width, int height)
-	: Backend("svg", width, height)
-{
-	_closure = malloc(sizeof(closure_t));
-	assert(_closure);
-	createSurface();
+  : Backend("svg", width, height) {
+  createSurface();
 }
 
-SvgBackend::~SvgBackend()
-{
-	cairo_surface_finish(this->surface);
-	closure_destroy((closure_t*)_closure);
-	free(_closure);
-
-	destroySurface();
+SvgBackend::~SvgBackend() {
+  cairo_surface_finish(surface);
+  if (_closure) delete _closure;
+  destroySurface();
 }
 
 
-cairo_surface_t* SvgBackend::createSurface()
-{
-	cairo_status_t status = closure_init((closure_t*)_closure, this->canvas, 0, PNG_NO_FILTERS);
-	assert(status == CAIRO_STATUS_SUCCESS);
-
-	this->surface = cairo_svg_surface_create_for_stream(toBuffer, _closure, width, height);
-
-	return this->surface;
+cairo_surface_t* SvgBackend::createSurface() {
+  if (!_closure) _closure = new PdfSvgClosure(canvas);
+  surface = cairo_svg_surface_create_for_stream(toBuffer, _closure, width, height);
+  return surface;
 }
 
-cairo_surface_t* SvgBackend::recreateSurface()
-{
-	cairo_surface_finish(this->surface);
-	closure_destroy((closure_t*)_closure);
-	cairo_surface_destroy(this->surface);
+cairo_surface_t* SvgBackend::recreateSurface() {
+  cairo_surface_finish(surface);
+  delete _closure;
+  cairo_surface_destroy(surface);
 
-	return createSurface();
+  return createSurface();
  }
 
 
 Nan::Persistent<FunctionTemplate> SvgBackend::constructor;
 
-void SvgBackend::Initialize(Handle<Object> target)
-{
-	Nan::HandleScope scope;
+void SvgBackend::Initialize(Handle<Object> target) {
+  Nan::HandleScope scope;
 
-	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(SvgBackend::New);
-	SvgBackend::constructor.Reset(ctor);
-	ctor->InstanceTemplate()->SetInternalFieldCount(1);
-	ctor->SetClassName(Nan::New<String>("SvgBackend").ToLocalChecked());
-	target->Set(Nan::New<String>("SvgBackend").ToLocalChecked(), ctor->GetFunction());
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(SvgBackend::New);
+  SvgBackend::constructor.Reset(ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(Nan::New<String>("SvgBackend").ToLocalChecked());
+  target->Set(Nan::New<String>("SvgBackend").ToLocalChecked(), ctor->GetFunction());
 }
 
-NAN_METHOD(SvgBackend::New)
-{
-	int width  = 0;
-	int height = 0;
-	if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
-	if (info[1]->IsNumber()) height = info[1]->Uint32Value();
+NAN_METHOD(SvgBackend::New) {
+  int width  = 0;
+  int height = 0;
+  if (info[0]->IsNumber()) width  = info[0]->Uint32Value();
+  if (info[1]->IsNumber()) height = info[1]->Uint32Value();
 
-	SvgBackend* backend = new SvgBackend(width, height);
+  SvgBackend* backend = new SvgBackend(width, height);
 
-	backend->Wrap(info.This());
-	info.GetReturnValue().Set(info.This());
+  backend->Wrap(info.This());
+  info.GetReturnValue().Set(info.This());
 }

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -4,6 +4,7 @@
 #include <v8.h>
 
 #include "Backend.h"
+#include "../closure.h"
 
 using namespace std;
 
@@ -14,6 +15,9 @@ class SvgBackend : public Backend
     cairo_surface_t* recreateSurface();
 
   public:
+    PdfSvgClosure* _closure = NULL;
+    inline PdfSvgClosure* closure() { return _closure; }
+
     SvgBackend(int width, int height);
     ~SvgBackend();
 

--- a/src/closure.cc
+++ b/src/closure.cc
@@ -1,30 +1,27 @@
 #include "closure.h"
 
-
-/*
- * Initialize the given closure.
- */
-
-cairo_status_t
-closure_init(closure_t *closure, Canvas *canvas, unsigned int compression_level, unsigned int filter) {
-  closure->len = 0;
-  closure->canvas = canvas;
-  closure->data = (uint8_t *) malloc(closure->max_len = PAGE_SIZE);
-  if (!closure->data) return CAIRO_STATUS_NO_MEMORY;
-  closure->compression_level = compression_level;
-  closure->filter = filter;
-  return CAIRO_STATUS_SUCCESS;
+PdfSvgClosure::PdfSvgClosure(Canvas* canvas) : Closure(canvas) {
+  //data = new (std::nothrow) uint8_t[max_len]; // toBuffer.cc uses realloc
+  data = static_cast<uint8_t*>(malloc(max_len));
+  if (!data) throw CAIRO_STATUS_NO_MEMORY;
 }
 
-/*
- * Free the given closure's data,
- * and hint V8 at the memory dealloc.
- */
+PdfSvgClosure::~PdfSvgClosure() {
+  if (len) {
+    //delete[] data;
+    free(data);
+    Nan::AdjustExternalMemory(-static_cast<int>(max_len));
+  }
+}
 
-void
-closure_destroy(closure_t *closure) {
-  if (closure->len) {
-    free(closure->data);
-    Nan::AdjustExternalMemory(-static_cast<int>(closure->max_len));
+PngClosure::PngClosure(Canvas* canvas) : Closure(canvas) {
+  data = static_cast<uint8_t*>(malloc(max_len));
+  if (!data) throw CAIRO_STATUS_NO_MEMORY;
+}
+
+PngClosure::~PngClosure() {
+  if (len) {
+    free(data);
+    Nan::AdjustExternalMemory(-static_cast<int>(max_len));
   }
 }

--- a/src/closure.h
+++ b/src/closure.h
@@ -17,11 +17,57 @@
 #endif
 
 #include <nan.h>
+#include <png.h>
 
 #include "Canvas.h"
 
 /*
- * PNG stream closure.
+ * Image encoding closures.
+ */
+
+struct Closure {
+  Nan::Callback *pfn;
+  Local<Function> fn;
+  unsigned len = 0;
+  unsigned max_len = PAGE_SIZE;
+  uint8_t* data = NULL;
+  Canvas* canvas = NULL;
+  cairo_status_t status = CAIRO_STATUS_SUCCESS;
+
+  Closure(Canvas* canvas) : canvas(canvas) {};
+};
+
+struct PdfSvgClosure : Closure {
+  PdfSvgClosure(Canvas* canvas);
+  ~PdfSvgClosure();
+};
+
+struct PngClosure : Closure {
+  uint32_t compressionLevel = 6;
+  uint32_t filters = PNG_ALL_FILTERS;
+  // Indexed PNGs:
+  uint32_t nPaletteColors = 0;
+  uint8_t* palette = NULL;
+  uint8_t backgroundIndex = 0;
+
+  PngClosure(Canvas* canvas);
+  ~PngClosure();
+};
+
+struct JpegClosure : Closure {
+  uint32_t quality = 75;
+  uint32_t chromaSubsampling = 2;
+  bool progressive = false;
+
+  JpegClosure(Canvas* canvas) : Closure(canvas) {};
+  ~JpegClosure() {
+    // jpeg_mem_dest mallocs 'data'
+    if (data) free(data);
+  }
+};
+
+/*
+ * Image encoding closure.
  */
 
 typedef struct {
@@ -32,11 +78,6 @@ typedef struct {
   uint8_t *data;
   Canvas *canvas;
   cairo_status_t status;
-  uint32_t compression_level;
-  uint32_t filter;
-  uint8_t *palette;
-  size_t nPaletteColors;
-  uint8_t backgroundIndex;
 } closure_t;
 
 /*
@@ -44,7 +85,7 @@ typedef struct {
  */
 
 cairo_status_t
-closure_init(closure_t *closure, Canvas *canvas, unsigned int compression_level, unsigned int filter);
+closure_init(closure_t *closure, Canvas *canvas);
 
 /*
  * Free the given closure's data,

--- a/src/toBuffer.cc
+++ b/src/toBuffer.cc
@@ -8,9 +8,11 @@
  * Canvas::ToBuffer callback.
  */
 
+// TODO try to use std::vector instead
+
 cairo_status_t
 toBuffer(void *c, const uint8_t *odata, unsigned len) {
-  closure_t *closure = (closure_t *) c;
+  Closure* closure = (Closure*)c;
 
   if (closure->len + len > closure->max_len) {
     uint8_t *data;

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1352,9 +1352,9 @@ describe('Canvas', function () {
     });
   });
 
-  it('Canvas#jpegStream()', function (done) {
+  it('Canvas#createJPEGStream()', function (done) {
     var canvas = createCanvas(640, 480);
-    var stream = canvas.jpegStream();
+    var stream = canvas.createJPEGStream();
     assert(stream instanceof Readable);
     var firstChunk = true;
     var bytes = 0;
@@ -1378,9 +1378,9 @@ describe('Canvas', function () {
 
   // based on https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format
   // end of image marker (FF D9) must exist to maintain JPEG standards
-  it('EOI at end of Canvas#jpegStream()', function (done) {
+  it('EOI at end of Canvas#createJPEGStream()', function (done) {
     var canvas = createCanvas(640, 480);
-    var stream = canvas.jpegStream();
+    var stream = canvas.createJPEGStream();
     var chunks = []
     stream.on('data', function(chunk){
       chunks.push(chunk)

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -487,100 +487,148 @@ describe('Canvas', function () {
     assert.equal('end', ctx.textAlign);
   });
 
-  it('Canvas#toBuffer()', function () {
-    var buf = createCanvas(200,200).toBuffer();
-    assert.equal('PNG', buf.slice(1,4).toString());
-  });
-
-  it('Canvas#toBuffer() async', function (done) {
-    createCanvas(200, 200).toBuffer(function(err, buf){
-      assert.ok(!err);
+  describe('#toBuffer', function () {
+    it('Canvas#toBuffer()', function () {
+      var buf = createCanvas(200,200).toBuffer();
       assert.equal('PNG', buf.slice(1,4).toString());
-      done();
     });
-  });
-
-  describe('#toBuffer("raw")', function() {
-    var canvas = createCanvas(11, 10)
-        , ctx = canvas.getContext('2d');
-
-    ctx.clearRect(0, 0, 11, 10);
-
-    ctx.fillStyle = 'rgba(200, 200, 200, 0.505)';
-    ctx.fillRect(0, 0, 5, 5);
-
-    ctx.fillStyle = 'red';
-    ctx.fillRect(5, 0, 5, 5);
-
-    ctx.fillStyle = '#00ff00';
-    ctx.fillRect(0, 5, 5, 5);
-
-    ctx.fillStyle = 'black';
-    ctx.fillRect(5, 5, 4, 5);
-
-    /** Output:
-     *    *****RRRRR-
-     *    *****RRRRR-
-     *    *****RRRRR-
-     *    *****RRRRR-
-     *    *****RRRRR-
-     *    GGGGGBBBB--
-     *    GGGGGBBBB--
-     *    GGGGGBBBB--
-     *    GGGGGBBBB--
-     *    GGGGGBBBB--
-     */
-
-    var buf = canvas.toBuffer('raw');
-    var stride = canvas.stride;
-
-    var endianness = os.endianness();
-
-    function assertPixel(u32, x, y, message) {
-      var expected = '0x' + u32.toString(16);
-
-      // Buffer doesn't have readUInt32(): it only has readUInt32LE() and
-      // readUInt32BE().
-      var px = buf['readUInt32' + endianness](y * stride + x * 4);
-      var actual = '0x' + px.toString(16);
-
-      assert.equal(actual, expected, message);
-    }
-
-    it('should have the correct size', function() {
-      assert.equal(buf.length, stride * 10);
+  
+    it('Canvas#toBuffer("image/png")', function () {
+      var buf = createCanvas(200,200).toBuffer('image/png');
+      assert.equal('PNG', buf.slice(1,4).toString());
+    });
+  
+    it('Canvas#toBuffer("image/png", {compressionLevel: 5})', function () {
+      var buf = createCanvas(200,200).toBuffer('image/png', {compressionLevel: 5});
+      assert.equal('PNG', buf.slice(1,4).toString());
     });
 
-    it('does not premultiply alpha', function() {
-      assertPixel(0x80646464, 0, 0, 'first semitransparent pixel');
-      assertPixel(0x80646464, 4, 4, 'last semitransparent pixel');
+    it('Canvas#toBuffer("image/jpeg")', function () {
+      var buf = createCanvas(200,200).toBuffer('image/jpeg');
+      assert.equal(buf[0], 0xff);
+      assert.equal(buf[1], 0xd8);
+      assert.equal(buf[buf.byteLength - 2], 0xff);
+      assert.equal(buf[buf.byteLength - 1], 0xd9);
     });
 
-    it('draws red', function() {
-      assertPixel(0xffff0000, 5, 0, 'first red pixel');
-      assertPixel(0xffff0000, 9, 4, 'last red pixel');
+    it('Canvas#toBuffer("image/jpeg", {quality: 0.95})', function () {
+      var buf = createCanvas(200,200).toBuffer('image/jpeg', {quality: 0.95});
+      assert.equal(buf[0], 0xff);
+      assert.equal(buf[1], 0xd8);
+      assert.equal(buf[buf.byteLength - 2], 0xff);
+      assert.equal(buf[buf.byteLength - 1], 0xd9);
     });
 
-    it('draws green', function() {
-      assertPixel(0xff00ff00, 0, 5, 'first green pixel');
-      assertPixel(0xff00ff00, 4, 9, 'last green pixel');
+    it('Canvas#toBuffer(callback)', function (done) {
+      createCanvas(200, 200).toBuffer(function(err, buf){
+        assert.ok(!err);
+        assert.equal('PNG', buf.slice(1,4).toString());
+        done();
+      });
     });
 
-    it('draws black', function() {
-      assertPixel(0xff000000, 5, 5, 'first black pixel');
-      assertPixel(0xff000000, 8, 9, 'last black pixel');
+    it('Canvas#toBuffer(callback, "image/jpeg")', function () {
+      var buf = createCanvas(200,200).toBuffer(function (err, buff) {
+        assert.ok(!err);
+        assert.equal(buf[0], 0xff);
+        assert.equal(buf[1], 0xd8);
+        assert.equal(buf[buf.byteLength - 2], 0xff);
+        assert.equal(buf[buf.byteLength - 1], 0xd9);
+      }, 'image/jpeg');
     });
 
-    it('leaves undrawn pixels black, transparent', function() {
-      assertPixel(0x0, 9, 5, 'first undrawn pixel');
-      assertPixel(0x0, 9, 9, 'last undrawn pixel');
+    it('Canvas#toBuffer(callback, "image/jpeg", {quality: 0.95})', function () {
+      var buf = createCanvas(200,200).toBuffer(function (err, buff) {
+        assert.ok(!err);
+        assert.equal(buf[0], 0xff);
+        assert.equal(buf[1], 0xd8);
+        assert.equal(buf[buf.byteLength - 2], 0xff);
+        assert.equal(buf[buf.byteLength - 1], 0xd9);
+      }, 'image/jpeg', {quality: 0.95});
     });
 
-    it('is immutable', function() {
-      ctx.fillStyle = 'white';
-      ctx.fillRect(0, 0, 10, 10);
-      canvas.toBuffer('raw'); // (side-effect: flushes canvas)
-      assertPixel(0xffff0000, 5, 0, 'first red pixel');
+    describe('#toBuffer("raw")', function() {
+      var canvas = createCanvas(11, 10)
+          , ctx = canvas.getContext('2d');
+  
+      ctx.clearRect(0, 0, 11, 10);
+  
+      ctx.fillStyle = 'rgba(200, 200, 200, 0.505)';
+      ctx.fillRect(0, 0, 5, 5);
+  
+      ctx.fillStyle = 'red';
+      ctx.fillRect(5, 0, 5, 5);
+  
+      ctx.fillStyle = '#00ff00';
+      ctx.fillRect(0, 5, 5, 5);
+  
+      ctx.fillStyle = 'black';
+      ctx.fillRect(5, 5, 4, 5);
+  
+      /** Output:
+       *    *****RRRRR-
+       *    *****RRRRR-
+       *    *****RRRRR-
+       *    *****RRRRR-
+       *    *****RRRRR-
+       *    GGGGGBBBB--
+       *    GGGGGBBBB--
+       *    GGGGGBBBB--
+       *    GGGGGBBBB--
+       *    GGGGGBBBB--
+       */
+  
+      var buf = canvas.toBuffer('raw');
+      var stride = canvas.stride;
+  
+      var endianness = os.endianness();
+  
+      function assertPixel(u32, x, y, message) {
+        var expected = '0x' + u32.toString(16);
+  
+        // Buffer doesn't have readUInt32(): it only has readUInt32LE() and
+        // readUInt32BE().
+        var px = buf['readUInt32' + endianness](y * stride + x * 4);
+        var actual = '0x' + px.toString(16);
+  
+        assert.equal(actual, expected, message);
+      }
+  
+      it('should have the correct size', function() {
+        assert.equal(buf.length, stride * 10);
+      });
+  
+      it('does not premultiply alpha', function() {
+        assertPixel(0x80646464, 0, 0, 'first semitransparent pixel');
+        assertPixel(0x80646464, 4, 4, 'last semitransparent pixel');
+      });
+  
+      it('draws red', function() {
+        assertPixel(0xffff0000, 5, 0, 'first red pixel');
+        assertPixel(0xffff0000, 9, 4, 'last red pixel');
+      });
+  
+      it('draws green', function() {
+        assertPixel(0xff00ff00, 0, 5, 'first green pixel');
+        assertPixel(0xff00ff00, 4, 9, 'last green pixel');
+      });
+  
+      it('draws black', function() {
+        assertPixel(0xff000000, 5, 5, 'first black pixel');
+        assertPixel(0xff000000, 8, 9, 'last black pixel');
+      });
+  
+      it('leaves undrawn pixels black, transparent', function() {
+        assertPixel(0x0, 9, 5, 'first undrawn pixel');
+        assertPixel(0x0, 9, 9, 'last undrawn pixel');
+      });
+  
+      it('is immutable', function() {
+        ctx.fillStyle = 'white';
+        ctx.fillRect(0, 0, 10, 10);
+        canvas.toBuffer('raw'); // (side-effect: flushes canvas)
+        assertPixel(0xffff0000, 5, 0, 'first red pixel');
+      });
     });
   });
 
@@ -1346,16 +1394,6 @@ describe('Canvas', function () {
     stream.on('error', function(err) {
       done(err);
     });
-  });
-
-  it('Canvas#jpegStream() should clamp buffer size (#674)', function (done) {
-    var c = createCanvas(10, 10);
-    var SIZE = 10 * 1024 * 1024;
-    var s = c.jpegStream({bufsize: SIZE});
-    s.on('data', function (chunk) {
-      assert(chunk.length < SIZE);
-    });
-    s.on('end', done);
   });
 
   it('Context2d#fill()', function() {


### PR DESCRIPTION
Docs showing the new API: https://github.com/zbjornson/node-canvas/tree/tobufferjpeg#canvastobuffer

* **Added**: support for `canvas.toBuffer("image/jpeg")`. This unblocks #1146 and helps make `canvas.toBuffer()` **the** universal method for getting encoded data out of a canvas. Unblocks adding `toBlob` if we want it -- a later topic.

* **Changed (breaking)**: PNG filter and ZLIB compression options are now named instead of positional for `canvas.toBuffer` and (undocumented) `canvas.pngStream`. Less awkward API, easier support for more parameters in the future (including #716/#766).

* **Improved**: `canvas.toBuffer`, `canvas.jpegStream` and `canvas.pngStream` now all accept the same config objects. Previously some options were only available when streaming.

* **Removed (breaking)**: The weird argument handling that allowed the compression level `"0"` (string). The logic in that section was all sort of weird, not sure if I'm misreading it.

* **Changed (breaking)**: The quality argument for `jpegStream` now goes from 0 to 1 to match the quality argument in `canvas.toBlob`.

* **Question**: Should there be a `canvas.toBuffer(callback, "raw")`? **NO** per below. <strike>There's no async work to be done here (just a memcpy). Adding this would make the API consist, but would encourage a bad usage pattern (callback-all-the-things!). There's also no `canvas.toBuffer(callback)` support for SVG or PDF canvases.</strike>

* `image/jpeg` uses the threadpool. <strike>**Question**: `image/jpeg` runs in the main thread currently, but that *could* reasonably be offloaded to the threadpool later. It's easy enough to invoke the callback in the next tick now so that if it moves to the threadpool in the future it'll be async now and in the future -- should it? One less semver major change in the future.</strike>

- [x] Have you updated CHANGELOG.md?

Fixes #982