### PR TITLE
Explicitly export some C++ symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ canvas.createJPEGStream() // new
  * Fix DEP0005 deprecation warning
  * Don't assume `data:` URIs assigned to `img.src` are always base64-encoded
  * Fix formatting of color strings (e.g. `ctx.fillStyle`) on 32-bit platforms
+ * Explicitly export symbols for the C++ API
 
 ### Added
  * Prebuilds (#992) with different libc versions to the prebuilt binary (#1140)

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -17,6 +17,7 @@
 #include <cairo.h>
 #include <nan.h>
 
+#include "dll_visibility.h"
 #include "backend/Backend.h"
 
 
@@ -70,16 +71,16 @@ class Canvas: public Nan::ObjectWrap {
     static PangoStyle GetStyleFromCSSString(const char *style);
     static PangoFontDescription *ResolveFontDescription(const PangoFontDescription *desc);
 
-    inline Backend* backend() { return _backend; }
-    inline cairo_surface_t* surface(){ return backend()->getSurface(); }
+    DLL_PUBLIC inline Backend* backend() { return _backend; }
+    DLL_PUBLIC inline cairo_surface_t* surface(){ return backend()->getSurface(); }
     cairo_t* createCairoContext();
 
-    inline uint8_t *data(){ return cairo_image_surface_get_data(surface()); }
-    inline int stride(){ return cairo_image_surface_get_stride(surface()); }
-    inline int nBytes(){ return getHeight() * stride(); }
+    DLL_PUBLIC inline uint8_t *data(){ return cairo_image_surface_get_data(surface()); }
+    DLL_PUBLIC inline int stride(){ return cairo_image_surface_get_stride(surface()); }
+    DLL_PUBLIC inline int nBytes(){ return getHeight() * stride(); }
 
-    inline int getWidth() { return backend()->getWidth(); }
-    inline int getHeight() { return backend()->getHeight(); }
+    DLL_PUBLIC inline int getWidth() { return backend()->getWidth(); }
+    DLL_PUBLIC inline int getHeight() { return backend()->getHeight(); }
 
     Canvas(Backend* backend);
     void resurface(Local<Object> canvas);

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -28,7 +28,7 @@ cairo_surface_t* Backend::recreateSurface()
   return this->createSurface();
 }
 
-cairo_surface_t* Backend::getSurface() {
+DLL_PUBLIC cairo_surface_t* Backend::getSurface() {
   if (!surface) createSurface();
   return surface;
 }

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -9,6 +9,8 @@
 #include <nan.h>
 #include <cairo.h>
 
+#include "../dll_visibility.h"
+
 class Canvas;
 
 using namespace std;
@@ -35,15 +37,15 @@ class Backend : public Nan::ObjectWrap
     virtual cairo_surface_t* createSurface() = 0;
     virtual cairo_surface_t* recreateSurface();
 
-    cairo_surface_t* getSurface();
+    DLL_PUBLIC cairo_surface_t* getSurface();
     void             destroySurface();
 
-    string getName();
+    DLL_PUBLIC string getName();
 
-    int getWidth();
+    DLL_PUBLIC int getWidth();
     virtual void setWidth(int width);
 
-    int getHeight();
+    DLL_PUBLIC int getHeight();
     virtual void setHeight(int height);
 
     // Overridden by ImageBackend. SVG and PDF thus always return INVALID.

--- a/src/dll_visibility.h
+++ b/src/dll_visibility.h
@@ -1,0 +1,20 @@
+#ifndef DLL_PUBLIC
+
+#if defined _WIN32
+  #ifdef __GNUC__
+    #define DLL_PUBLIC __attribute__ ((dllexport))
+  #else
+    #define DLL_PUBLIC __declspec(dllexport)
+  #endif
+  #define DLL_LOCAL
+#else
+  #if __GNUC__ >= 4
+    #define DLL_PUBLIC __attribute__ ((visibility ("default")))
+    #define DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define DLL_PUBLIC
+    #define DLL_LOCAL
+  #endif
+#endif
+
+#endif


### PR DESCRIPTION
This only affects the C++ API on Windows, where symbols are not always exported by default.

Linking against node-canvas used to happen to work, until backends were added and the combination of inlining lead to some missing symbols.

This is the correct thing to do when offering a C++ API. For example, node does it in node.h: https://github.com/nodejs/node/blob/602da6492f278c1345f7f2d82014d9248254476b/src/node.h#L25-L33 and v8: https://github.com/nodejs/node/blob/ca480719199d2ff38223aff8e301aced25d7e6f1/deps/v8/src/base/base-export.h. The directives for GCC are unnecessary since we don't use DLL_LOCAL yet and it exports by default, but using DLL_LOCAL in the future can offer some significant performance benefits (see https://gcc.gnu.org/wiki/Visibility).

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?

---

For now, this API is sufficient to get the cairo surface, its data pointer, its width/height and its type. That's enough to write `toBuffer` encoder formats (e.g. webp, which I'm playing with now as a pluggable extension).
