### PR TITLE
Allow assigning non-string values to fillStyle and strokeStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  * Improve handling of invalid arguments (#1129)
  * Fix repeating patterns when drawing a canvas to itself (#1136)
  * Prevent segfaults caused by creating a too large canvas
+ * Allow assigning non-string values to fillStyle and strokeStyle
 
 ### Added
  * Prebuilds (#992) with different libc versions to the prebuilt binary (#1140)

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -131,7 +131,7 @@ Context2d.prototype.__defineSetter__('fillStyle', function(val){
     this._setFillPattern(val);
   } else {
     this.lastFillStyle = undefined;
-    this._setFillColor(val + '');
+    this._setFillColor(String(val));
   }
 });
 
@@ -158,7 +158,7 @@ Context2d.prototype.__defineSetter__('strokeStyle', function(val){
     this.lastStrokeStyle = val;
     this._setStrokePattern(val);
   } else {
-    this._setStrokeColor(val + '');
+    this._setStrokeColor(String(val));
   }
 });
 

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -131,7 +131,7 @@ Context2d.prototype.__defineSetter__('fillStyle', function(val){
     this._setFillPattern(val);
   } else {
     this.lastFillStyle = undefined;
-    this._setFillColor(val);
+    this._setFillColor(val + '');
   }
 });
 
@@ -158,7 +158,7 @@ Context2d.prototype.__defineSetter__('strokeStyle', function(val){
     this.lastStrokeStyle = val;
     this._setStrokePattern(val);
   } else {
-    this._setStrokeColor(val);
+    this._setStrokeColor(val + '');
   }
 });
 

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -130,7 +130,7 @@ Context2d.prototype.__defineSetter__('fillStyle', function(val){
     || 'CanvasPattern' == val.constructor.name) {
     this.lastFillStyle = val;
     this._setFillPattern(val);
-  } else if ('string' == typeof val) {
+  } else {
     this.lastFillStyle = undefined;
     this._setFillColor(val);
   }
@@ -159,7 +159,7 @@ Context2d.prototype.__defineSetter__('strokeStyle', function(val){
     || 'CanvasPattern' == val.constructor.name) {
     this.lastStrokeStyle = val;
     this._setStrokePattern(val);
-  } else if ('string' == typeof val) {
+  } else {
     this._setStrokeColor(val);
   }
 });

--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -125,9 +125,8 @@ Object.defineProperty(Context2d.prototype, 'currentTransform', {
  */
 
 Context2d.prototype.__defineSetter__('fillStyle', function(val){
-  if (!val) return;
-  if ('CanvasGradient' == val.constructor.name
-    || 'CanvasPattern' == val.constructor.name) {
+  if (val instanceof CanvasGradient
+    || val instanceof CanvasPattern) {
     this.lastFillStyle = val;
     this._setFillPattern(val);
   } else {
@@ -154,9 +153,8 @@ Context2d.prototype.__defineGetter__('fillStyle', function(){
  */
 
 Context2d.prototype.__defineSetter__('strokeStyle', function(val){
-  if (!val) return;
-  if ('CanvasGradient' == val.constructor.name
-    || 'CanvasPattern' == val.constructor.name) {
+  if (val instanceof CanvasGradient
+    || val instanceof CanvasPattern) {
     this.lastStrokeStyle = val;
     this._setStrokePattern(val);
   } else {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1803,16 +1803,9 @@ NAN_GETTER(Context2d::GetShadowColor) {
 NAN_METHOD(Context2d::SetFillColor) {
   short ok;
 
-  Isolate *isolate = Isolate::GetCurrent();
-  Nan::TryCatch try_catch;
-  MaybeLocal<String> color = info[0]->ToString(Context::New(isolate));
-
-  if (try_catch.HasCaught()) {
-    try_catch.ReThrow();
-    return;
-  }
-
-  String::Utf8Value str(color.ToLocalChecked());
+  if (!info[0]->IsString()) return;
+  String::Utf8Value str(info[0]);
+  
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
@@ -1838,16 +1831,9 @@ NAN_GETTER(Context2d::GetFillColor) {
 NAN_METHOD(Context2d::SetStrokeColor) {
   short ok;
 
-  Isolate *isolate = Isolate::GetCurrent();
-  Nan::TryCatch try_catch;
-  MaybeLocal<String> color = info[0]->ToString(Context::New(isolate));
+  if (!info[0]->IsString()) return;
+  String::Utf8Value str(info[0]);
 
-  if (try_catch.HasCaught()) {
-    try_catch.ReThrow();
-    return;
-  }
-
-  String::Utf8Value str(color.ToLocalChecked());
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1804,7 +1804,7 @@ NAN_METHOD(Context2d::SetFillColor) {
   short ok;
 
   Isolate *isolate = Isolate::GetCurrent();
-  v8::TryCatch try_catch(isolate);
+  Nan::TryCatch try_catch;
   MaybeLocal<String> color = info[0]->ToString(Context::New(isolate));
 
   if (try_catch.HasCaught()) {
@@ -1839,7 +1839,7 @@ NAN_METHOD(Context2d::SetStrokeColor) {
   short ok;
 
   Isolate *isolate = Isolate::GetCurrent();
-  v8::TryCatch try_catch(isolate);
+  Nan::TryCatch try_catch;
   MaybeLocal<String> color = info[0]->ToString(Context::New(isolate));
 
   if (try_catch.HasCaught()) {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1802,8 +1802,17 @@ NAN_GETTER(Context2d::GetShadowColor) {
 
 NAN_METHOD(Context2d::SetFillColor) {
   short ok;
-  if (!info[0]->IsString()) return;
-  String::Utf8Value str(info[0]);
+
+  Isolate *isolate = Isolate::GetCurrent();
+  v8::TryCatch try_catch(isolate);
+  MaybeLocal<String> color = info[0]->ToString(Context::New(isolate));
+
+  if (try_catch.HasCaught()) {
+    try_catch.ReThrow();
+    return;
+  }
+
+  String::Utf8Value str(color.ToLocalChecked());
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
@@ -1828,8 +1837,17 @@ NAN_GETTER(Context2d::GetFillColor) {
 
 NAN_METHOD(Context2d::SetStrokeColor) {
   short ok;
-  if (!info[0]->IsString()) return;
-  String::Utf8Value str(info[0]);
+
+  Isolate *isolate = Isolate::GetCurrent();
+  v8::TryCatch try_catch(isolate);
+  MaybeLocal<String> color = info[0]->ToString(Context::New(isolate));
+
+  if (try_catch.HasCaught()) {
+    try_catch.ReThrow();
+    return;
+  }
+
+  String::Utf8Value str(color.ToLocalChecked());
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1603,4 +1603,24 @@ describe('Canvas', function () {
     assert.strictEqual(count, 10 * 10 * 2);
   });
 
+  it('Context2d#SetFillColor()', function () {
+    var canvas = createCanvas(2, 2);
+    var ctx = canvas.getContext('2d');
+
+    ctx.fillStyle = ['#808080'];
+    ctx.fillRect(0, 0, 2, 2);
+    var data = ctx.getImageData(0, 0, 2, 2).data;
+
+    data.forEach(function (byte, index) {
+      if (byte + 1 & 3)
+        assert.strictEqual(byte, 128);
+      else
+        assert.strictEqual(byte, 255);
+    });
+
+    assert.throws(function () {
+      ctx.fillStyle = Object.create(null);
+    });
+  });
+
 });

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1612,7 +1612,7 @@ describe('Canvas', function () {
     var data = ctx.getImageData(0, 0, 2, 2).data;
 
     data.forEach(function (byte, index) {
-      if (byte + 1 & 3)
+      if (index + 1 & 3)
         assert.strictEqual(byte, 128);
       else
         assert.strictEqual(byte, 255);


### PR DESCRIPTION
When a non-string value is assigned to `fillStyle` or `strokeStyle` browsers convert it to string, but node-canvas does nothing in such case (except if the value is an instance of gradient or pattern).

This fix allows arbitrary object to be used as a color.

- [x] Updated the changelog
- [x] Added a test