### PR TITLE
CSS colors: case-insensitive, faster lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ canvas.createJPEGStream() // new
  * Don't assume `data:` URIs assigned to `img.src` are always base64-encoded
  * Fix formatting of color strings (e.g. `ctx.fillStyle`) on 32-bit platforms
  * Explicitly export symbols for the C++ API
+ * Named CSS colors should match case-insensitive
 
 ### Added
  * Prebuilds (#992) with different libc versions to the prebuilt binary (#1140)

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -64,6 +64,10 @@ function done (benchmark, times, start, isAsync) {
 
 // node-canvas
 
+bm('fillStyle= name', function () {
+  ctx.fillStyle = "transparent";
+});
+
 bm('lineTo()', function () {
   ctx.lineTo(0, 50)
 })

--- a/src/color.cc
+++ b/src/color.cc
@@ -8,7 +8,8 @@
 #include <cstdlib>
 #include <cmath>
 #include <limits>
-
+#include <string>
+#include <algorithm>
 #include "color.h"
 
 // Compatibility with Visual Studio versions prior to VS2015
@@ -398,7 +399,6 @@ static struct named_color {
   , { "whitesmoke", 0xF5F5F5FF }
   , { "yellow", 0xFFFF00FF }
   , { "yellowgreen", 0x9ACD32FF }
-  , { NULL, 0 }
 };
 
 /*
@@ -727,11 +727,12 @@ rgba_from_hex_string(const char *str, short *ok) {
 
 static int32_t
 rgba_from_name_string(const char *str, short *ok) {
-  int i = 0;
-  struct named_color color;
-  while ((color = named_colors[i++]).name) {
-    if (*str == *color.name && 0 == strcmp(str, color.name))
+  std::string lowered(str);
+  std::transform(lowered.begin(), lowered.end(), lowered.begin(), tolower);
+  for (auto color : named_colors) {
+    if (color.name == lowered) {
       return *ok = 1, color.val;
+    }
   }
   return *ok = 0;
 }

--- a/src/color.cc
+++ b/src/color.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <algorithm>
 #include "color.h"
+#include <map>
 
 // Compatibility with Visual Studio versions prior to VS2015
 #if defined(_MSC_VER) && _MSC_VER < 1900
@@ -245,11 +246,7 @@ parse_clipped_percentage(const char** pStr, float *pFraction) {
 /*
  * Named colors.
  */
-
-static struct named_color {
-  const char *name;
-  uint32_t val;
-} named_colors[] = {
+static const std::map<std::string, uint32_t> named_colors = {
     { "transparent", 0xFFFFFF00}
   , { "aliceblue", 0xF0F8FFFF }
   , { "antiquewhite", 0xFAEBD7FF }
@@ -729,10 +726,9 @@ static int32_t
 rgba_from_name_string(const char *str, short *ok) {
   std::string lowered(str);
   std::transform(lowered.begin(), lowered.end(), lowered.begin(), tolower);
-  for (auto color : named_colors) {
-    if (color.name == lowered) {
-      return *ok = 1, color.val;
-    }
+  auto color = named_colors.find(lowered);
+  if (color != named_colors.end()) {
+    return *ok = 1, color->second;
   }
   return *ok = 0;
 }

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -238,6 +238,10 @@ describe('Canvas', function () {
 
     ctx.fillStyle = 'hsl(1.24e2, 760e-1%, 4.7e1%)';
     assert.equal('#1dd329', ctx.fillStyle);
+
+    // case-insensitive (#235)
+    ctx.fillStyle = "sILveR";
+    assert.equal(ctx.fillStyle, "#c0c0c0");
   });
 
   it('Canvas#type', function () {


### PR DESCRIPTION
Fixes #235

Also improves performance:

| color | AoS loop | `std::map` |
| --- | ---: | ---: |
| "whitesmoke" (near end of array) | 668,905 | 2,764,503 |
| "transparent" (beginning of array) | 4,519,027 | 4,578,934 |

- [x] Have you updated CHANGELOG.md?
