### PR TITLE
Ship 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-2.0.0 (unreleased -- encompasses all alpha versions)
+(Unreleased)
+==================
+### Changed
+### Added
+### Fixed
+
+2.0.0
 ==================
 
 **Upgrading from 1.x**

--- a/Readme.md
+++ b/Readme.md
@@ -1,14 +1,5 @@
 # node-canvas
 
-## This is the documentation for version 2.0.0-alpha
-Alpha versions of 2.0 can be installed using `npm install canvas@next`.
-
-See the [changelog](https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md) for a guide to upgrading from 1.x to 2.x.
-
-**For version 1.x documentation, see [the v1.x branch](https://github.com/Automattic/node-canvas/tree/v1.x)**
-
------
-
 [![Build Status](https://travis-ci.org/Automattic/node-canvas.svg?branch=master)](https://travis-ci.org/Automattic/node-canvas)
 [![NPM version](https://badge.fury.io/js/canvas.svg)](http://badge.fury.io/js/canvas)
 
@@ -69,6 +60,12 @@ loadImage('examples/images/lime-cat.jpg').then((image) => {
   console.log('<img src="' + canvas.toDataURL() + '" />')
 })
 ```
+
+## Upgrading from 2.x
+
+See the [changelog](https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md) for a guide to upgrading from 1.x to 2.x.
+
+For version 1.x documentation, see [the v1.x branch](https://github.com/Automattic/node-canvas/tree/v1.x).
 
 ## Documentation
 


### PR DESCRIPTION
What do you guys think, is it time finally?

* No known regressions.
* Complete docs present for upgrading from v1.x.
* All open PRs are semver minor/patch, except Linus' #1280, which I think should be 3.x because it drops Node.js 6.x support.
* [Five possible semver-major issues open](https://github.com/Automattic/node-canvas/issues?q=is%3Aopen+is%3Aissue+label%3Asemver-major), but none have activity and another semver-major release can come in the near future.
* Prebuilds are working fairly smoothly. The largest improvement would probably come from uploading the binaries in the npm tarball itself, but the builds are too large right now. Using N-API so we have a stable ABI would require Node.js 10 for non-experimental support. I think the dependencies could be deduped between ABI builds though (should only need one per platform).

Closes #743 
Closes #916