### PR TITLE
Make src property on Image.prototype configurable

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -69,7 +69,9 @@ Object.defineProperty(Image.prototype, 'src', {
   get() {
     // TODO https://github.com/Automattic/node-canvas/issues/118
     return this._originalSource || this.source;
-  }
+  },
+
+  configurable: true
 });
 
 /**


### PR DESCRIPTION
A fix for https://github.com/Automattic/node-canvas/issues/1224

I have checked with Jest locally: the `Cannot redefine property: src` error went away after making the `src` property on the `Image` prototype configurable.