### PR TITLE
adds crossOrigin attribute to loadImage

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -21,8 +21,8 @@ exports.createImageData = function (array, width, height) {
 exports.loadImage = function (src) {
   return new Promise((resolve, reject) => {
     const image = document.createElement('img')
-    image.crossOrigin = "anonymous"
-    
+    image.crossOrigin = 'anonymous'
+
     function cleanup () {
       image.onload = null
       image.onerror = null

--- a/browser.js
+++ b/browser.js
@@ -21,7 +21,8 @@ exports.createImageData = function (array, width, height) {
 exports.loadImage = function (src) {
   return new Promise((resolve, reject) => {
     const image = document.createElement('img')
-
+    image.crossOrigin = "anonymous"
+    
     function cleanup () {
       image.onload = null
       image.onerror = null

--- a/browser.js
+++ b/browser.js
@@ -18,10 +18,9 @@ exports.createImageData = function (array, width, height) {
   }
 }
 
-exports.loadImage = function (src) {
+exports.loadImage = function (src, options) {
   return new Promise((resolve, reject) => {
-    const image = document.createElement('img')
-    image.crossOrigin = 'anonymous'
+    const image = Object.assign(document.createElement('img'), options)
 
     function cleanup () {
       image.onload = null

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -294,7 +294,7 @@ export function createImageData(width: number, height: number): ImageData
  * @param src URL, `data: ` URI or (Node.js only) a local file path or Buffer
  * instance.
  */
-export function loadImage(src: string|Buffer): Promise<Image>
+export function loadImage(src: string|Buffer, options?: any): Promise<Image>
 
 /**
  * Registers a font that is not installed as a system font. This must be used


### PR DESCRIPTION
without that using the image later with webgl errors
 DOMException: Failed to execute 'texImage2D' on 'WebGLRenderingContext': The image element contains cross-origin data, and may not be loaded.

- [ ] Have you updated CHANGELOG.md?


Not sure if there is any reason why to not have this attribute. Please let me know 