### PR TITLE
Return when setting font to invalid CSS font string

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2460,7 +2460,10 @@ NAN_SETTER(Context2d::SetFont) {
 
   MaybeLocal<Value> mparsed = _parseFont.Get(iso)->Call(ctx, ctx->Global(), argc, argv);
   if (mparsed.IsEmpty()) return;
-  MaybeLocal<Object> mfont = Nan::To<Object>(mparsed.ToLocalChecked());
+  Local<Value> mparsedChecked = mparsed.ToLocalChecked();
+  // parseFont returns undefined for invalid CSS font strings
+  if (mparsedChecked->IsUndefined()) return;
+  MaybeLocal<Object> mfont = Nan::To<Object>(mparsedChecked);
   if (mfont.IsEmpty()) return;
   Local<Object> font = mfont.ToLocalChecked();
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -93,10 +93,7 @@ describe('Canvas', function () {
       assert.deepEqual(actual, expected, 'Failed to parse: ' + str);
     }
 
-    assert.throws(() => {
-      const ctx = createCanvas(10, 10).getContext('2d')
-      ctx.font = 'bold undefinedpx Arial'
-    })
+    assert.strictEqual(parseFont('Helvetica, sans'), undefined)
   });
 
   it('registerFont', function () {
@@ -417,12 +414,15 @@ describe('Canvas', function () {
   });
 
   it('Context2d#font=', function () {
-    var canvas = createCanvas(200, 200)
-      , ctx = canvas.getContext('2d');
+    const canvas = createCanvas(200, 200)
+    const ctx = canvas.getContext('2d')
 
-    assert.equal('10px sans-serif', ctx.font);
-    ctx.font = '15px Arial, sans-serif';
-    assert.equal('15px Arial, sans-serif', ctx.font);
+    assert.equal(ctx.font, '10px sans-serif')
+    ctx.font = '15px Arial, sans-serif'
+    assert.equal(ctx.font, '15px Arial, sans-serif')
+
+    ctx.font = 'Helvetica, sans' // invalid
+    assert.equal(ctx.font, '15px Arial, sans-serif')
   });
 
   it('Context2d#lineWidth=', function () {


### PR DESCRIPTION
> If the new value is syntactically incorrect (including using property-independent style sheet syntax like 'inherit' or 'initial'), then it must be ignored, without assigning a new font value.

Fixes #1336

- [ ] Have you updated CHANGELOG.md? - no; there hasn't been a release since #1328