### PR TITLE
fix lib path for Aarch64/Tegra (jetson/agx xavier)

### DIFF
--- a/util/has_lib.js
+++ b/util/has_lib.js
@@ -11,7 +11,8 @@ var SYSTEM_PATHS = [
   '/usr/lib/x86_64-linux-gnu',
   '/usr/lib/i386-linux-gnu',
   '/usr/lib/arm-linux-gnueabihf',
-  '/usr/lib/arm-linux-gnueabi'
+  '/usr/lib/arm-linux-gnueabi',
+  '/usr/lib/aarch64-linux-gnu'
 ]
 
 /**


### PR DESCRIPTION
Hello, 
This is needed in order to have has_lib returning true from Linux/Tegra on Jetson based architecture. Thanks.