### PR TITLE
Fix missing encoding options (quality) parameter in `canvas.toDataURL()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Fix encoding options (quality) parameter in `canvas.toDataURL()`
 
 2.4.0
 ==================

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -108,6 +108,6 @@ Canvas.prototype.toDataURL = function(a1, a2, a3){
       fn(null, `data:${type};base64,${buf.toString('base64')}`);
     }, type, opts)
   } else {
-    return `data:${type};base64,${this.toBuffer(type).toString('base64')}`
+    return `data:${type};base64,${this.toBuffer(type, opts).toString('base64')}`
   }
 };


### PR DESCRIPTION
I noticed that toDataURL always created the same URL, no matter what encoding options I specified. So I looked into the source code and found out that the `opts` variable is not always passed to `toBuffer`. This PR fixes this.