### PR TITLE
Use size_t where appropriate and guard against overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Use size_t where appropriate and guard against overflow
 * Fix electron 5 and node 12 compatibility
 * Fix encoding options (quality) parameter in `canvas.toDataURL()`
 

--- a/src/Image.h
+++ b/src/Image.h
@@ -37,8 +37,8 @@ using JPEGDecodeL = std::function<uint32_t (uint8_t* const src)>;
 class Image: public Nan::ObjectWrap {
   public:
     char *filename;
-    int width, height;
-    int naturalWidth, naturalHeight;
+    size_t width, height;
+    size_t naturalWidth, naturalHeight;
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
@@ -120,8 +120,8 @@ class Image: public Nan::ObjectWrap {
 #ifdef HAVE_RSVG
     RsvgHandle *_rsvg;
     bool _is_svg;
-    int _svg_last_width;
-    int _svg_last_height;
+    size_t _svg_last_width;
+    size_t _svg_last_height;
 #endif
     ~Image();
 };


### PR DESCRIPTION
ping @zbjornson, @chearon 

I think that `size_t` might be the correct type here since it's a "type which is used to represent sizes of objects in bytes", and "it is guaranteed to be big enough to contain the size of the biggest object that system can handle".