### PR TITLE
Fix build with SVG support enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - libjpeg8-dev
       - libpango1.0-dev
       - libgif-dev
+      - librsvg2-dev
       - g++-4.9
 env:
   - CXX=g++-4.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ canvas.createJPEGStream() // new
    on the incorrect types.
 
 ### Fixed
- * Fix build with SVG support (#1205)
+ * Fix build with SVG support enabled (#1123)
  * Prevent segfaults caused by loading invalid fonts (#1105)
  * Fix memory leak in font loading
  * Port has_lib.sh to javascript (#872)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ canvas.createJPEGStream() // new
    on the incorrect types.
 
 ### Fixed
+ * Fix build with SVG support (#1205)
  * Prevent segfaults caused by loading invalid fonts (#1105)
  * Fix memory leak in font loading
  * Port has_lib.sh to javascript (#872)

--- a/binding.gyp
+++ b/binding.gyp
@@ -191,6 +191,17 @@
           ],
           'conditions': [
             ['OS=="win"', {
+              'copies': [{
+                'destination': '<(PRODUCT_DIR)',
+                'files': [
+                  '<(GTK_Root)/bin/librsvg-2-2.dll',
+                  '<(GTK_Root)/bin/libgdk_pixbuf-2.0-0.dll',
+                  '<(GTK_Root)/bin/libgio-2.0-0.dll',
+                  '<(GTK_Root)/bin/libcroco-0.6-3.dll',
+                  '<(GTK_Root)/bin/libgsf-1-114.dll',
+                  '<(GTK_Root)/bin/libxml2-2.dll'
+                ]
+              }],
               'libraries': [
                 '-l<(GTK_Root)/lib/librsvg-2-2.lib'
               ]

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -392,7 +392,7 @@ cairo_surface_t *Image::surface() {
     cairo_status_t status = renderSVGToSurface();
     if (status != CAIRO_STATUS_SUCCESS) {
       g_object_unref(_rsvg);
-      error(Canvas::Error(status));
+      Nan::ThrowError(Canvas::Error(status));
       return NULL;
     }
   }

--- a/src/Image.h
+++ b/src/Image.h
@@ -86,7 +86,6 @@ class Image: public Nan::ObjectWrap {
     cairo_status_t assignDataAsMime(uint8_t *data, int len, const char *mime_type);
 #endif
 #endif
-    void error(Local<Value> error);
     void loaded();
     cairo_status_t load();
     Image();


### PR DESCRIPTION
This PR fixes build with svg support enabled. It replaces call of inexistent `error` method of Image class with an exception. In addition, It adjusts build process to copy librsvg and its dependencies into destination folder (this is what I had to do manually on each build).

P.S.: I have no experience in node modules development, so this PR must be examined thoroughly. :)
