### PR TITLE
Throw/emit nice errors if built without needed image format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ canvas.createJPEGStream() // new
  * Support for `img.src = <url>` to match browsers
  * Support reading data URL on `img.src`
  * Readme: add dependencies command for OpenBSD
+ * Throw error if calling jpegStream when canvas was not built with JPEG support
+ * Emit error if trying to load GIF, SVG or JPEG image when canvas was not built
+   with support for that format
 
 1.6.x (unreleased)
 ==================

--- a/lib/jpegstream.js
+++ b/lib/jpegstream.js
@@ -34,6 +34,10 @@ var JPEGStream = module.exports = function JPEGStream(canvas, options) {
     throw new TypeError("Class constructors cannot be invoked without 'new'");
   }
 
+  if (canvas.streamJPEGSync === undefined) {
+    throw new Error("node-canvas was built without JPEG support.");
+  }
+
   Readable.call(this);
 
   this.options = options;


### PR DESCRIPTION
`canvas.jpegStream` without JPEG support -> throw errors
`img.src = xxx` without support for that format -> emit error

Fixes #770

- [x] Have you updated CHANGELOG.md?
