### PR TITLE
Detect invalid PNG and prevent segfault

### DIFF
--- a/test/image.test.js
+++ b/test/image.test.js
@@ -84,6 +84,12 @@ describe('Image', function () {
     })
   })
 
+  it('detects invalid PNG', function (done) {
+    const img = new Image()
+    img.onerror = () => done()
+    img.src = Buffer.from('89504E470D', 'hex')
+  })
+
   it('loads SVG data URL base64', function () {
     const base64Enc = fs.readFileSync(svg_tree, 'base64')
     const dataURL = `data:image/svg+xml;base64,${base64Enc}`


### PR DESCRIPTION
IIUC, the cairo PNG parser reads data until the IEND chunk is reached. It doesn't perform any overrun checks, and if there is no IEND chunk, it will cause a segfault.

- [x] Have you updated CHANGELOG.md?