### PR TITLE
Fix drawImage regression with particular use case of 9 arguments.

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1183,11 +1183,11 @@ NAN_METHOD(Context2d::DrawImage) {
   float fx = (float) dw / sw;
   float fy = (float) dh / sh;
   bool needScale = dw != sw || dh != sh;
-  bool needCut = sw != source_h || sh != source_h || sx < 0 || sy < 0;
-  bool needClip = sx < 0 || sy < 0 || sw > source_w || sh > source_h;
+  bool needCut = sw != source_w || sh != source_h || sx < 0 || sy < 0;
+  bool needCairoClip = sx < 0 || sy < 0 || sw > source_w || sh > source_h;
 
   bool sameCanvas = surface == context->canvas()->surface();
-  bool needsExtraSurface = sameCanvas || needCut || needScale;
+  bool needsExtraSurface = sameCanvas || needCut || needScale || needCairoClip;
   cairo_surface_t *surfTemp = NULL;
   cairo_t *ctxTemp = NULL;
 
@@ -1195,7 +1195,7 @@ NAN_METHOD(Context2d::DrawImage) {
     surfTemp = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dw, dh);
     ctxTemp = cairo_create(surfTemp);
     cairo_scale(ctxTemp, fx, fy);
-    if (needClip) {
+    if (needCairoClip) {
       float clip_w = (std::min)(sw, source_w);
       float clip_h = (std::min)(sh, source_h);
       if (sx > 0) {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1112,8 +1112,8 @@ NAN_METHOD(Context2d::DrawImage) {
     , dy = 0
     , dw = 0
     , dh = 0
-    , fw = 0
-    , fh = 0;
+    , source_w = 0
+    , source_h = 0;
 
   cairo_surface_t *surface;
 
@@ -1125,15 +1125,15 @@ NAN_METHOD(Context2d::DrawImage) {
     if (!img->isComplete()) {
       return Nan::ThrowError("Image given has not completed loading");
     }
-    fw = sw = img->width;
-    fh = sh = img->height;
+    source_w = sw = img->width;
+    source_h = sh = img->height;
     surface = img->surface();
 
   // Canvas
   } else if (Nan::New(Canvas::constructor)->HasInstance(obj)) {
     Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(obj);
-    fw = sw = canvas->getWidth();
-    fh = sh = canvas->getHeight();
+    source_w = sw = canvas->getWidth();
+    source_h = sh = canvas->getHeight();
     surface = canvas->surface();
 
   // Invalid
@@ -1183,7 +1183,8 @@ NAN_METHOD(Context2d::DrawImage) {
   float fx = (float) dw / sw;
   float fy = (float) dh / sh;
   bool needScale = dw != sw || dh != sh;
-  bool needCut = sw != fw || sh != fh;
+  bool needCut = sw != source_h || sh != source_h || sx < 0 || sy < 0;
+  bool needClip = sx < 0 || sy < 0 || sw > source_w || sh > source_h;
 
   bool sameCanvas = surface == context->canvas()->surface();
   bool needsExtraSurface = sameCanvas || needCut || needScale;
@@ -1194,6 +1195,18 @@ NAN_METHOD(Context2d::DrawImage) {
     surfTemp = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dw, dh);
     ctxTemp = cairo_create(surfTemp);
     cairo_scale(ctxTemp, fx, fy);
+    if (needClip) {
+      float clip_w = (std::min)(sw, source_w);
+      float clip_h = (std::min)(sh, source_h);
+      if (sx > 0) {
+        clip_w -= sx;
+      }
+      if (sy > 0) {
+        clip_h -= sy;
+      }
+      cairo_rectangle(ctxTemp, -sx , -sy , clip_w, clip_h);
+      cairo_clip(ctxTemp);
+    }
     cairo_set_source_surface(ctxTemp, surface, -sx, -sy);
     cairo_pattern_set_filter(cairo_get_source(ctxTemp), context->state->imageSmoothingEnabled ? context->state->patternQuality : CAIRO_FILTER_NEAREST);
     cairo_pattern_set_extend(cairo_get_source(ctxTemp), CAIRO_EXTEND_REFLECT);

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1199,7 +1199,7 @@ gco.forEach(op => {
     var img2 = new Image()
     img1.onload = function () {
       img2.onload = function () {
-        ctx.globalAlpha = 0.8
+        ctx.globalAlpha = 0.7
         ctx.drawImage(img1, 0, 0)
         ctx.globalCompositeOperation = op
         ctx.drawImage(img2, 0, 0)
@@ -1217,7 +1217,7 @@ gco.forEach(op => {
     var img2 = new Image()
     img1.onload = function () {
       img2.onload = function () {
-        ctx.globalAlpha = 0.8
+        ctx.globalAlpha = 0.7
         ctx.drawImage(img1, 0, 0)
         ctx.globalCompositeOperation = op
         ctx.rotate(0.1)

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1199,9 +1199,31 @@ gco.forEach(op => {
     var img2 = new Image()
     img1.onload = function () {
       img2.onload = function () {
+        ctx.globalAlpha = 0.8
         ctx.drawImage(img1, 0, 0)
         ctx.globalCompositeOperation = op
         ctx.drawImage(img2, 0, 0)
+        done()
+      }
+      img2.src = imageSrc('newcontent.png')
+    }
+    img1.src = imageSrc('existing.png')
+  }
+})
+
+gco.forEach(op => {
+  tests['9 args, transform, globalCompositeOperator ' + op] = function (ctx, done) {
+    var img1 = new Image()
+    var img2 = new Image()
+    img1.onload = function () {
+      img2.onload = function () {
+        ctx.globalAlpha = 0.8
+        ctx.drawImage(img1, 0, 0)
+        ctx.globalCompositeOperation = op
+        ctx.rotate(0.1)
+        ctx.scale(0.8, 1.2)
+        ctx.translate(5, -5)
+        ctx.drawImage(img2, -80, -50, 400, 400, 10, 10, 180, 180)
         done()
       }
       img2.src = imageSrc('newcontent.png')

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1232,6 +1232,21 @@ gco.forEach(op => {
   }
 })
 
+tests['drawImage issue #1249'] = function (ctx, done) {
+  var img1 = new Image()
+  var img2 = new Image()
+  img1.onload = function () {
+    img2.onload = function () {
+      ctx.drawImage(img1, 0, 0, 200, 200)
+      ctx.drawImage(img2, -8, -8, 18, 18, 0, 0, 200, 200);
+      ctx.restore()
+      done()
+    }
+    img2.src = imageSrc('checkers.png')
+  }
+  img1.src = imageSrc('chrome.jpg')
+}
+
 tests['known bug #416'] = function (ctx, done) {
   var img1 = new Image()
   var img2 = new Image()

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -1238,7 +1238,7 @@ tests['drawImage issue #1249'] = function (ctx, done) {
   img1.onload = function () {
     img2.onload = function () {
       ctx.drawImage(img1, 0, 0, 200, 200)
-      ctx.drawImage(img2, -8, -8, 18, 18, 0, 0, 200, 200);
+      ctx.drawImage(img2, -8, -8, 18, 18, 0, 0, 200, 200)
       ctx.restore()
       done()
     }


### PR DESCRIPTION
So this should fix 95% of the cases, and almost all real usage cases.

I think my code introduced another regression that i have no time to verify and i ll verify ( and in case fix ) as soon as possible, is NOT visible from the screenshots, when a scaling is applied on the canvas, and is not considered in drawImage code with the extra canvas, some detail loss will happen. I have an idea how to fix this, but i think should be a different PR.

This will happen only when a small destination size is specified but with upscaled receiving context.
Is a weird use case that will likely happen on higher level libraries like fabricJS and not on direct canvas usage ( since the pattern is a bit strange )

I changed a bit the tests, i should reverify them with the 1.6.9 to be sure the failing one are failing for my code or also before.
I set the globalAlpha of the globalCompositeOperation tests lower than 1 so that particular interaction can be noted.

## NEW BUG UNRELATED WITH THIS FIX

something is wrong with the copy version
![image](https://user-images.githubusercontent.com/1194048/45925155-751cbe00-bf10-11e8-91bf-225e6e31ce63.png)

saturation is not perfect yet
![image](https://user-images.githubusercontent.com/1194048/45925163-a1d0d580-bf10-11e8-8bdb-1ffa3a8ecf39.png)

## FIXES RELATED TO THIS PR
<details>

![image](https://user-images.githubusercontent.com/1194048/45925178-bd3be080-bf10-11e8-8fc7-8be1d91c140c.png)
![image](https://user-images.githubusercontent.com/1194048/45925181-d0e74700-bf10-11e8-86c6-5993ed913cc3.png)
![image](https://user-images.githubusercontent.com/1194048/45925185-de9ccc80-bf10-11e8-8429-e808adcb0d95.png)
![image](https://user-images.githubusercontent.com/1194048/45925187-ea888e80-bf10-11e8-87ea-38bcaf1efdf8.png)
![image](https://user-images.githubusercontent.com/1194048/45925192-f3796000-bf10-11e8-821b-4d7ad73191c7.png)
![image](https://user-images.githubusercontent.com/1194048/45925196-fd9b5e80-bf10-11e8-9888-89bfc5363519.png)
![image](https://user-images.githubusercontent.com/1194048/45925202-09872080-bf11-11e8-932d-dc5af6a81a2e.png)
![image](https://user-images.githubusercontent.com/1194048/45925206-14da4c00-bf11-11e8-9a5d-29bed8fe8d11.png)
![image](https://user-images.githubusercontent.com/1194048/45925210-1d328700-bf11-11e8-9af2-5c332e421d39.png)

</details>

## TESTS RESULT WITH MASTER CODE

<details>

![image](https://user-images.githubusercontent.com/1194048/45925237-b95c8e00-bf11-11e8-804d-2fab7e6b4427.png)
![image](https://user-images.githubusercontent.com/1194048/45925239-c8dbd700-bf11-11e8-88d7-d924e8a90e78.png)
![image](https://user-images.githubusercontent.com/1194048/45925242-d1341200-bf11-11e8-8e5d-80421b5f381e.png)
![image](https://user-images.githubusercontent.com/1194048/45925243-d98c4d00-bf11-11e8-9399-6519ea298898.png)
.... and so on ....

</details>

## IMAGE SAMPLING TEST
This test is the reason why we need to use an extend in first place and works fine.
![image](https://user-images.githubusercontent.com/1194048/45925254-f9237580-bf11-11e8-82d2-1e63940d8318.png)

<sub>zbjornson edited to put all the images in `<details>`</sub>