### PR TITLE
Error when building with old cairo; explicitly require 1.10.0 or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+* Warn when building with old, unsupported versions of cairo or libjpeg.
+
 ### Fixed
 
 2.0.0

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ The minimum version of Node.js required is **6.0.0**.
 
 If you don't have a supported OS or processor architecture, or you use `--build-from-source`, the module will be compiled on your system. This requires several dependencies, including Cairo and Pango.
 
-For detailed installation information, see the [wiki](https://github.com/Automattic/node-canvas/wiki/_pages). One-line installation instructions for common OSes are below. Note that libgif/giflib, librsvg and libjpeg are optional and only required if you need GIF, SVG and JPEG support, respectively.
+For detailed installation information, see the [wiki](https://github.com/Automattic/node-canvas/wiki/_pages). One-line installation instructions for common OSes are below. Note that libgif/giflib, librsvg and libjpeg are optional and only required if you need GIF, SVG and JPEG support, respectively. Cairo v1.10.0 or later is required.
 
 OS | Command
 ----- | -----

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1310,7 +1310,6 @@ NAN_GETTER(Context2d::GetGlobalCompositeOperation) {
     // Note: "source-over" and "normal" are synonyms. Chrome and FF both report
     // "source-over" after setting gCO to "normal".
     // case CAIRO_OPERATOR_OVER: op = "normal";
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 10, 0)
     case CAIRO_OPERATOR_MULTIPLY: op = "multiply"; break;
     case CAIRO_OPERATOR_SCREEN: op = "screen"; break;
     case CAIRO_OPERATOR_OVERLAY: op = "overlay"; break;
@@ -1326,7 +1325,6 @@ NAN_GETTER(Context2d::GetGlobalCompositeOperation) {
     case CAIRO_OPERATOR_HSL_SATURATION: op = "saturation"; break;
     case CAIRO_OPERATOR_HSL_COLOR: op = "color"; break;
     case CAIRO_OPERATOR_HSL_LUMINOSITY: op = "luminosity"; break;
-#endif
     // non-standard:
     case CAIRO_OPERATOR_SATURATE: op = "saturate"; break;
   }
@@ -1414,7 +1412,6 @@ NAN_SETTER(Context2d::SetGlobalCompositeOperation) {
     {"lighter", CAIRO_OPERATOR_ADD},
     // blend modes:
     {"normal", CAIRO_OPERATOR_OVER},
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 10, 0)
     {"multiply", CAIRO_OPERATOR_MULTIPLY},
     {"screen", CAIRO_OPERATOR_SCREEN},
     {"overlay", CAIRO_OPERATOR_OVERLAY},
@@ -1430,7 +1427,6 @@ NAN_SETTER(Context2d::SetGlobalCompositeOperation) {
     {"saturation", CAIRO_OPERATOR_HSL_SATURATION},
     {"color", CAIRO_OPERATOR_HSL_COLOR},
     {"luminosity", CAIRO_OPERATOR_HSL_LUMINOSITY},
-#endif
     // non-standard:
     {"saturate", CAIRO_OPERATOR_SATURATE}
   };

--- a/src/Image.h
+++ b/src/Image.h
@@ -84,10 +84,8 @@ class Image: public Nan::ObjectWrap {
     cairo_status_t loadJPEG(FILE *stream);
     void jpegToARGB(jpeg_decompress_struct* args, uint8_t* data, uint8_t* src, JPEGDecodeL decode);
     cairo_status_t decodeJPEGIntoSurface(jpeg_decompress_struct *info);
-#if CAIRO_VERSION_MINOR >= 10
     cairo_status_t decodeJPEGBufferIntoMimeSurface(uint8_t *buf, unsigned len);
     cairo_status_t assignDataAsMime(uint8_t *data, int len, const char *mime_type);
-#endif
 #endif
     CanvasError errorInfo;
     void loaded();

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -17,10 +17,6 @@
 #define unlikely(expr) (expr)
 #endif
 
-#ifndef CAIRO_FORMAT_INVALID
-#define CAIRO_FORMAT_INVALID -1
-#endif
-
 static void canvas_png_flush(png_structp png_ptr) {
     /* Do nothing; fflush() is said to be just a waste of energy. */
     (void) png_ptr;   /* Stifle compiler warning */

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -50,12 +50,7 @@ class Backend : public Nan::ObjectWrap
 
     // Overridden by ImageBackend. SVG and PDF thus always return INVALID.
     virtual cairo_format_t getFormat() {
-#ifndef CAIRO_FORMAT_INVALID
-      // For old Cairo (CentOS) support
-      return static_cast<cairo_format_t>(-1);
-#else
       return CAIRO_FORMAT_INVALID;
-#endif
     }
 
     bool isSurfaceValid();

--- a/src/init.cc
+++ b/src/init.cc
@@ -9,6 +9,17 @@
 #include <pango/pango.h>
 #include <glib.h>
 
+#include <cairo.h>
+#if CAIRO_VERSION < CAIRO_VERSION_ENCODE(1, 10, 0)
+// CAIRO_FORMAT_RGB16_565: undeprecated in v1.10.0
+// CAIRO_STATUS_INVALID_SIZE: v1.10.0
+// CAIRO_FORMAT_INVALID: v1.10.0
+// Lots of the compositing operators: v1.10.0
+// JPEG MIME tracking: v1.10.0
+// Note: CAIRO_FORMAT_RGB30 is v1.12.0 and still optional
+#error("cairo v1.10.0 or later is required")
+#endif
+
 #include "Backends.h"
 #include "Canvas.h"
 #include "CanvasGradient.h"


### PR DESCRIPTION
Cairo 1.10.0 was released in 2010 and is the oldest version that will work AFAICT. Removes a lot of the preprocessor directives 🎉 .

Ref #1290 and most of the [CentOS issues](https://github.com/Automattic/node-canvas/issues?q=is%3Aissue+centos+label%3A%22Installation+help%22).

- [x] Have you updated CHANGELOG.md?
