### PR TITLE
lazy-load simple-get

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -12,8 +12,10 @@
 
 const bindings = require('./bindings')
 const Image = module.exports = bindings.Image
-const get = require('simple-get')
 const util = require('util')
+
+// Lazily loaded simple-get
+let get;
 
 const {GetSource, SetSource} = bindings;
 
@@ -44,6 +46,8 @@ Object.defineProperty(Image.prototype, 'src', {
             throw err
           }
         }
+
+        if (!get) get = require('simple-get');
 
         get.concat(val, (err, res, data) => {
           if (err) return onerror(err)


### PR DESCRIPTION
Appears to save ~1.5-2 MB of memory and improves startup speed.

Given that the ability to use a URL for an image source was added only recently, I'm guessing it's not super widely used, so I think it makes sense to lazy-load it.

- [ ] Have you updated CHANGELOG.md? - no, not notable/no release since simple-get was added
