### PR TITLE
Support Jest test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * Reset context on resurface (#1292)
+* Support Jest test framework (#1311)
 
 2.1.0
 ==================

--- a/lib/image.js
+++ b/lib/image.js
@@ -15,12 +15,7 @@ const Image = module.exports = bindings.Image
 const http = require("http")
 const https = require("https")
 
-const proto = Image.prototype;
-const _getSource = proto.getSource;
-const _setSource = proto.setSource;
-
-delete proto.getSource;
-delete proto.setSource;
+const {GetSource, SetSource} = bindings;
 
 Object.defineProperty(Image.prototype, 'src', {
   /**
@@ -95,10 +90,10 @@ Image.prototype.inspect = function(){
 };
 
 function getSource(img){
-  return img._originalSource || _getSource.call(img);
+  return img._originalSource || GetSource.call(img);
 }
 
 function setSource(img, src, origSrc){
-  _setSource.call(img, src);
+  SetSource.call(img, src);
   img._originalSource = origSrc;
 }

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -62,13 +62,16 @@ Image::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   SetProtoAccessor(proto, Nan::New("height").ToLocalChecked(), GetHeight, SetHeight, ctor);
   SetProtoAccessor(proto, Nan::New("naturalWidth").ToLocalChecked(), GetNaturalWidth, NULL, ctor);
   SetProtoAccessor(proto, Nan::New("naturalHeight").ToLocalChecked(), GetNaturalHeight, NULL, ctor);
-
-  Nan::SetMethod(proto, "getSource", GetSource);
-  Nan::SetMethod(proto, "setSource", SetSource);
   SetProtoAccessor(proto, Nan::New("dataMode").ToLocalChecked(), GetDataMode, SetDataMode, ctor);
+
   ctor->Set(Nan::New("MODE_IMAGE").ToLocalChecked(), Nan::New<Number>(DATA_IMAGE));
   ctor->Set(Nan::New("MODE_MIME").ToLocalChecked(), Nan::New<Number>(DATA_MIME));
+
   Nan::Set(target, Nan::New("Image").ToLocalChecked(), ctor->GetFunction());
+
+  // Used internally in lib/image.js
+  NAN_EXPORT(target, GetSource);
+  NAN_EXPORT(target, SetSource);
 }
 
 /*


### PR DESCRIPTION
Jest re-evaluates modules, whereas `require` is only supposed to evaluate them once. Fix: make reloading lib/image.js safe.

Fixes #1310
Fixes #1294
Fixes #1250

- [x] Have you updated CHANGELOG.md?
