### PR TITLE
update the layout before calculating the extent fix for #1088

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2059,7 +2059,7 @@ NAN_METHOD(Context2d::Stroke) {
 
 double
 get_text_scale(Context2d *context, char *str, double maxWidth) {
-  PangoLayout *layout = context->layout()
+  PangoLayout *layout = context->layout();
   PangoRectangle logical_rect;
   pango_layout_set_text(layout, str, -1);
   pango_cairo_update_layout(context->context(), layout);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2059,10 +2059,11 @@ NAN_METHOD(Context2d::Stroke) {
 
 double
 get_text_scale(Context2d *context, char *str, double maxWidth) {
+  PangoLayout *layout = context->layout()
   PangoRectangle logical_rect;
-  pango_layout_set_text(context->layout(), str, -1);
-  pango_cairo_update_layout(context->context(), context->layout());
-  pango_layout_get_pixel_extents(context->layout(), NULL, &logical_rect);
+  pango_layout_set_text(layout, str, -1);
+  pango_cairo_update_layout(context->context(), layout);
+  pango_layout_get_pixel_extents(layout, NULL, &logical_rect);
 
   if (logical_rect.width > maxWidth) {
     return maxWidth / logical_rect.width;

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2059,9 +2059,10 @@ NAN_METHOD(Context2d::Stroke) {
 
 double
 get_text_scale(Context2d *context, char *str, double maxWidth) {
-  PangoLayout *layout = context->layout();
   PangoRectangle logical_rect;
-  pango_layout_get_pixel_extents(layout, NULL, &logical_rect);
+  pango_layout_set_text(context->layout(), str, -1);
+  pango_cairo_update_layout(context->context(), context->layout());
+  pango_layout_get_pixel_extents(context->layout(), NULL, &logical_rect);
 
   if (logical_rect.width > maxWidth) {
     return maxWidth / logical_rect.width;
@@ -2083,7 +2084,6 @@ paintText(const Nan::FunctionCallbackInfo<Value> &info, bool stroke) {
   double scaled_by = 1;
 
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-
   if (argsNum == 3) {
     scaled_by = get_text_scale(context, *str, args[2]);
     cairo_save(context->context());

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2097,9 +2097,9 @@ paintText(const Nan::FunctionCallbackInfo<Value> &info, bool stroke) {
   context->savePath();
   if (context->state->textDrawingMode == TEXT_DRAW_GLYPHS) {
     if (stroke == true) { context->stroke(); } else { context->fill(); }
-    context->setTextPath(*str, x, y);
+    context->setTextPath(x, y);
   } else if (context->state->textDrawingMode == TEXT_DRAW_PATHS) {
-    context->setTextPath(*str, x, y);
+    context->setTextPath(x, y);
     if (stroke == true) { context->stroke(); } else { context->fill(); }
   }
   context->restorePath();
@@ -2148,14 +2148,14 @@ inline double getBaselineAdjustment(PangoLayout* layout, short baseline) {
 }
 
 /*
- * Set text path for the given string at (x, y).
+ * Set text path for the string in the layout at (x, y).
  * This function is called by paintText and won't behave correctly
  * if is not called from there.
  * it needs pango_layout_set_text and pango_cairo_update_layout to be called before
  */
 
 void
-Context2d::setTextPath(const char *str, double x, double y) {
+Context2d::setTextPath(double x, double y) {
   PangoRectangle logical_rect;
 
   switch (state->textAlignment) {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2058,7 +2058,7 @@ NAN_METHOD(Context2d::Stroke) {
  */
 
 double
-get_text_scale(PangoLayout *layout, char *str, double maxWidth) {
+get_text_scale(PangoLayout *layout, double maxWidth) {
 
   PangoRectangle logical_rect;
   pango_layout_get_pixel_extents(layout, NULL, &logical_rect);
@@ -2085,11 +2085,11 @@ paintText(const Nan::FunctionCallbackInfo<Value> &info, bool stroke) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   PangoLayout *layout = context->layout();
 
-  pango_layout_set_text(layout, str, -1);
+  pango_layout_set_text(layout, *str, -1);
   pango_cairo_update_layout(context->context(), layout);
 
   if (argsNum == 3) {
-    scaled_by = get_text_scale(layout, *str, args[2]);
+    scaled_by = get_text_scale(layout, args[2]);
     cairo_save(context->context());
     cairo_scale(context->context(), scaled_by, 1);
   }

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -156,7 +156,7 @@ class Context2d: public Nan::ObjectWrap {
     inline bool hasShadow();
     void inline setSourceRGBA(rgba_t color);
     void inline setSourceRGBA(cairo_t *ctx, rgba_t color);
-    void setTextPath(const char *str, double x, double y);
+    void setTextPath(double x, double y);
     void blur(cairo_surface_t *surface, int radius);
     void shadow(void (fn)(cairo_t *cr));
     void shadowStart();

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -860,19 +860,19 @@ tests['fillText() maxWidth argument'] = function (ctx) {
 }
 
 tests['maxWidth bug first usage path'] = function (ctx, done) {
-  ctx.textDrawingMode = 'path';
+  ctx.textDrawingMode = 'path'
   ctx.fillText('Drawing text can be fun!', 0, 20, 50)
   ctx.fillText('Drawing text can be fun!', 0, 40, 50)
   ctx.fillText('Drawing text can be fun changing text bug!', 0, 60, 50)
-  done();
+  done()
 }
 
 tests['maxWidth bug first usage glyph'] = function (ctx, done) {
-  ctx.textDrawingMode = 'glyph';
+  ctx.textDrawingMode = 'glyph'
   ctx.fillText('Drawing text can be fun!', 0, 20, 50)
   ctx.fillText('Drawing text can be fun!', 0, 40, 50)
   ctx.fillText('Drawing text can be fun changing text bug!', 0, 60, 50)
-  done();
+  done()
 }
 
 tests['strokeText()'] = function (ctx) {

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -859,6 +859,22 @@ tests['fillText() maxWidth argument'] = function (ctx) {
   ctx.fillText('Drawing text can be fun!', 0, 20 * 7)
 }
 
+tests['maxWidth bug first usage path'] = function (ctx, done) {
+  ctx.textDrawingMode = 'path';
+  ctx.fillText('Drawing text can be fun!', 0, 20, 50)
+  ctx.fillText('Drawing text can be fun!', 0, 40, 50)
+  ctx.fillText('Drawing text can be fun changing text bug!', 0, 60, 50)
+  done();
+}
+
+tests['maxWidth bug first usage glyph'] = function (ctx, done) {
+  ctx.textDrawingMode = 'glyph';
+  ctx.fillText('Drawing text can be fun!', 0, 20, 50)
+  ctx.fillText('Drawing text can be fun!', 0, 40, 50)
+  ctx.fillText('Drawing text can be fun changing text bug!', 0, 60, 50)
+  done();
+}
+
 tests['strokeText()'] = function (ctx) {
   ctx.strokeStyle = '#666'
   ctx.strokeRect(0, 0, 200, 200)


### PR DESCRIPTION
In get_text_scale we are using pango_layout_get_pixel_extent without first updating the text for the layout.
So the bug in #1088, since measurement happen on last text used in measureText or setTextPath.

Added tests for regressiong ( visual )
![image](https://user-images.githubusercontent.com/1194048/45001045-0b248f00-afca-11e8-99ba-c16e58eba228.png)

Test before fix
![image](https://user-images.githubusercontent.com/1194048/45001060-42933b80-afca-11e8-929b-2ab06e49991e.png)


close #1088