### PR TITLE
Fix drawing zero-width and zero-height images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  * Prevent segfaults caused by creating a too large canvas
  * Fix parse-font regex to allow for whitespaces.
  * Allow assigning non-string values to fillStyle and strokeStyle
+ * Fix drawing zero-width and zero-height images.
 
 ### Added
  * Prebuilds (#992) with different libc versions to the prebuilt binary (#1140)

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1168,6 +1168,9 @@ NAN_METHOD(Context2d::DrawImage) {
       break;
   }
 
+  if (!(sw && sh && dw && dh))
+    return;
+
   // Start draw
   cairo_save(ctx);
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1605,6 +1605,8 @@ describe('Canvas', function () {
 
     // Drawing zero-width image
     ctx.drawImage(canvas, 0, 0, 0, 0, 0, 0, 0, 0);
+    ctx.drawImage(canvas, 0, 0, 0, 0, 1, 1, 1, 1);
+    ctx.drawImage(canvas, 1, 1, 1, 1, 0, 0, 0, 0);
     ctx.fillStyle = 'white';
     ctx.fillRect(0, 0, 500, 500);
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1585,22 +1585,39 @@ describe('Canvas', function () {
     var canvas = createCanvas(500, 500);
     var ctx = canvas.getContext('2d');
 
+    // Drawing canvas to itself
     ctx.fillStyle = 'white';
     ctx.fillRect(0, 0, 500, 500);
     ctx.fillStyle = 'black';
     ctx.fillRect(5, 5, 10, 10);
-    ctx.drawImage(ctx.canvas, 20, 20);
+    ctx.drawImage(canvas, 20, 20);
 
     var imgd = ctx.getImageData(0, 0, 500, 500);
     var data = imgd.data;
     var count = 0;
 
-    for(var i = 0; i < 500 * 500; i += 4){
+    for(var i = 0; i < 500 * 500 * 4; i += 4){
       if(data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 0)
         count++;
     }
 
     assert.strictEqual(count, 10 * 10 * 2);
+
+    // Drawing zero-width image
+    ctx.drawImage(canvas, 0, 0, 0, 0, 0, 0, 0, 0);
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, 500, 500);
+
+    imgd = ctx.getImageData(0, 0, 500, 500);
+    data = imgd.data;
+    count = 0;
+
+    for(i = 0; i < 500 * 500 * 4; i += 4){
+      if(data[i] === 255 && data[i + 1] === 255 && data[i + 2] === 255)
+        count++;
+    }
+
+    assert.strictEqual(count, 500 * 500);
   });
 
   it('Context2d#SetFillColor()', function () {


### PR DESCRIPTION
Spec: https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage

> If one of the `sw` or `sh` arguments is zero, then return. Nothing is painted.

Currently, after executing this

```js
ctx.drawImage(image, 0, 0, 0, 0, 1, 1, 1, 1);
ctx.drawImage(image, 1, 1, 1, 1, 0, 0, 0, 0);
```

the rendering context stops drawing anything after it.

- [x] Updated the changelog
- [x] Added a test