### PR TITLE
add test demonstrating drawImage reflection bug

### DIFF
--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -2448,3 +2448,12 @@ tests['image sampling (#1084)'] = function (ctx, done) {
   img1.src = imageSrc('halved-1.jpeg')
   img2.src = imageSrc('halved-2.jpeg')
 }
+
+tests['drawImage reflection bug'] = function (ctx, done) {
+  var img1 = new Image()
+  img1.onload = function () {
+    ctx.drawImage(img1, 60, 30, 150, 150, 0, 0, 200, 200)
+    done()
+  }
+  img1.src = imageSrc('chrome.jpg')
+}


### PR DESCRIPTION
![screenshot from 2018-12-20 15-47-43](https://user-images.githubusercontent.com/704368/50315115-4c03bf00-0466-11e9-84ca-111107574e28.png)

Maybe related to https://github.com/Automattic/node-canvas/issues/1249 ?

This seems to occur when you use `context.drawImage` with a source image size that is less than the destination size.