### PR TITLE
sticky headers for tests

### DIFF
--- a/test/public/style.css
+++ b/test/public/style.css
@@ -37,3 +37,10 @@ table tr td:nth-child(3) {
 table tr td p {
   margin: 5px 0;
 }
+
+table th {
+  background: white;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+}


### PR DESCRIPTION
Small improvement to stick headers in the browser tests. I always forget which is which when you scroll down.