### PR TITLE
change binary module_name from canvas-prebuilt to canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "install": "node-pre-gyp install --fallback-to-build"
   },
   "binary": {
-    "module_name": "canvas-prebuilt",
+    "module_name": "canvas",
     "module_path": "build/Release",
     "host": "https://github.com/node-gfx/node-canvas-prebuilt/releases/download/",
     "remote_path": "v{version}",


### PR DESCRIPTION
so we can download it from a mirror

* https://github.com/mapbox/node-pre-gyp#module_name
* https://github.com/mapbox/node-pre-gyp#download-binary-files-from-a-mirror

fixes #1346

Thanks for contributing!

- [ ] Have you updated CHANGELOG.md?
