### PR TITLE
Fix crash when resurfacing SVG canvases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Fix crash when changing canvas width/height while `fillStyle` or `strokeStyle`
   was set to a `CanvasPattern` or `CanvasGradient` (#1357).
+* Fix crash when changing width/height of SVG canvases (#1380).
 
 2.5.0
 ==================

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -3,6 +3,7 @@
 #include <cairo-svg.h>
 #include "../Canvas.h"
 #include "../closure.h"
+#include <cassert>
 
 using namespace v8;
 
@@ -13,7 +14,10 @@ SvgBackend::SvgBackend(int width, int height)
 
 SvgBackend::~SvgBackend() {
   cairo_surface_finish(surface);
-  if (_closure) delete _closure;
+  if (_closure) {
+    delete _closure;
+    _closure = nullptr;
+  }
   destroySurface();
 }
 
@@ -22,7 +26,8 @@ Backend *SvgBackend::construct(int width, int height){
 }
 
 cairo_surface_t* SvgBackend::createSurface() {
-  if (!_closure) _closure = new PdfSvgClosure(canvas);
+  assert(!_closure);
+  _closure = new PdfSvgClosure(canvas);
   surface = cairo_svg_surface_create_for_stream(PdfSvgClosure::writeVec, _closure, width, height);
   return surface;
 }
@@ -30,6 +35,7 @@ cairo_surface_t* SvgBackend::createSurface() {
 cairo_surface_t* SvgBackend::recreateSurface() {
   cairo_surface_finish(surface);
   delete _closure;
+  _closure = nullptr;
   cairo_surface_destroy(surface);
 
   return createSurface();

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -392,6 +392,11 @@ describe('Canvas', function () {
     })
   });
 
+  it('SVG Canvas#width changes don\'t crash (#1380)', function () {
+    const myCanvas = createCanvas(100, 100, 'svg')
+    myCanvas.width = 120;
+  });
+
   it('Canvas#stride', function() {
     var canvas = createCanvas(24, 10);
     assert.ok(canvas.stride >= 24, 'canvas.stride is too short');


### PR DESCRIPTION
Fixes #1380

- [x] Have you updated CHANGELOG.md?

---

The backend code is sorely in need of more cleanup. Right now changing either the width or height causes the backend to be recreated twice (and the common case of changing both width and height thus causes four recreations).