### PR TITLE
Fix ES6 syntax usage for IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Support Node.js v12
 ### Fixed
+* Fix object literal & arrow function syntax usage for IE.
 
 2.4.1
 ==================

--- a/browser.js
+++ b/browser.js
@@ -5,7 +5,7 @@ const parseFont = require('./lib/parse-font')
 exports.parseFont = parseFont
 
 exports.createCanvas = function (width, height) {
-  return Object.assign(document.createElement('canvas'), { width, height })
+  return Object.assign(document.createElement('canvas'), { width: width, height: height })
 }
 
 exports.createImageData = function (array, width, height) {
@@ -19,7 +19,7 @@ exports.createImageData = function (array, width, height) {
 }
 
 exports.loadImage = function (src, options) {
-  return new Promise((resolve, reject) => {
+  return new Promise(function (resolve, reject) {
     const image = Object.assign(document.createElement('img'), options)
 
     function cleanup () {
@@ -27,8 +27,8 @@ exports.loadImage = function (src, options) {
       image.onerror = null
     }
 
-    image.onload = () => { cleanup(); resolve(image) }
-    image.onerror = () => { cleanup(); reject(new Error(`Failed to load the image "${src}"`)) }
+    image.onload = function () { cleanup(); resolve(image) }
+    image.onerror = function () { cleanup(); reject(new Error('Failed to load the image "' + src + '"')) }
 
     image.src = src
   })

--- a/lib/parse-font.js
+++ b/lib/parse-font.js
@@ -14,10 +14,10 @@ const weights = 'bold|bolder|lighter|[1-9]00'
 // [ [ <‘font-style’> || <font-variant-css21> || <‘font-weight’> || <‘font-stretch’> ]?
 //    <‘font-size’> [ / <‘line-height’> ]? <‘font-family’> ]
 // https://drafts.csswg.org/css-fonts-3/#font-prop
-const weightRe = new RegExp(`(${weights}) +`, 'i')
-const styleRe = new RegExp(`(${styles}) +`, 'i')
-const variantRe = new RegExp(`(${variants}) +`, 'i')
-const stretchRe = new RegExp(`(${stretches}) +`, 'i')
+const weightRe = new RegExp('(' + weights + ') +', 'i')
+const styleRe = new RegExp('(' + styles + ') +', 'i')
+const variantRe = new RegExp('(' + variants + ') +', 'i')
+const stretchRe = new RegExp('(' + stretches + ') +', 'i')
 const sizeFamilyRe = new RegExp(
   '([\\d\\.]+)(' + units + ') *'
   + '((?:' + string + ')( *, *(?:' + string + '))*)')


### PR DESCRIPTION
IE11 throws an error due to the object literal, arrow function, and string interpolation syntax used by `browser.js`.  This fixes those usages so that the canvas package can run properly.

![Screen Shot 2019-03-22 at 11 01 09 AM](https://user-images.githubusercontent.com/169093/54836253-d9d38e00-4c91-11e9-9ff3-7b0b1037b378.png)

I tested these changes locally by directly applying these changes within my project's node_modules folder, and it fixed all IE errors, allowing the page to load.

- [x] Have you updated CHANGELOG.md?
