### PR TITLE
Remove deprecation warning for v8::String::Utf8Value

### DIFF
--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -93,9 +93,9 @@ NAN_METHOD(Canvas::New) {
     if (info[1]->IsNumber()) height = info[1]->Uint32Value();
 
     if (info[2]->IsString()) {
-      if (0 == strcmp("pdf", *String::Utf8Value(Isolate::GetCurrent(), info[2])))
+      if (0 == strcmp("pdf", *Nan::Utf8String(info[2])))
         backend = new PdfBackend(width, height);
-      else if (0 == strcmp("svg", *String::Utf8Value(Isolate::GetCurrent(), info[2])))
+      else if (0 == strcmp("svg", *Nan::Utf8String(info[2])))
         backend = new SvgBackend(width, height);
       else
         backend = new ImageBackend(width, height);
@@ -638,7 +638,7 @@ NAN_METHOD(Canvas::StreamJPEGSync) {
 char *
 str_value(Local<Value> val, const char *fallback, bool can_be_number) {
   if (val->IsString() || (can_be_number && val->IsNumber())) {
-    return g_strdup(*String::Utf8Value(Isolate::GetCurrent(), val));
+    return g_strdup(*Nan::Utf8String(val));
   } else if (fallback) {
     return g_strdup(fallback);
   } else {
@@ -653,7 +653,7 @@ NAN_METHOD(Canvas::RegisterFont) {
     return Nan::ThrowError(GENERIC_FACE_ERROR);
   }
 
-  String::Utf8Value filePath(Isolate::GetCurrent(), info[0]);
+  Nan::Utf8String filePath(info[0]);
   PangoFontDescription *sys_desc = get_pango_font_description((unsigned char *) *filePath);
 
   if (!sys_desc) return Nan::ThrowError("Could not parse font file");

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -93,9 +93,9 @@ NAN_METHOD(Canvas::New) {
     if (info[1]->IsNumber()) height = info[1]->Uint32Value();
 
     if (info[2]->IsString()) {
-      if (0 == strcmp("pdf", *String::Utf8Value(info[2])))
+      if (0 == strcmp("pdf", *String::Utf8Value(Isolate::GetCurrent(), info[2])))
         backend = new PdfBackend(width, height);
-      else if (0 == strcmp("svg", *String::Utf8Value(info[2])))
+      else if (0 == strcmp("svg", *String::Utf8Value(Isolate::GetCurrent(), info[2])))
         backend = new SvgBackend(width, height);
       else
         backend = new ImageBackend(width, height);
@@ -638,7 +638,7 @@ NAN_METHOD(Canvas::StreamJPEGSync) {
 char *
 str_value(Local<Value> val, const char *fallback, bool can_be_number) {
   if (val->IsString() || (can_be_number && val->IsNumber())) {
-    return g_strdup(*String::Utf8Value(val));
+    return g_strdup(*String::Utf8Value(Isolate::GetCurrent(), val));
   } else if (fallback) {
     return g_strdup(fallback);
   } else {
@@ -653,7 +653,7 @@ NAN_METHOD(Canvas::RegisterFont) {
     return Nan::ThrowError(GENERIC_FACE_ERROR);
   }
 
-  String::Utf8Value filePath(info[0]);
+  String::Utf8Value filePath(Isolate::GetCurrent(), info[0]);
   PangoFontDescription *sys_desc = get_pango_font_description((unsigned char *) *filePath);
 
   if (!sys_desc) return Nan::ThrowError("Could not parse font file");

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -80,7 +80,7 @@ NAN_METHOD(Gradient::AddColorStop) {
 
   Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(info.This());
   short ok;
-  String::Utf8Value str(Isolate::GetCurrent(), info[1]);
+  Nan::Utf8String str(info[1]);
   uint32_t rgba = rgba_from_string(*str, &ok);
 
   if (ok) {

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -80,7 +80,7 @@ NAN_METHOD(Gradient::AddColorStop) {
 
   Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(info.This());
   short ok;
-  String::Utf8Value str(info[1]);
+  String::Utf8Value str(Isolate::GetCurrent(), info[1]);
   uint32_t rgba = rgba_from_string(*str, &ok);
 
   if (ok) {

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -64,11 +64,11 @@ NAN_METHOD(Pattern::New) {
     return Nan::ThrowTypeError("Image or Canvas expected");
   }
   repeat_type_t repeat = REPEAT;
-  if (0 == strcmp("no-repeat", *String::Utf8Value(info[1]))) {
+  if (0 == strcmp("no-repeat", *String::Utf8Value(Isolate::GetCurrent(), info[1]))) {
     repeat = NO_REPEAT;
-  } else if (0 == strcmp("repeat-x", *String::Utf8Value(info[1]))) {
+  } else if (0 == strcmp("repeat-x", *String::Utf8Value(Isolate::GetCurrent(), info[1]))) {
     repeat = REPEAT_X;
-  } else if (0 == strcmp("repeat-y", *String::Utf8Value(info[1]))) {
+  } else if (0 == strcmp("repeat-y", *String::Utf8Value(Isolate::GetCurrent(), info[1]))) {
     repeat = REPEAT_Y;
   }
   Pattern *pattern = new Pattern(surface, repeat);

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -64,11 +64,11 @@ NAN_METHOD(Pattern::New) {
     return Nan::ThrowTypeError("Image or Canvas expected");
   }
   repeat_type_t repeat = REPEAT;
-  if (0 == strcmp("no-repeat", *String::Utf8Value(Isolate::GetCurrent(), info[1]))) {
+  if (0 == strcmp("no-repeat", *Nan::Utf8String(info[1]))) {
     repeat = NO_REPEAT;
-  } else if (0 == strcmp("repeat-x", *String::Utf8Value(Isolate::GetCurrent(), info[1]))) {
+  } else if (0 == strcmp("repeat-x", *Nan::Utf8String(info[1]))) {
     repeat = REPEAT_X;
-  } else if (0 == strcmp("repeat-y", *String::Utf8Value(Isolate::GetCurrent(), info[1]))) {
+  } else if (0 == strcmp("repeat-y", *Nan::Utf8String(info[1]))) {
     repeat = REPEAT_Y;
   }
   Pattern *pattern = new Pattern(surface, repeat);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -335,7 +335,7 @@ void
 Context2d::setFillRule(v8::Local<v8::Value> value) {
   cairo_fill_rule_t rule = CAIRO_FILL_RULE_WINDING;
   if (value->IsString()) {
-    String::Utf8Value str(value);
+    String::Utf8Value str(Isolate::GetCurrent(), value);
     if (std::strcmp(*str, "evenodd") == 0) {
       rule = CAIRO_FILL_RULE_EVEN_ODD;
     }
@@ -654,7 +654,7 @@ NAN_METHOD(Context2d::New) {
 
       Local<Value> pixelFormat = ctxAttributes->Get(Nan::New("pixelFormat").ToLocalChecked());
       if (pixelFormat->IsString()) {
-        String::Utf8Value utf8PixelFormat(pixelFormat);
+        String::Utf8Value utf8PixelFormat(Isolate::GetCurrent(), pixelFormat);
         if (!strcmp(*utf8PixelFormat, "RGBA32")) format = CAIRO_FORMAT_ARGB32;
         else if (!strcmp(*utf8PixelFormat, "RGB24")) format = CAIRO_FORMAT_RGB24;
         else if (!strcmp(*utf8PixelFormat, "A8")) format = CAIRO_FORMAT_A8;
@@ -1335,7 +1335,7 @@ NAN_GETTER(Context2d::GetGlobalCompositeOperation) {
 
 NAN_SETTER(Context2d::SetPatternQuality) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-  String::Utf8Value quality(value->ToString());
+  String::Utf8Value quality(Isolate::GetCurrent(), value->ToString());
   if (0 == strcmp("fast", *quality)) {
     context->state->patternQuality = CAIRO_FILTER_FAST;
   } else if (0 == strcmp("good", *quality)) {
@@ -1373,7 +1373,7 @@ NAN_GETTER(Context2d::GetPatternQuality) {
 NAN_SETTER(Context2d::SetGlobalCompositeOperation) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
-  String::Utf8Value type(value->ToString());
+  String::Utf8Value type(Isolate::GetCurrent(), value->ToString());
   if (0 == strcmp("xor", *type)) {
     cairo_set_operator(ctx, CAIRO_OPERATOR_XOR);
   } else if (0 == strcmp("source-atop", *type)) {
@@ -1521,7 +1521,7 @@ NAN_GETTER(Context2d::GetAntiAlias) {
  */
 
 NAN_SETTER(Context2d::SetAntiAlias) {
-  String::Utf8Value str(value->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
   cairo_antialias_t a;
@@ -1561,7 +1561,7 @@ NAN_GETTER(Context2d::GetTextDrawingMode) {
  */
 
 NAN_SETTER(Context2d::SetTextDrawingMode) {
-  String::Utf8Value str(value->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   if (0 == strcmp("path", *str)) {
     context->state->textDrawingMode = TEXT_DRAW_PATHS;
@@ -1592,7 +1592,7 @@ NAN_GETTER(Context2d::GetFilter) {
  */
 
 NAN_SETTER(Context2d::SetFilter) {
-  String::Utf8Value str(value->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_filter_t filter;
   if (0 == strcmp("fast", *str)) {
@@ -1673,7 +1673,7 @@ NAN_GETTER(Context2d::GetLineJoin) {
 NAN_SETTER(Context2d::SetLineJoin) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
-  String::Utf8Value type(value->ToString());
+  String::Utf8Value type(Isolate::GetCurrent(), value->ToString());
   if (0 == strcmp("round", *type)) {
     cairo_set_line_join(ctx, CAIRO_LINE_JOIN_ROUND);
   } else if (0 == strcmp("bevel", *type)) {
@@ -1705,7 +1705,7 @@ NAN_GETTER(Context2d::GetLineCap) {
 NAN_SETTER(Context2d::SetLineCap) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
-  String::Utf8Value type(value->ToString());
+  String::Utf8Value type(Isolate::GetCurrent(), value->ToString());
   if (0 == strcmp("round", *type)) {
     cairo_set_line_cap(ctx, CAIRO_LINE_CAP_ROUND);
   } else if (0 == strcmp("square", *type)) {
@@ -1780,7 +1780,7 @@ NAN_METHOD(Context2d::SetStrokePattern) {
 
 NAN_SETTER(Context2d::SetShadowColor) {
   short ok;
-  String::Utf8Value str(value->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (ok) {
     Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
@@ -1807,7 +1807,7 @@ NAN_METHOD(Context2d::SetFillColor) {
   short ok;
 
   if (!info[0]->IsString()) return;
-  String::Utf8Value str(info[0]);
+  String::Utf8Value str(Isolate::GetCurrent(), info[0]);
   
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
@@ -1835,7 +1835,7 @@ NAN_METHOD(Context2d::SetStrokeColor) {
   short ok;
 
   if (!info[0]->IsString()) return;
-  String::Utf8Value str(info[0]);
+  String::Utf8Value str(Isolate::GetCurrent(), info[0]);
 
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
@@ -2085,7 +2085,7 @@ NAN_METHOD(Context2d::FillText) {
   if(!checkArgs(info, args, argsNum, 1))
     return;
 
-  String::Utf8Value str(info[0]->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), info[0]->ToString());
   double x = args[0];
   double y = args[1];
   double scaled_by = 1;
@@ -2120,7 +2120,7 @@ NAN_METHOD(Context2d::StrokeText) {
   if(!checkArgs(info, args, argsNum, 1))
     return;
 
-  String::Utf8Value str(info[0]->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), info[0]->ToString());
   double x = args[0];
   double y = args[1];
   double scaled_by = 1;
@@ -2245,11 +2245,11 @@ NAN_METHOD(Context2d::SetFont) {
     || !info[3]->IsString()
     || !info[4]->IsString()) return;
 
-  String::Utf8Value weight(info[0]);
-  String::Utf8Value style(info[1]);
+  String::Utf8Value weight(Isolate::GetCurrent(), info[0]);
+  String::Utf8Value style(Isolate::GetCurrent(), info[1]);
   double size = info[2]->NumberValue();
-  String::Utf8Value unit(info[3]);
-  String::Utf8Value family(info[4]);
+  String::Utf8Value unit(Isolate::GetCurrent(), info[3]);
+  String::Utf8Value family(Isolate::GetCurrent(), info[4]);
 
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
 
@@ -2282,7 +2282,7 @@ NAN_METHOD(Context2d::MeasureText) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
 
-  String::Utf8Value str(info[0]->ToString());
+  String::Utf8Value str(Isolate::GetCurrent(), info[0]->ToString());
   Local<Object> obj = Nan::New<Object>();
 
   PangoRectangle _ink_rect, _logical_rect;

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -335,7 +335,7 @@ void
 Context2d::setFillRule(v8::Local<v8::Value> value) {
   cairo_fill_rule_t rule = CAIRO_FILL_RULE_WINDING;
   if (value->IsString()) {
-    String::Utf8Value str(Isolate::GetCurrent(), value);
+    Nan::Utf8String str(value);
     if (std::strcmp(*str, "evenodd") == 0) {
       rule = CAIRO_FILL_RULE_EVEN_ODD;
     }
@@ -654,7 +654,7 @@ NAN_METHOD(Context2d::New) {
 
       Local<Value> pixelFormat = ctxAttributes->Get(Nan::New("pixelFormat").ToLocalChecked());
       if (pixelFormat->IsString()) {
-        String::Utf8Value utf8PixelFormat(Isolate::GetCurrent(), pixelFormat);
+        Nan::Utf8String utf8PixelFormat(pixelFormat);
         if (!strcmp(*utf8PixelFormat, "RGBA32")) format = CAIRO_FORMAT_ARGB32;
         else if (!strcmp(*utf8PixelFormat, "RGB24")) format = CAIRO_FORMAT_RGB24;
         else if (!strcmp(*utf8PixelFormat, "A8")) format = CAIRO_FORMAT_A8;
@@ -1335,7 +1335,7 @@ NAN_GETTER(Context2d::GetGlobalCompositeOperation) {
 
 NAN_SETTER(Context2d::SetPatternQuality) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-  String::Utf8Value quality(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String quality(value->ToString());
   if (0 == strcmp("fast", *quality)) {
     context->state->patternQuality = CAIRO_FILTER_FAST;
   } else if (0 == strcmp("good", *quality)) {
@@ -1373,7 +1373,7 @@ NAN_GETTER(Context2d::GetPatternQuality) {
 NAN_SETTER(Context2d::SetGlobalCompositeOperation) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
-  String::Utf8Value type(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String type(value->ToString());
   if (0 == strcmp("xor", *type)) {
     cairo_set_operator(ctx, CAIRO_OPERATOR_XOR);
   } else if (0 == strcmp("source-atop", *type)) {
@@ -1521,7 +1521,7 @@ NAN_GETTER(Context2d::GetAntiAlias) {
  */
 
 NAN_SETTER(Context2d::SetAntiAlias) {
-  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String str(value->ToString());
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
   cairo_antialias_t a;
@@ -1561,7 +1561,7 @@ NAN_GETTER(Context2d::GetTextDrawingMode) {
  */
 
 NAN_SETTER(Context2d::SetTextDrawingMode) {
-  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String str(value->ToString());
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   if (0 == strcmp("path", *str)) {
     context->state->textDrawingMode = TEXT_DRAW_PATHS;
@@ -1592,7 +1592,7 @@ NAN_GETTER(Context2d::GetFilter) {
  */
 
 NAN_SETTER(Context2d::SetFilter) {
-  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String str(value->ToString());
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_filter_t filter;
   if (0 == strcmp("fast", *str)) {
@@ -1673,7 +1673,7 @@ NAN_GETTER(Context2d::GetLineJoin) {
 NAN_SETTER(Context2d::SetLineJoin) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
-  String::Utf8Value type(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String type(value->ToString());
   if (0 == strcmp("round", *type)) {
     cairo_set_line_join(ctx, CAIRO_LINE_JOIN_ROUND);
   } else if (0 == strcmp("bevel", *type)) {
@@ -1705,7 +1705,7 @@ NAN_GETTER(Context2d::GetLineCap) {
 NAN_SETTER(Context2d::SetLineCap) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
-  String::Utf8Value type(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String type(value->ToString());
   if (0 == strcmp("round", *type)) {
     cairo_set_line_cap(ctx, CAIRO_LINE_CAP_ROUND);
   } else if (0 == strcmp("square", *type)) {
@@ -1780,7 +1780,7 @@ NAN_METHOD(Context2d::SetStrokePattern) {
 
 NAN_SETTER(Context2d::SetShadowColor) {
   short ok;
-  String::Utf8Value str(Isolate::GetCurrent(), value->ToString());
+  Nan::Utf8String str(value->ToString());
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (ok) {
     Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
@@ -1807,7 +1807,7 @@ NAN_METHOD(Context2d::SetFillColor) {
   short ok;
 
   if (!info[0]->IsString()) return;
-  String::Utf8Value str(Isolate::GetCurrent(), info[0]);
+  Nan::Utf8String str(info[0]);
   
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
@@ -1835,7 +1835,7 @@ NAN_METHOD(Context2d::SetStrokeColor) {
   short ok;
 
   if (!info[0]->IsString()) return;
-  String::Utf8Value str(Isolate::GetCurrent(), info[0]);
+  Nan::Utf8String str(info[0]);
 
   uint32_t rgba = rgba_from_string(*str, &ok);
   if (!ok) return;
@@ -2085,7 +2085,7 @@ NAN_METHOD(Context2d::FillText) {
   if(!checkArgs(info, args, argsNum, 1))
     return;
 
-  String::Utf8Value str(Isolate::GetCurrent(), info[0]->ToString());
+  Nan::Utf8String str(info[0]->ToString());
   double x = args[0];
   double y = args[1];
   double scaled_by = 1;
@@ -2120,7 +2120,7 @@ NAN_METHOD(Context2d::StrokeText) {
   if(!checkArgs(info, args, argsNum, 1))
     return;
 
-  String::Utf8Value str(Isolate::GetCurrent(), info[0]->ToString());
+  Nan::Utf8String str(info[0]->ToString());
   double x = args[0];
   double y = args[1];
   double scaled_by = 1;
@@ -2245,11 +2245,11 @@ NAN_METHOD(Context2d::SetFont) {
     || !info[3]->IsString()
     || !info[4]->IsString()) return;
 
-  String::Utf8Value weight(Isolate::GetCurrent(), info[0]);
-  String::Utf8Value style(Isolate::GetCurrent(), info[1]);
+  Nan::Utf8String weight(info[0]);
+  Nan::Utf8String style(info[1]);
   double size = info[2]->NumberValue();
-  String::Utf8Value unit(Isolate::GetCurrent(), info[3]);
-  String::Utf8Value family(Isolate::GetCurrent(), info[4]);
+  Nan::Utf8String unit(info[3]);
+  Nan::Utf8String family(info[4]);
 
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
 
@@ -2282,7 +2282,7 @@ NAN_METHOD(Context2d::MeasureText) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_t *ctx = context->context();
 
-  String::Utf8Value str(Isolate::GetCurrent(), info[0]->ToString());
+  Nan::Utf8String str(info[0]->ToString());
   Local<Object> obj = Nan::New<Object>();
 
   PangoRectangle _ink_rect, _logical_rect;

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -230,7 +230,7 @@ NAN_SETTER(Image::SetSource) {
 
   // url string
   if (value->IsString()) {
-    String::Utf8Value src(Isolate::GetCurrent(), value);
+    Nan::Utf8String src(value);
     if (img->filename) free(img->filename);
     img->filename = strdup(*src);
     status = img->load();

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -229,7 +229,7 @@ NAN_SETTER(Image::SetSource) {
 
   // url string
   if (value->IsString()) {
-    String::Utf8Value src(value);
+    String::Utf8Value src(Isolate::GetCurrent(), value);
     if (img->filename) free(img->filename);
     img->filename = strdup(*src);
     status = img->load();

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -25,7 +25,8 @@ typedef struct {
 #include <csetjmp>
 
 struct canvas_jpeg_error_mgr: jpeg_error_mgr {
-  jmp_buf setjmp_buffer;
+  private: char unused[8];
+  public: jmp_buf setjmp_buffer;
 };
 #endif
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -548,7 +548,7 @@ describe('Canvas', function () {
     });
 
     it('Canvas#toBuffer(callback, "image/jpeg")', function () {
-      var buf = createCanvas(200,200).toBuffer(function (err, buff) {
+      createCanvas(200,200).toBuffer(function (err, buf) {
         assert.ok(!err);
         assert.equal(buf[0], 0xff);
         assert.equal(buf[1], 0xd8);
@@ -558,7 +558,7 @@ describe('Canvas', function () {
     });
 
     it('Canvas#toBuffer(callback, "image/jpeg", {quality: 0.95})', function () {
-      var buf = createCanvas(200,200).toBuffer(function (err, buff) {
+      createCanvas(200,200).toBuffer(function (err, buf) {
         assert.ok(!err);
         assert.equal(buf[0], 0xff);
         assert.equal(buf[1], 0xd8);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -547,23 +547,25 @@ describe('Canvas', function () {
       });
     });
 
-    it('Canvas#toBuffer(callback, "image/jpeg")', function () {
+    it('Canvas#toBuffer(callback, "image/jpeg")', function (done) {
       createCanvas(200,200).toBuffer(function (err, buf) {
         assert.ok(!err);
         assert.equal(buf[0], 0xff);
         assert.equal(buf[1], 0xd8);
         assert.equal(buf[buf.byteLength - 2], 0xff);
         assert.equal(buf[buf.byteLength - 1], 0xd9);
+        done();
       }, 'image/jpeg');
     });
 
-    it('Canvas#toBuffer(callback, "image/jpeg", {quality: 0.95})', function () {
+    it('Canvas#toBuffer(callback, "image/jpeg", {quality: 0.95})', function (done) {
       createCanvas(200,200).toBuffer(function (err, buf) {
         assert.ok(!err);
         assert.equal(buf[0], 0xff);
         assert.equal(buf[1], 0xd8);
         assert.equal(buf[buf.byteLength - 2], 0xff);
         assert.equal(buf[buf.byteLength - 1], 0xd9);
+        done();
       }, 'image/jpeg', {quality: 0.95});
     });
 


### PR DESCRIPTION
* Fix deprecation warning related to String::Utf8Value
* Suppress alignment warning

Fixes https://github.com/Automattic/node-canvas/issues/1159

---

Also, there was a test which was failing at master (before this fix)

https://github.com/Automattic/node-canvas/blob/013223f92afdbb3265a7073368b9800fbacc40cf/test/canvas.test.js#L550-L558

Am I missing something here? Shouldn't it be like

```diff
- var buf = createCanvas(200,200).toBuffer(function (err, buff) {
+ createCanvas(200,200).toBuffer(function (err, buf) {
```

since the function is asynchronous and `var buf` is `undefined`?