### PR TITLE
Try fix raspi build

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1288,8 +1288,8 @@ NAN_METHOD(Context2d::DrawImage) {
   decompose_matrix(matrix, transforms);
   // extract the scale value from the current transform so that we know how many pixels we
   // need for our extra canvas in the drawImage operation.
-  double current_scale_x = abs(transforms[1]);
-  double current_scale_y = abs(transforms[2]);
+  double current_scale_x = std::abs(transforms[1]);
+  double current_scale_y = std::abs(transforms[2]);
   double extra_dx = 0;
   double extra_dy = 0;
   double fx = dw / sw * current_scale_x; // transforms[1] is scale on X


### PR DESCRIPTION
Tiny patch to fix the build from source on raspberry-pi /armv7l platform
Use std::abs which is templated and type-safe instead of abs which converts to int and is ambiguous.

Build tested on
gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
running on
Linux c1a2af6e321d 4.14.98-v7+ #1200 SMP Tue Feb 12 20:27:48 GMT 2019 armv7l GNU/Linux
and
Linux 1ee1e153e104 4.9.125-linuxkit #1 SMP Fri Sep 7 08:20:28 UTC 2018 x86_64 GNU/Linux

Changelog.md not updated - no functional change.

