### PR TITLE
Support https urls

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -36,10 +36,18 @@ Object.defineProperty(Image.prototype, 'src', {
         this.source = Buffer.from(content, isBase64 ? 'base64' : 'utf8')
         this._originalSource = val
       } else if (/^\s*https?:\/\//.test(val)) { // remote URL
+        const onerror = err => {
+          if (typeof this.onerror === 'function') {
+            this.onerror(err)
+          } else {
+            throw err
+          }
+        }
+
         const type = /^\s*https:\/\//.test(val) ? https : http
         type.get(val, res => {
           if (res.statusCode !== 200) {
-            return this.onHttpError(new Error(`Server responded with ${res.statusCode}`))
+            return onerror(new Error(`Server responded with ${res.statusCode}`))
           }
           const buffers = []
           res.on('data', buffer => buffers.push(buffer))
@@ -47,7 +55,7 @@ Object.defineProperty(Image.prototype, 'src', {
             this.source = Buffer.concat(buffers)
             this._originalSource = undefined
           })
-        }).on('error', this.onHttpError.bind(this))
+        }).on('error', onerror)
       } else { // local file path assumed
         this.source = val
         this._originalSource = undefined
@@ -57,6 +65,7 @@ Object.defineProperty(Image.prototype, 'src', {
       this._originalSource = undefined
     }
   },
+
   get() {
     // TODO https://github.com/Automattic/node-canvas/issues/118
     return this._originalSource || this.source;
@@ -78,12 +87,4 @@ Image.prototype.inspect = function(){
     + (this.src ? ' ' + this.src : '')
     + (this.complete ? ' complete' : '')
     + ']';
-};
-
-Image.prototype.onHttpError = function(err) {
-  if (typeof this.onerror === 'function') {
-    this.onerror(err)
-  } else {
-    throw err
-  }
 };

--- a/lib/image.js
+++ b/lib/image.js
@@ -35,8 +35,9 @@ Object.defineProperty(Image.prototype, 'src', {
         const content = val.slice(commaI + 1)
         this.source = Buffer.from(content, isBase64 ? 'base64' : 'utf8')
         this._originalSource = val
-      } else if (/^\s*https:\/\//.test(val)) { // https URL
-        https.get(val, res => {
+      } else if (/^\s*https?:\/\//.test(val)) { // remote URL
+        const type = /^\s*https:\/\//.test(val) ? https : http
+        type.get(val, res => {
           if (res.statusCode !== 200) {
             return this.onHttpError(new Error(`Server responded with ${res.statusCode}`))
           }
@@ -46,19 +47,7 @@ Object.defineProperty(Image.prototype, 'src', {
             this.source = Buffer.concat(buffers)
             this._originalSource = undefined
           })
-        }).on('error', this.onHttpError)
-      } else if (/^\s*http:\/\//.test(val)) { // http URL
-        http.get(val, res => {
-          if (res.statusCode !== 200) {
-            return this.onHttpError(new Error(`Server responded with ${res.statusCode}`))
-          }
-          const buffers = []
-          res.on('data', buffer => buffers.push(buffer))
-          res.on('end', () => {
-            this.source = Buffer.concat(buffers)
-            this._originalSource = undefined
-          })
-        }).on('error', this.onHttpError)
+        }).on('error', this.onHttpError.bind(this))
       } else { // local file path assumed
         this.source = val
         this._originalSource = undefined
@@ -66,13 +55,6 @@ Object.defineProperty(Image.prototype, 'src', {
     } else if (Buffer.isBuffer(val)) {
       this.source = val
       this._originalSource = undefined
-    }
-  },
-  onHttpError: err => {
-    if (typeof this.onerror === 'function') {
-      this.onerror(err)
-    } else {
-      throw err
     }
   },
   get() {
@@ -96,4 +78,12 @@ Image.prototype.inspect = function(){
     + (this.src ? ' ' + this.src : '')
     + (this.complete ? ' complete' : '')
     + ']';
+};
+
+Image.prototype.onHttpError = function(err) {
+  if (typeof this.onerror === 'function') {
+    this.onerror(err)
+  } else {
+    throw err
+  }
 };

--- a/lib/image.js
+++ b/lib/image.js
@@ -13,6 +13,7 @@
 const bindings = require('./bindings')
 const Image = module.exports = bindings.Image
 const http = require("http")
+const https = require("https")
 
 Object.defineProperty(Image.prototype, 'src', {
   /**
@@ -34,17 +35,10 @@ Object.defineProperty(Image.prototype, 'src', {
         const content = val.slice(commaI + 1)
         this.source = Buffer.from(content, isBase64 ? 'base64' : 'utf8')
         this._originalSource = val
-      } else if (/^\s*http/.test(val)) { // remote URL
-        const onerror = err => {
-          if (typeof this.onerror === 'function') {
-            this.onerror(err)
-          } else {
-            throw err
-          }
-        }
-        http.get(val, res => {
+      } else if (/^\s*https:\/\//.test(val)) { // https URL
+        https.get(val, res => {
           if (res.statusCode !== 200) {
-            return onerror(new Error(`Server responded with ${res.statusCode}`))
+            return this.onHttpError(new Error(`Server responded with ${res.statusCode}`))
           }
           const buffers = []
           res.on('data', buffer => buffers.push(buffer))
@@ -52,7 +46,19 @@ Object.defineProperty(Image.prototype, 'src', {
             this.source = Buffer.concat(buffers)
             this._originalSource = undefined
           })
-        }).on('error', onerror)
+        }).on('error', this.onHttpError)
+      } else if (/^\s*http:\/\//.test(val)) { // http URL
+        http.get(val, res => {
+          if (res.statusCode !== 200) {
+            return this.onHttpError(new Error(`Server responded with ${res.statusCode}`))
+          }
+          const buffers = []
+          res.on('data', buffer => buffers.push(buffer))
+          res.on('end', () => {
+            this.source = Buffer.concat(buffers)
+            this._originalSource = undefined
+          })
+        }).on('error', this.onHttpError)
       } else { // local file path assumed
         this.source = val
         this._originalSource = undefined
@@ -62,7 +68,13 @@ Object.defineProperty(Image.prototype, 'src', {
       this._originalSource = undefined
     }
   },
-
+  onHttpError: err => {
+    if (typeof this.onerror === 'function') {
+      this.onerror(err)
+    } else {
+      throw err
+    }
+  },
   get() {
     // TODO https://github.com/Automattic/node-canvas/issues/118
     return this._originalSource || this.source;


### PR DESCRIPTION
Hey there, seems like http support was added for `Image.src`, but it throws an error when providing an https URL. This PR should resolve that.

I would've updated/changed tests, but it doesn't look like there are any for URL `src` values.