### PR TITLE
Fix Electron 5 and NodeJS 12 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Fix electron 5 and node 12 compatibility
 
 2.4.0
 ==================

--- a/src/Backends.cc
+++ b/src/Backends.cc
@@ -6,7 +6,7 @@
 
 using namespace v8;
 
-void Backends::Initialize(Handle<Object> target) {
+void Backends::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<Object> obj = Nan::New<Object>();

--- a/src/Backends.h
+++ b/src/Backends.h
@@ -6,5 +6,5 @@
 
 class Backends : public Nan::ObjectWrap {
   public:
-    static void Initialize(v8::Handle<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target);
 };

--- a/src/backend/ImageBackend.cc
+++ b/src/backend/ImageBackend.cc
@@ -57,7 +57,7 @@ void ImageBackend::setFormat(cairo_format_t _format) {
 
 Nan::Persistent<FunctionTemplate> ImageBackend::constructor;
 
-void ImageBackend::Initialize(Handle<Object> target) {
+void ImageBackend::Initialize(Local<Object> target) {
 	Nan::HandleScope scope;
 
 	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageBackend::New);

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -20,7 +20,7 @@ class ImageBackend : public Backend
     int32_t approxBytesPerPixel();
 
     static Nan::Persistent<v8::FunctionTemplate> constructor;
-    static void Initialize(v8::Handle<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
     const static cairo_format_t DEFAULT_FORMAT = CAIRO_FORMAT_ARGB32;
 };

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -36,7 +36,7 @@ cairo_surface_t* PdfBackend::recreateSurface() {
 
 Nan::Persistent<FunctionTemplate> PdfBackend::constructor;
 
-void PdfBackend::Initialize(Handle<Object> target) {
+void PdfBackend::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New);

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -19,6 +19,6 @@ class PdfBackend : public Backend
     static Backend *construct(int width, int height);
 
     static Nan::Persistent<v8::FunctionTemplate> constructor;
-    static void Initialize(v8::Handle<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
 };

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -38,7 +38,7 @@ cairo_surface_t* SvgBackend::recreateSurface() {
 
 Nan::Persistent<FunctionTemplate> SvgBackend::constructor;
 
-void SvgBackend::Initialize(Handle<Object> target) {
+void SvgBackend::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(SvgBackend::New);

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -19,6 +19,6 @@ class SvgBackend : public Backend
     static Backend *construct(int width, int height);
 
     static Nan::Persistent<v8::FunctionTemplate> constructor;
-    static void Initialize(v8::Handle<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
 };


### PR DESCRIPTION
Electron 5 is still in beta and will be shipped with Node 12. There are some breaking changes to native modules: https://electronjs.org/blog/nodejs-native-addons-and-electron-5

With latest version the command `node-gyp rebuild --target=5.0.0-beta.5 --runtime=electron` fails. This PR fixes build, and it works fine with my Electron application. 

Unfortunately, some new deprecated warnings have appeared. I'm not so experienced in writing native addons and I'd appreciate help with that. Or, if it is necessary, I could give it a try, but need more time with that. 

- [x] Have you updated CHANGELOG.md?
