### PR TITLE
Clean up #includes

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -105,7 +105,7 @@
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
                   'DisableSpecificWarnings': [
-                    4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512
+                    4100, 4611
                   ]
                 }
               }
@@ -116,7 +116,7 @@
                   'WarningLevel': 4,
                   'ExceptionHandling': 1,
                   'DisableSpecificWarnings': [
-                    4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512
+                    4100, 4611
                   ]
                 }
               }

--- a/src/Backends.h
+++ b/src/Backends.h
@@ -1,14 +1,10 @@
-#ifndef __NODE_BACKENDS_H__
-#define __NODE_BACKENDS_H__
-
-#include <nan.h>
+#pragma once
 
 #include "backend/Backend.h"
-
+#include <nan.h>
+#include <v8.h>
 
 class Backends : public Nan::ObjectWrap {
   public:
     static void Initialize(v8::Handle<v8::Object> target);
 };
-
-#endif

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -1,29 +1,25 @@
-//
-// Canvas.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#include <assert.h>
-#include <stdlib.h>
-#include <cstring>
-#include <cctype>
-#include <string>
+#include "Canvas.h"
+
 #include <algorithm> // std::min
-#include <vector>
-#include <unordered_set>
-#include <node_buffer.h>
-#include <node_version.h>
-#include <glib.h>
+#include <assert.h>
 #include <cairo-pdf.h>
 #include <cairo-svg.h>
-#include <ctime>
-#include "Util.h"
-#include "Canvas.h"
-#include "PNG.h"
 #include "CanvasRenderingContext2d.h"
 #include "closure.h"
+#include <cstring>
+#include <cctype>
+#include <ctime>
+#include <glib.h>
+#include "PNG.h"
 #include "register_font.h"
+#include <sstream>
+#include <stdlib.h>
+#include <string>
+#include <unordered_set>
+#include "Util.h"
+#include <vector>
 
 #ifdef HAVE_JPEG
 #include "JPEGStream.h"
@@ -309,7 +305,7 @@ static void parseJPEGArgs(Local<Value> arg, JpegClosure& jpegargs) {
 static uint32_t getSafeBufSize(Canvas* canvas) {
   // Don't allow the buffer size to exceed the size of the canvas (#674)
   // TODO not sure if this is really correct, but it fixed #674
-  return std::min(canvas->getWidth() * canvas->getHeight() * 4, static_cast<int>(PAGE_SIZE));
+  return (std::min)(canvas->getWidth() * canvas->getHeight() * 4, static_cast<int>(PAGE_SIZE));
 }
 
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <cctype>
 #include <string>
+#include <algorithm> // std::min
 #include <vector>
 #include <unordered_set>
 #include <node_buffer.h>
@@ -36,6 +37,9 @@
   "The second argument to registerFont is required, and should be an object " \
   "with at least a family (string) and optionally weight (string/number) " \
   "and style (string)."
+
+using namespace v8;
+using namespace std;
 
 Nan::Persistent<FunctionTemplate> Canvas::constructor;
 
@@ -305,7 +309,7 @@ static void parseJPEGArgs(Local<Value> arg, JpegClosure& jpegargs) {
 static uint32_t getSafeBufSize(Canvas* canvas) {
   // Don't allow the buffer size to exceed the size of the canvas (#674)
   // TODO not sure if this is really correct, but it fixed #674
-  return min(canvas->getWidth() * canvas->getHeight() * 4, static_cast<int>(PAGE_SIZE));
+  return std::min(canvas->getWidth() * canvas->getHeight() * 4, static_cast<int>(PAGE_SIZE));
 }
 
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
@@ -377,7 +381,7 @@ NAN_METHOD(Canvas::ToBuffer) {
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(info.This());
 
   // Vector canvases, sync only
-  const string name = canvas->backend()->getName();
+  const std::string name = canvas->backend()->getName();
   if (name == "pdf" || name == "svg") {
     // mime type may be present, but it's not checked
     PdfSvgClosure* closure;

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -19,10 +19,6 @@
 #include "dll_visibility.h"
 #include "backend/Backend.h"
 
-
-using namespace node;
-using namespace v8;
-
 /*
  * Maxmimum states per context.
  * TODO: remove/resize
@@ -48,7 +44,7 @@ class FontFace {
 
 class Canvas: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(ToBuffer);
@@ -62,7 +58,7 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_METHOD(StreamPDFSync);
     static NAN_METHOD(StreamJPEGSync);
     static NAN_METHOD(RegisterFont);
-    static Local<Value> Error(cairo_status_t status);
+    static v8::Local<v8::Value> Error(cairo_status_t status);
     static void ToPngBufferAsync(uv_work_t *req);
     static void ToJpegBufferAsync(uv_work_t *req);
     static void ToBufferAsyncAfter(uv_work_t *req);
@@ -82,7 +78,7 @@ class Canvas: public Nan::ObjectWrap {
     DLL_PUBLIC inline int getHeight() { return backend()->getHeight(); }
 
     Canvas(Backend* backend);
-    void resurface(Local<Object> canvas);
+    void resurface(v8::Local<v8::Object> canvas);
 
   private:
     ~Canvas();

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -1,23 +1,14 @@
-
-//
-// Canvas.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_CANVAS_H__
-#define __NODE_CANVAS_H__
+#pragma once
 
-#include <node.h>
-#include <v8.h>
-#include <node_object_wrap.h>
-#include <node_version.h>
-#include <pango/pangocairo.h>
-#include <cairo.h>
-#include <nan.h>
-
-#include "dll_visibility.h"
 #include "backend/Backend.h"
+#include <cairo.h>
+#include "dll_visibility.h"
+#include <nan.h>
+#include <pango/pangocairo.h>
+#include <v8.h>
+#include <vector>
 
 /*
  * Maxmimum states per context.
@@ -84,5 +75,3 @@ class Canvas: public Nan::ObjectWrap {
     ~Canvas();
     Backend* _backend;
 };
-
-#endif

--- a/src/CanvasError.h
+++ b/src/CanvasError.h
@@ -1,5 +1,4 @@
-#ifndef __CANVAS_ERROR_H__
-#define __CANVAS_ERROR_H__
+#pragma once
 
 #include <string>
 
@@ -22,5 +21,3 @@ class CanvasError {
       cerrno = 0;
     }
 };
-
-#endif

--- a/src/CanvasError.h
+++ b/src/CanvasError.h
@@ -8,11 +8,11 @@ class CanvasError {
     std::string syscall;
     std::string path;
     int cerrno = 0;
-    void set(char *iMessage = NULL, char *iSyscall = NULL, int iErrno = 0, char *iPath = NULL) {
-      if (iMessage) message = std::string(iMessage);
-      if (iSyscall) syscall = std::string(iSyscall);
+    void set(const char* iMessage = NULL, const char* iSyscall = NULL, int iErrno = 0, const char* iPath = NULL) {
+      if (iMessage) message.assign(iMessage);
+      if (iSyscall) syscall.assign(iSyscall);
       cerrno = iErrno;
-      if (iPath) path = std::string(iPath);
+      if (iPath) path.assign(iPath);
     }
     void reset() {
       message.clear();

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -1,13 +1,9 @@
-
-//
-// Gradient.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#include "color.h"
-#include "Canvas.h"
 #include "CanvasGradient.h"
+
+#include "Canvas.h"
+#include "color.h"
 
 using namespace v8;
 

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -9,6 +9,8 @@
 #include "Canvas.h"
 #include "CanvasGradient.h"
 
+using namespace v8;
+
 Nan::Persistent<FunctionTemplate> Gradient::constructor;
 
 /*

--- a/src/CanvasGradient.h
+++ b/src/CanvasGradient.h
@@ -1,14 +1,10 @@
-
-//
-// CanvasGradient.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_GRADIENT_H__
-#define __NODE_GRADIENT_H__
+#pragma once
 
-#include "Canvas.h"
+#include <nan.h>
+#include <v8.h>
+#include <cairo.h>
 
 class Gradient: public Nan::ObjectWrap {
   public:
@@ -24,5 +20,3 @@ class Gradient: public Nan::ObjectWrap {
     ~Gradient();
     cairo_pattern_t *_pattern;
 };
-
-#endif

--- a/src/CanvasGradient.h
+++ b/src/CanvasGradient.h
@@ -12,7 +12,7 @@
 
 class Gradient: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(AddColorStop);

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -9,6 +9,8 @@
 #include "Image.h"
 #include "CanvasPattern.h"
 
+using namespace v8;
+
 const cairo_user_data_key_t *pattern_repeat_key;
 
 Nan::Persistent<FunctionTemplate> Pattern::constructor;

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -1,13 +1,9 @@
-
-//
-// Pattern.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
+
+#include "CanvasPattern.h"
 
 #include "Canvas.h"
 #include "Image.h"
-#include "CanvasPattern.h"
 
 using namespace v8;
 

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -25,7 +25,7 @@ extern const cairo_user_data_key_t *pattern_repeat_key;
 
 class Pattern: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static repeat_type_t get_repeat_type_for_cairo_pattern(cairo_pattern_t *pattern);

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -1,14 +1,10 @@
-
-//
-// CanvasPattern.h
-//
 // Copyright (c) 2011 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_PATTERN_H__
-#define __NODE_PATTERN_H__
+#pragma once
 
-#include "Canvas.h"
+#include <cairo.h>
+#include <nan.h>
+#include <v8.h>
 
 /*
  * Canvas types.
@@ -36,5 +32,3 @@ class Pattern: public Nan::ObjectWrap {
     cairo_pattern_t *_pattern;
     repeat_type_t _repeat;
 };
-
-#endif

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1766,7 +1766,6 @@ NAN_GETTER(Context2d::GetFillStyle) {
 
 NAN_SETTER(Context2d::SetFillStyle) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-  Local<Context> ctx = Nan::GetCurrentContext();
 
   if (Nan::New(Gradient::constructor)->HasInstance(value) ||
       Nan::New(Pattern::constructor)->HasInstance(value)) {
@@ -1813,8 +1812,6 @@ NAN_GETTER(Context2d::GetStrokeStyle) {
 
 NAN_SETTER(Context2d::SetStrokeStyle) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-  Isolate *iso = Isolate::GetCurrent();
-  Local<Context> ctx = Nan::GetCurrentContext();
 
   if (Nan::New(Gradient::constructor)->HasInstance(value) ||
       Nan::New(Pattern::constructor)->HasInstance(value)) {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1,28 +1,23 @@
-
-//
-// CanvasRenderingContext2d.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#include <cmath>
-#include <cstdlib>
-#include <limits>
-#include <vector>
-#include <algorithm>
-#include <string>
-#include <map>
-
-#include "Util.h"
-#include "Canvas.h"
-#include "Point.h"
-#include "Image.h"
-#include "ImageData.h"
 #include "CanvasRenderingContext2d.h"
-#include "CanvasGradient.h"
-#include "CanvasPattern.h"
+
+#include <algorithm>
 #include "backend/ImageBackend.h"
 #include <cairo/cairo-pdf.h>
+#include "Canvas.h"
+#include "CanvasGradient.h"
+#include "CanvasPattern.h"
+#include <cmath>
+#include <cstdlib>
+#include "Image.h"
+#include "ImageData.h"
+#include <limits>
+#include <map>
+#include "Point.h"
+#include <string>
+#include "Util.h"
+#include <vector>
 
 using namespace v8;
 

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -24,6 +24,8 @@
 #include "backend/ImageBackend.h"
 #include <cairo/cairo-pdf.h>
 
+using namespace v8;
+
 // Windows doesn't support the C99 names for these
 #ifdef _MSC_VER
 #define isnan(x) _isnan(x)

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -1,19 +1,12 @@
-
-//
-// CanvasRenderingContext2d.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_CONTEXT2D_H__
-#define __NODE_CONTEXT2D_H__
+#pragma once
 
-#include <vector>
-#include <pango/pangocairo.h>
-
-#include "color.h"
+#include "cairo.h"
 #include "Canvas.h"
-#include "CanvasGradient.h"
+#include "color.h"
+#include "nan.h"
+#include <pango/pangocairo.h>
 
 typedef enum {
   TEXT_DRAW_PATHS,
@@ -207,5 +200,3 @@ class Context2d: public Nan::ObjectWrap {
     cairo_path_t *_path;
     PangoLayout *_layout;
 };
-
-#endif

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -15,8 +15,6 @@
 #include "Canvas.h"
 #include "CanvasGradient.h"
 
-using namespace std;
-
 typedef enum {
   TEXT_DRAW_PATHS,
   TEXT_DRAW_GLYPHS
@@ -71,9 +69,9 @@ class Context2d: public Nan::ObjectWrap {
     canvas_state_t *states[CANVAS_MAX_STATES];
     canvas_state_t *state;
     Context2d(Canvas *canvas);
-    static Nan::Persistent<Function> _DOMMatrix;
-    static Nan::Persistent<Function> _parseFont;
-    static Nan::Persistent<FunctionTemplate> constructor;
+    static Nan::Persistent<v8::Function> _DOMMatrix;
+    static Nan::Persistent<v8::Function> _parseFont;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(SaveExternalModules);
@@ -193,17 +191,17 @@ class Context2d: public Nan::ObjectWrap {
   private:
     ~Context2d();
     void _resetPersistentHandles();
-    Local<Value> _getFillColor();
-    Local<Value> _getStrokeColor();
-    void _setFillColor(Local<Value> arg);
-    void _setFillPattern(Local<Value> arg);
-    void _setStrokeColor(Local<Value> arg);
-    void _setStrokePattern(Local<Value> arg);
-    Nan::Persistent<Value> _fillStyle;
-    Nan::Persistent<Value> _strokeStyle;
-    Nan::Persistent<Value> _font;
-    Nan::Persistent<Value> _textBaseline;
-    Nan::Persistent<Value> _textAlign;
+    v8::Local<v8::Value> _getFillColor();
+    v8::Local<v8::Value> _getStrokeColor();
+    void _setFillColor(v8::Local<v8::Value> arg);
+    void _setFillPattern(v8::Local<v8::Value> arg);
+    void _setStrokeColor(v8::Local<v8::Value> arg);
+    void _setStrokePattern(v8::Local<v8::Value> arg);
+    Nan::Persistent<v8::Value> _fillStyle;
+    Nan::Persistent<v8::Value> _strokeStyle;
+    Nan::Persistent<v8::Value> _font;
+    Nan::Persistent<v8::Value> _textBaseline;
+    Nan::Persistent<v8::Value> _textAlign;
     Canvas *_canvas;
     cairo_t *_context;
     cairo_path_t *_path;

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -40,6 +40,8 @@ typedef struct {
   uint8_t *buf;
 } read_closure_t;
 
+using namespace v8;
+
 Nan::Persistent<FunctionTemplate> Image::constructor;
 
 /*
@@ -239,9 +241,9 @@ NAN_METHOD(Image::SetSource){
     img->filename = strdup(*src);
     status = img->load();
   // Buffer
-  } else if (Buffer::HasInstance(value)) {
-    uint8_t *buf = (uint8_t *) Buffer::Data(Nan::To<Object>(value).ToLocalChecked());
-    unsigned len = Buffer::Length(Nan::To<Object>(value).ToLocalChecked());
+  } else if (node::Buffer::HasInstance(value)) {
+    uint8_t *buf = (uint8_t *) node::Buffer::Data(Nan::To<Object>(value).ToLocalChecked());
+    unsigned len = node::Buffer::Length(Nan::To<Object>(value).ToLocalChecked());
     status = img->loadFromBuffer(buf, len);
   }
 
@@ -1374,7 +1376,7 @@ Image::isSVG(uint8_t *data, unsigned len) {
 
 int Image::isBMP(uint8_t *data, unsigned len) {
   if(len < 2) return false;
-  string sig = string(1, (char)data[0]) + (char)data[1];
+  std::string sig = std::string(1, (char)data[0]) + (char)data[1];
   return sig == "BM" ||
          sig == "BA" ||
          sig == "CI" ||

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -1,18 +1,14 @@
-//
-// Image.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
+#include "Image.h"
+
+#include "bmp/BMPParser.h"
+#include "Canvas.h"
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include <node_buffer.h>
-
 #include "Util.h"
-#include "Canvas.h"
-#include "Image.h"
-#include "bmp/BMPParser.h"
 
 #ifdef HAVE_GIF
 typedef struct {

--- a/src/Image.h
+++ b/src/Image.h
@@ -42,7 +42,7 @@ class Image: public Nan::ObjectWrap {
     char *filename;
     int width, height;
     int naturalWidth, naturalHeight;
-    static Nan::Persistent<FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetComplete);

--- a/src/Image.h
+++ b/src/Image.h
@@ -1,16 +1,13 @@
-
-//
-// Image.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_IMAGE_H__
-#define __NODE_IMAGE_H__
+#pragma once
 
-#include "Canvas.h"
+#include <cairo.h>
 #include "CanvasError.h"
 #include <functional>
+#include <nan.h>
+#include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
+#include <v8.h>
 
 #ifdef HAVE_JPEG
 #include <jpeglib.h>
@@ -128,5 +125,3 @@ class Image: public Nan::ObjectWrap {
 #endif
     ~Image();
 };
-
-#endif

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -8,6 +8,8 @@
 #include "Util.h"
 #include "ImageData.h"
 
+using namespace v8;
+
 Nan::Persistent<FunctionTemplate> ImageData::constructor;
 
 /*

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -1,12 +1,8 @@
-
-//
-// ImageData.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
+
+#include "ImageData.h"
 
 #include "Util.h"
-#include "ImageData.h"
 
 using namespace v8;
 

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -15,7 +15,7 @@
 
 class ImageData: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<FunctionTemplate> constructor;
+    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetWidth);

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -1,17 +1,10 @@
-
-//
-// ImageData.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_IMAGE_DATA_H__
-#define __NODE_IMAGE_DATA_H__
+#pragma once
 
-#include <cstdlib>
+#include <nan.h>
+#include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
 #include <v8.h>
-
-#include "Canvas.h"
 
 class ImageData: public Nan::ObjectWrap {
   public:
@@ -32,5 +25,3 @@ class ImageData: public Nan::ObjectWrap {
     uint8_t *_data;
 
 };
-
-#endif

--- a/src/JPEGStream.h
+++ b/src/JPEGStream.h
@@ -1,13 +1,6 @@
-
-//
-// JPEGStream.h
-//
-
-#ifndef __NODE_JPEG_STREAM_H__
-#define __NODE_JPEG_STREAM_H__
+#pragma once
 
 #include "closure.h"
-#include "Canvas.h"
 #include <jpeglib.h>
 #include <jerror.h>
 
@@ -172,5 +165,3 @@ write_to_jpeg_buffer(cairo_surface_t* surface, JpegClosure* closure) {
     closure->chromaSubsampling,
     closure->chromaSubsampling);
 }
-
-#endif

--- a/src/JPEGStream.h
+++ b/src/JPEGStream.h
@@ -34,10 +34,10 @@ empty_closure_output_buffer(j_compress_ptr cinfo){
   Nan::AsyncResource async("canvas:empty_closure_output_buffer");
   closure_destination_mgr *dest = (closure_destination_mgr *) cinfo->dest;
 
-  Local<Object> buf = Nan::NewBuffer((char *)dest->buffer, dest->bufsize).ToLocalChecked();
+  v8::Local<v8::Object> buf = Nan::NewBuffer((char *)dest->buffer, dest->bufsize).ToLocalChecked();
 
   // emit "data"
-  Local<Value> argv[2] = {
+  v8::Local<v8::Value> argv[2] = {
       Nan::Null()
     , buf
   };
@@ -56,16 +56,16 @@ term_closure_destination(j_compress_ptr cinfo){
   closure_destination_mgr *dest = (closure_destination_mgr *) cinfo->dest;
 
   /* emit remaining data */
-  Local<Object> buf = Nan::NewBuffer((char *)dest->buffer, dest->bufsize - dest->pub.free_in_buffer).ToLocalChecked();
+  v8::Local<v8::Object> buf = Nan::NewBuffer((char *)dest->buffer, dest->bufsize - dest->pub.free_in_buffer).ToLocalChecked();
 
-  Local<Value> data_argv[2] = {
+  v8::Local<v8::Value> data_argv[2] = {
       Nan::Null()
     , buf
   };
   dest->closure->cb.Call(sizeof data_argv / sizeof *data_argv, data_argv, &async);
 
   // emit "end"
-  Local<Value> end_argv[2] = {
+  v8::Local<v8::Value> end_argv[2] = {
       Nan::Null()
     , Nan::Null()
   };

--- a/src/PNG.h
+++ b/src/PNG.h
@@ -1,13 +1,12 @@
-#ifndef _CANVAS_PNG_H
-#define _CANVAS_PNG_H
+#pragma once
 
+#include <cairo.h>
+#include "closure.h"
+#include <cmath> // round
 #include <cstdlib>
 #include <cstring>
 #include <png.h>
 #include <pngconf.h>
-#include <cairo.h>
-#include <cmath> // round
-#include "closure.h"
 
 #if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
 #define likely(expr) (__builtin_expect (!!(expr), 1))
@@ -291,4 +290,3 @@ static cairo_status_t canvas_write_to_png_stream(cairo_surface_t *surface, cairo
 
     return canvas_write_png(surface, canvas_stream_write_func, &png_closure);
 }
-#endif

--- a/src/Point.h
+++ b/src/Point.h
@@ -1,13 +1,6 @@
-
-
-//
-// Point.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_POINT_H__
-#define __NODE_POINT_H__
+#pragma once
 
 template <class T>
 class Point {
@@ -15,5 +8,3 @@ class Point {
     T x, y;
     Point(T x, T y): x(x), y(y) {}
 };
-
-#endif /* __NODE_POINT_H__ */

--- a/src/Util.h
+++ b/src/Util.h
@@ -1,5 +1,7 @@
-#include <v8.h>
+#pragma once
+
 #include <nan.h>
+#include <v8.h>
 
 // Wrapper around Nan::SetAccessor that makes it easier to change the last
 // argument (signature). Getters/setters must be accessed only when there is

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -1,6 +1,7 @@
 #include "Backend.h"
+#include <string>
 
-Backend::Backend(string name, int width, int height)
+Backend::Backend(std::string name, int width, int height)
   : name(name)
   , width(width)
   , height(height)
@@ -51,7 +52,7 @@ void Backend::destroySurface()
 }
 
 
-string Backend::getName()
+std::string Backend::getName()
 {
   return name;
 }
@@ -95,7 +96,7 @@ bool Backend::isSurfaceValid(){
 
 
 BackendOperationNotAvailable::BackendOperationNotAvailable(Backend* backend,
-  string operation_name)
+  std::string operation_name)
   : backend(backend)
   , operation_name(operation_name)
 {};
@@ -104,10 +105,8 @@ BackendOperationNotAvailable::~BackendOperationNotAvailable() throw() {};
 
 const char* BackendOperationNotAvailable::what() const throw()
 {
-  std::ostringstream o;
+  std::string msg = "operation " + this->operation_name +
+    " not supported by backend " + backend->getName();
 
-  o << "operation " << this->operation_name;
-  o << " not supported by backend " + backend->getName();
-
-  return o.str().c_str();
+  return msg.c_str();
 };

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -1,9 +1,7 @@
 #ifndef __BACKEND_H__
 #define __BACKEND_H__
 
-#include <iostream>
 #include <string>
-#include <sstream>
 #include <exception>
 
 #include <v8.h>
@@ -14,12 +12,10 @@
 
 class Canvas;
 
-using namespace std;
-
 class Backend : public Nan::ObjectWrap
 {
   private:
-    const string name;
+    const std::string name;
     const char* error = NULL;
 
   protected:
@@ -28,7 +24,7 @@ class Backend : public Nan::ObjectWrap
     cairo_surface_t* surface = nullptr;
     Canvas* canvas = nullptr;
 
-    Backend(string name, int width, int height);
+    Backend(std::string name, int width, int height);
     static void init(const Nan::FunctionCallbackInfo<v8::Value> &info);
     static Backend *construct(int width, int height){ return nullptr; }
 
@@ -43,7 +39,7 @@ class Backend : public Nan::ObjectWrap
     DLL_PUBLIC cairo_surface_t* getSurface();
     virtual void destroySurface();
 
-    DLL_PUBLIC string getName();
+    DLL_PUBLIC std::string getName();
 
     DLL_PUBLIC int getWidth();
     virtual void setWidth(int width);
@@ -61,14 +57,14 @@ class Backend : public Nan::ObjectWrap
 };
 
 
-class BackendOperationNotAvailable: public exception
+class BackendOperationNotAvailable: public std::exception
 {
   private:
     Backend* backend;
-    string operation_name;
+    std::string operation_name;
 
   public:
-    BackendOperationNotAvailable(Backend* backend, string operation_name);
+    BackendOperationNotAvailable(Backend* backend, std::string operation_name);
     ~BackendOperationNotAvailable() throw();
 
     const char* what() const throw();

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -1,14 +1,11 @@
-#ifndef __BACKEND_H__
-#define __BACKEND_H__
+#pragma once
 
-#include <string>
-#include <exception>
-
-#include <v8.h>
-#include <nan.h>
 #include <cairo.h>
-
 #include "../dll_visibility.h"
+#include <exception>
+#include <nan.h>
+#include <string>
+#include <v8.h>
 
 class Canvas;
 
@@ -69,5 +66,3 @@ class BackendOperationNotAvailable: public std::exception
 
     const char* what() const throw();
 };
-
-#endif

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -5,8 +5,6 @@
 
 #include "Backend.h"
 
-using namespace std;
-
 class ImageBackend : public Backend
 {
   private:

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -1,9 +1,7 @@
-#ifndef __IMAGE_BACKEND_H__
-#define __IMAGE_BACKEND_H__
-
-#include <v8.h>
+#pragma once
 
 #include "Backend.h"
+#include <v8.h>
 
 class ImageBackend : public Backend
 {
@@ -26,5 +24,3 @@ class ImageBackend : public Backend
     static NAN_METHOD(New);
     const static cairo_format_t DEFAULT_FORMAT = CAIRO_FORMAT_ARGB32;
 };
-
-#endif

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -1,11 +1,8 @@
 #include "PdfBackend.h"
 
 #include <cairo-pdf.h>
-#include <png.h>
-
 #include "../Canvas.h"
 #include "../closure.h"
-
 
 using namespace v8;
 

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -6,8 +6,6 @@
 #include "../closure.h"
 #include "Backend.h"
 
-using namespace std;
-
 class PdfBackend : public Backend
 {
   private:

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -1,10 +1,8 @@
-#ifndef __PDF_BACKEND_H__
-#define __PDF_BACKEND_H__
+#pragma once
 
-#include <v8.h>
-
-#include "../closure.h"
 #include "Backend.h"
+#include "../closure.h"
+#include <v8.h>
 
 class PdfBackend : public Backend
 {
@@ -24,5 +22,3 @@ class PdfBackend : public Backend
     static void Initialize(v8::Handle<v8::Object> target);
     static NAN_METHOD(New);
 };
-
-#endif

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -1,11 +1,8 @@
 #include "SvgBackend.h"
 
 #include <cairo-svg.h>
-#include <png.h>
-
 #include "../Canvas.h"
 #include "../closure.h"
-
 
 using namespace v8;
 

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -6,8 +6,6 @@
 #include "Backend.h"
 #include "../closure.h"
 
-using namespace std;
-
 class SvgBackend : public Backend
 {
   private:

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -1,10 +1,8 @@
-#ifndef __SVG_BACKEND_H__
-#define __SVG_BACKEND_H__
-
-#include <v8.h>
+#pragma once
 
 #include "Backend.h"
 #include "../closure.h"
+#include <v8.h>
 
 class SvgBackend : public Backend
 {
@@ -24,5 +22,3 @@ class SvgBackend : public Backend
     static void Initialize(v8::Handle<v8::Object> target);
     static NAN_METHOD(New);
 };
-
-#endif

--- a/src/bmp/BMPParser.cc
+++ b/src/bmp/BMPParser.cc
@@ -1,6 +1,6 @@
-#include <cassert>
-
 #include "BMPParser.h"
+
+#include <cassert>
 
 using namespace std;
 using namespace BMPParser;

--- a/src/bmp/BMPParser.h
+++ b/src/bmp/BMPParser.h
@@ -1,11 +1,11 @@
-#ifndef __NODE_BMP_PARSER_H__
-#define __NODE_BMP_PARSER_H__
+#pragma once
 
 #ifdef ERROR
 #define ERROR_ ERROR
 #undef ERROR
 #endif
 
+#include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
 #include <string>
 
 namespace BMPParser{
@@ -55,6 +55,4 @@ namespace BMPParser{
 #ifdef ERROR_
 #define ERROR ERROR_
 #undef ERROR_
-#endif
-
 #endif

--- a/src/closure.h
+++ b/src/closure.h
@@ -1,23 +1,17 @@
-
-//
-// closure.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __NODE_CLOSURE_H__
-#define __NODE_CLOSURE_H__
+#pragma once
 
+#include "Canvas.h"
+#include <jpeglib.h>
 #include <nan.h>
 #include <png.h>
-#include <jpeglib.h>
+#include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
 #include <vector>
 
 #ifndef PAGE_SIZE
   #define PAGE_SIZE 4096
 #endif
-
-#include "Canvas.h"
 
 /*
  * Image encoding closures.
@@ -79,5 +73,3 @@ struct JpegClosure : Closure {
     delete jpeg_dest_mgr;
   }
 };
-
-#endif /* __NODE_CLOSURE_H__ */

--- a/src/closure.h
+++ b/src/closure.h
@@ -27,7 +27,7 @@ struct Closure {
     Closure* closure = static_cast<Closure*>(c);
     try {
       closure->vec.insert(closure->vec.end(), odata, odata + len);
-    } catch (std::bad_alloc) {
+    } catch (const std::bad_alloc &) {
       return CAIRO_STATUS_NO_MEMORY;
     }
     return CAIRO_STATUS_SUCCESS;

--- a/src/color.cc
+++ b/src/color.cc
@@ -1,17 +1,14 @@
-
-//
-// color.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#include <cstdlib>
-#include <cmath>
-#include <limits>
-#include <string>
-#include <algorithm>
 #include "color.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
 #include <map>
+#include <string>
 
 // Compatibility with Visual Studio versions prior to VS2015
 #if defined(_MSC_VER) && _MSC_VER < 1900

--- a/src/color.h
+++ b/src/color.h
@@ -1,17 +1,9 @@
-
-//
-// color.h
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
-#ifndef __COLOR_PARSER_H__
-#define __COLOR_PARSER_H__
+#pragma once
 
-#include <cstdio>
 #include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
-#include <cstring>
-#include <cstddef>
+#include <cstdlib>
 
 /*
  * RGBA struct.
@@ -36,5 +28,3 @@ rgba_to_string(rgba_t rgba, char *buf, size_t len);
 
 void
 rgba_inspect(int32_t rgba);
-
-#endif /* __COLOR_PARSER_H__ */

--- a/src/init.cc
+++ b/src/init.cc
@@ -31,6 +31,8 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
+using namespace v8;
+
 // Compatibility with Visual Studio versions prior to VS2015
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf

--- a/src/init.cc
+++ b/src/init.cc
@@ -61,7 +61,8 @@ NAN_MODULE_INIT(init) {
 #endif
 
   char jpeg_version[10];
-  if (JPEG_LIB_VERSION_MINOR > 0) {
+  static bool minor_gt_0 = JPEG_LIB_VERSION_MINOR > 0;
+  if (minor_gt_0) {
     snprintf(jpeg_version, 10, "%d%c", JPEG_LIB_VERSION_MAJOR, JPEG_LIB_VERSION_MINOR + 'a' - 1);
   } else {
     snprintf(jpeg_version, 10, "%d", JPEG_LIB_VERSION_MAJOR);

--- a/src/init.cc
+++ b/src/init.cc
@@ -1,13 +1,7 @@
-
-//
-// init.cc
-//
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
-//
 
 #include <cstdio>
 #include <pango/pango.h>
-#include <glib.h>
 
 #include <cairo.h>
 #if CAIRO_VERSION < CAIRO_VERSION_ENCODE(1, 10, 0)

--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -1,3 +1,5 @@
+#include "register_font.h"
+
 #include <pango/pangocairo.h>
 #include <pango/pango-fontmap.h>
 #include <pango/pango.h>

--- a/src/register_font.h
+++ b/src/register_font.h
@@ -1,5 +1,6 @@
+#pragma once
+
 #include <pango/pango.h>
 
 PangoFontDescription *get_pango_font_description(unsigned char *filepath);
 bool register_font(unsigned char *filepath);
-


### PR DESCRIPTION
This has been bugging me for ages. Each header can now stand alone and has no `using namespace`s.

I don't think this creates any conflicts with open PRs that are close to landing, except my #1340.

(Can we remove the comments at the top of the files from 2010 with the file name and copyright notice?)