### PR TITLE
support reading data URL on Canvas.Image#src.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ canvas.createJPEGStream() // new
    `canvas.createPNGStream()`
  * Support for `canvas.toDataURI("image/jpeg")` (sync)
  * Support for `img.src = <url>` to match browsers
+ * Support reading data URL on `img.src`
 
 1.6.x (unreleased)
 ==================

--- a/lib/image.js
+++ b/lib/image.js
@@ -31,8 +31,9 @@ Object.defineProperty(Image.prototype, 'src', {
         const commaI = val.indexOf(',')
         // 'base64' must come before the comma
         const isBase64 = val.lastIndexOf('base64', commaI)
-        val = val.slice(commaI + 1)
-        this.source = Buffer.from(val, isBase64 ? 'base64' : 'utf8')
+        const content = val.slice(commaI + 1)
+        this.source = Buffer.from(content, isBase64 ? 'base64' : 'utf8')
+        this.originalSource = val
       } else if (/^\s*http/.test(val)) { // remote URL
         const onerror = err => {
           if (typeof this.onerror === 'function') {
@@ -49,19 +50,22 @@ Object.defineProperty(Image.prototype, 'src', {
           res.on('data', buffer => buffers.push(buffer))
           res.on('end', () => {
             this.source = Buffer.concat(buffers)
+            this.originalSource = undefined
           })
         }).on('error', onerror)
       } else { // local file path assumed
         this.source = val
+        this.originalSource = undefined
       }
     } else if (Buffer.isBuffer(val)) {
       this.source = val
+      this.originalSource = undefined
     }
   },
 
   get() {
     // TODO https://github.com/Automattic/node-canvas/issues/118
-    return this.source;
+    return this.originalSource || this.source;
   }
 });
 

--- a/lib/image.js
+++ b/lib/image.js
@@ -33,7 +33,7 @@ Object.defineProperty(Image.prototype, 'src', {
         const isBase64 = val.lastIndexOf('base64', commaI)
         const content = val.slice(commaI + 1)
         this.source = Buffer.from(content, isBase64 ? 'base64' : 'utf8')
-        this.originalSource = val
+        this._originalSource = val
       } else if (/^\s*http/.test(val)) { // remote URL
         const onerror = err => {
           if (typeof this.onerror === 'function') {
@@ -50,22 +50,22 @@ Object.defineProperty(Image.prototype, 'src', {
           res.on('data', buffer => buffers.push(buffer))
           res.on('end', () => {
             this.source = Buffer.concat(buffers)
-            this.originalSource = undefined
+            this._originalSource = undefined
           })
         }).on('error', onerror)
       } else { // local file path assumed
         this.source = val
-        this.originalSource = undefined
+        this._originalSource = undefined
       }
     } else if (Buffer.isBuffer(val)) {
       this.source = val
-      this.originalSource = undefined
+      this._originalSource = undefined
     }
   },
 
   get() {
     // TODO https://github.com/Automattic/node-canvas/issues/118
-    return this.originalSource || this.source;
+    return this._originalSource || this.source;
   }
 });
 

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -39,12 +39,42 @@ describe('Image', function () {
     })
   })
 
+  it('loads JPEG data URL', function () {
+    const base64Encoded = fs.readFileSync(jpg_face, 'base64')
+    const dataURL = `data:image/png;base64,${base64Encoded}`
+
+    return loadImage(dataURL).then((img) => {
+      assert.strictEqual(img.onerror, null)
+      assert.strictEqual(img.onload, null)
+
+      assert.strictEqual(img.src, dataURL)
+      assert.strictEqual(img.width, 485)
+      assert.strictEqual(img.height, 401)
+      assert.strictEqual(img.complete, true)
+    })
+  })
+
   it('loads PNG image', function () {
     return loadImage(png_clock).then((img) => {
       assert.strictEqual(img.onerror, null)
       assert.strictEqual(img.onload, null)
 
       assert.strictEqual(img.src, png_clock)
+      assert.strictEqual(img.width, 320)
+      assert.strictEqual(img.height, 320)
+      assert.strictEqual(img.complete, true)
+    })
+  })
+
+  it('loads PNG data URL', function () {
+    const base64Encoded = fs.readFileSync(png_clock, 'base64')
+    const dataURL = `data:image/png;base64,${base64Encoded}`
+
+    return loadImage(dataURL).then((img) => {
+      assert.strictEqual(img.onerror, null)
+      assert.strictEqual(img.onload, null)
+
+      assert.strictEqual(img.src, dataURL)
       assert.strictEqual(img.width, 320)
       assert.strictEqual(img.height, 320)
       assert.strictEqual(img.complete, true)


### PR DESCRIPTION
This pull-request makes we can read data URL on `Canvas.Image#src`.

This pull-request doesn't have idealistic solution. I think idealistic solution is: `Canvas.Image#src` returns data URL by internal Cairo objects. But that solution has several flags and complex implementation.

So, this pull-request uses simply and pragmatic solution (save original data).
