### PR TITLE
Explicitly list files to be included in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-testing
-build
-benchmarks
-examples
-support
-test

--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
     "remote_path": "v{version}",
     "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{libc}-{arch}.tar.gz"
   },
+  "files": [
+    "binding.gyp",
+    "lib/",
+    "src/",
+    "util/"
+  ],
   "dependencies": {
     "nan": "^2.12.1",
     "node-pre-gyp": "^0.11.0"


### PR DESCRIPTION
I noticed that some of my VSCode configs were being published along with the module 😂 

This PR changes to an explicit list to things to include, instead of an ignore-file.

This is the difference in published files:

```diff
--- a	2019-01-14 18:31:52.000000000 +0000
+++ b	2019-01-14 18:32:04.000000000 +0000
@@ -1,15 +1,9 @@
 package.json
-.travis.yml
-appveyor.yml
 binding.gyp
 browser.js
 CHANGELOG.md
 index.js
 Readme.md
-.github/ISSUE_TEMPLATE.md
-.github/PULL_REQUEST_TEMPLATE.md
-.vscode/c_cpp_properties.json
-.vscode/settings.json
 lib/bindings.js
 lib/canvas.js
 lib/context2d.js
```

ping @zbjornson, @chearon do you think it's a good approach? ☺️ 