### PR TITLE
Make possible loading non base64 dataurl for svg

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -38,7 +38,7 @@ Object.defineProperty(Image.prototype, 'src', {
       if (/^\s*data:/.test(val)) { // data: URI
         const commaI = val.indexOf(',')
         // 'base64' must come before the comma
-        const isBase64 = val.lastIndexOf('base64', commaI)
+        const isBase64 = val.lastIndexOf('base64', commaI) !== -1
         const content = val.slice(commaI + 1)
         setSource(this, Buffer.from(content, isBase64 ? 'base64' : 'utf8'), val);
       } else if (/^\s*https?:\/\//.test(val)) { // remote URL

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -17,6 +17,7 @@ const png_checkers = `${__dirname}/fixtures/checkers.png`
 const png_clock = `${__dirname}/fixtures/clock.png`
 const jpg_chrome = `${__dirname}/fixtures/chrome.jpg`
 const jpg_face = `${__dirname}/fixtures/face.jpeg`
+const svg_tree = `${__dirname}/fixtures/tree.svg`
 
 describe('Image', function () {
   it('Prototype and ctor are well-shaped, don\'t hit asserts on accessors (GH-803)', function () {
@@ -77,6 +78,30 @@ describe('Image', function () {
       assert.strictEqual(img.src, dataURL)
       assert.strictEqual(img.width, 320)
       assert.strictEqual(img.height, 320)
+      assert.strictEqual(img.complete, true)
+    })
+  })
+
+  it('loads SVG data URL base64', function () {
+    const base64Enc = fs.readFileSync(svg_tree, 'base64')
+    const dataURL = `data:image/svg+xml;base64,${base64Enc}`
+      return loadImage(dataURL).then((img) => {
+      assert.strictEqual(img.onerror, null)
+      assert.strictEqual(img.onload, null)
+      assert.strictEqual(img.width, 200)
+      assert.strictEqual(img.height, 200)
+      assert.strictEqual(img.complete, true)
+    })
+  })
+
+  it('loads SVG data URL utf8', function () {
+    const utf8Encoded = fs.readFileSync(svg_tree, 'utf8')
+    const dataURL = `data:image/svg+xml;utf8,${utf8Encoded}`
+      return loadImage(dataURL).then((img) => {
+      assert.strictEqual(img.onerror, null)
+      assert.strictEqual(img.onload, null)
+      assert.strictEqual(img.width, 200)
+      assert.strictEqual(img.height, 200)
       assert.strictEqual(img.complete, true)
     })
   })


### PR DESCRIPTION
Noticed a bug playing with SVG dataURL. If the dataURL is not base64 encoded it would not be loaded.
This happen because the `isBase64` is actually the index rather than a boolean.
When base64 is missing, the index is -1 and is still considered true.