### PR TITLE
add 2 svg failing tests for scaling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ You can quickly install the dependencies by using the command for your OS:
 
 OS | Command
 ----- | -----
-OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib`<br/><br/>Using [MacPorts](https://www.macports.org/):<br/>`port install pkgconfig cairo pango libpng jpeg giflib`
+OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib`<br/><br/>Using [MacPorts](https://www.macports.org/):<br/>`port install pkgconfig cairo pango libpng jpeg giflib libsrvg`
 Ubuntu | `sudo apt-get install libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++`
 Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
 Solaris | `pkgin install cairo pango pkg-config xproto renderproto kbproto xextproto`
@@ -178,7 +178,7 @@ image contained in the canvas.
     the background palette index (indexed PNGs only) and/or the resolution (ppi):
     `{compressionLevel: 6, filters: canvas.PNG_ALL_FILTERS, palette: undefined, backgroundIndex: 0, resolution: undefined}`.
     All properties are optional.
-    
+
     Note that the PNG format encodes the resolution in pixels per meter, so if
     you specify `96`, the file will encode 3780 ppm (~96.01 ppi). The resolution
     is undefined by default to match common browser behavior.

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1687,6 +1687,31 @@ tests['drawImage(img) svg'] = function (ctx, done) {
   img.src = imageSrc('tree.svg')
 }
 
+tests['drawImage(img) svg with scaling from drawImage'] = function (ctx, done) {
+  var img = new Image()
+  img.onload = function () {
+    ctx.drawImage(img, -800, -800, 1000, 1000)
+    done(null)
+  }
+  img.onerror = function () {
+    done(new Error('Failed to load image'))
+  }
+  img.src = imageSrc('tree.svg')
+}
+
+tests['drawImage(img) svg with scaling from ctx'] = function (ctx, done) {
+  var img = new Image()
+  img.onload = function () {
+    ctx.scale(100, 100)
+    ctx.drawImage(img, -8, -8, 10, 10)
+    done(null)
+  }
+  img.onerror = function () {
+    done(new Error('Failed to load image'))
+  }
+  img.src = imageSrc('tree.svg')
+}
+
 tests['drawImage(img,x,y)'] = function (ctx, done) {
   var img = new Image()
   img.onload = function () {


### PR DESCRIPTION
Add 2 tests to show a defect in svg scaling during drawImage

![image](https://user-images.githubusercontent.com/1194048/45002540-01a22380-afd8-11e8-9506-209bdad2b194.png)
