### PR TITLE
Fix string formatting of RGBA colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ canvas.createJPEGStream() // new
  * Fix drawing zero-width and zero-height images.
  * Fix DEP0005 deprecation warning
  * Don't assume `data:` URIs assigned to `img.src` are always base64-encoded
+ * Fix formatting of color strings (e.g. `ctx.fillStyle`) on 32-bit platforms
 
 ### Added
  * Prebuilds (#992) with different libc versions to the prebuilt binary (#1140)

--- a/src/color.cc
+++ b/src/color.cc
@@ -458,16 +458,16 @@ rgba_create(uint32_t rgba) {
 void
 rgba_to_string(rgba_t rgba, char *buf, size_t len) {
   if (1 == rgba.a) {
-    snprintf(buf, len, "#%.2x%.2x%.2x"
-      , (int) (rgba.r * 255)
-      , (int) (rgba.g * 255)
-      , (int) (rgba.b * 255));
+    snprintf(buf, len, "#%.2x%.2x%.2x",
+      static_cast<int>(round(rgba.r * 255)),
+      static_cast<int>(round(rgba.g * 255)),
+      static_cast<int>(round(rgba.b * 255)));
   } else {
-    snprintf(buf, len, "rgba(%d, %d, %d, %.2f)"
-      , (int) (rgba.r * 255)
-      , (int) (rgba.g * 255)
-      , (int) (rgba.b * 255)
-      , rgba.a);
+    snprintf(buf, len, "rgba(%d, %d, %d, %.2f)",
+      static_cast<int>(round(rgba.r * 255)),
+      static_cast<int>(round(rgba.g * 255)),
+      static_cast<int>(round(rgba.b * 255)),
+      rgba.a);
   }
 }
 


### PR DESCRIPTION
Fixes #251. Casting truncates, so need to round. All tests now pass on 32-bit RHEL.

- [x] Have you updated CHANGELOG.md?
