### PR TITLE
Documentation fix: async to sync example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -401,7 +401,7 @@ ctx.addPage();
 ```js
 var canvas = createCanvas(200, 500, 'svg');
 // Use the normal primitives.
-fs.writeFile('out.svg', canvas.toBuffer());
+fs.writeFileSync('out.svg', canvas.toBuffer());
 ```
 
 ## SVG Image Support


### PR DESCRIPTION
`writeFile` should ask for a callback if it's async, in the example, the arguments are for sync, although it is used as async

- [ ] Have you updated CHANGELOG.md?
