### PR TITLE
Fix crash when resurfacing while fill/strokeStyle set to pattern or gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Fix crash when changing canvas width/height while `fillStyle` or `strokeStyle`
+  was set to a `CanvasPattern` or `CanvasGradient` (#1357).
 
 2.5.0
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -212,10 +212,10 @@ Context2d::~Context2d() {
 
 void Context2d::resetState(bool init) {
   if (!init) {
-    free(state->fillPattern);
-    free(state->strokePattern);
-    free(state->fillGradient);
-    free(state->strokeGradient);
+    cairo_pattern_destroy(state->fillPattern);
+    cairo_pattern_destroy(state->strokePattern);
+    cairo_pattern_destroy(state->fillGradient);
+    cairo_pattern_destroy(state->strokeGradient);
     pango_font_description_free(state->fontDescription);
   }
 
@@ -223,8 +223,10 @@ void Context2d::resetState(bool init) {
   state->shadowOffsetX = state->shadowOffsetY = 0;
   state->globalAlpha = 1;
   state->textAlignment = -1;
-  state->fillPattern = state->strokePattern = NULL;
-  state->fillGradient = state->strokeGradient = NULL;
+  state->fillPattern = nullptr;
+  state->strokePattern = nullptr;
+  state->fillGradient = nullptr;
+  state->strokeGradient = nullptr;
   state->textBaseline = TEXT_BASELINE_ALPHABETIC;
   rgba_t transparent = { 0, 0, 0, 1 };
   rgba_t transparent_black = { 0, 0, 0, 0 };

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -379,6 +379,19 @@ describe('Canvas', function () {
     assert.strictEqual(context.getImageData(0, 0, 1, 1).data.join(','), '0,0,0,0');
   });
 
+  it('Canvas#width= (resurfacing) doesn\'t crash when fillStyle is a pattern (#1357)', function (done) {
+    const canvas = createCanvas(100, 200);
+    const ctx = canvas.getContext('2d');
+
+    loadImage(`${__dirname}/fixtures/checkers.png`).then(img => {
+      const pattern = ctx.createPattern(img, 'repeat');
+      ctx.fillStyle = pattern;
+      ctx.fillRect(0, 0, 300, 300);
+      canvas.width = 200; // cause canvas to resurface
+      done();
+    })
+  });
+
   it('Canvas#stride', function() {
     var canvas = createCanvas(24, 10);
     assert.ok(canvas.stride >= 24, 'canvas.stride is too short');


### PR DESCRIPTION
Fixes #1357

- [x] Have you updated CHANGELOG.md?

Side note: I haven't found a way to get the CanvasPattern destructor to run. One, that could mean there's a memory leak, but two, that could be a double-free (i.e. there should probably be a `_pattern = nullptr` line in the destructor). I left it as-is because I want to find a way to get the dtor to run first.