### PR TITLE
Update package.json typings field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix crash when changing width/height of SVG canvases (#1380).
 * Fix crash when using `toBuffer('raw')` with large canvases (#1158).
 * Clarified meaning of byte ordering for `toBuffer('raw')` in readme. (#1416)
-* Fixed package.json Typings field (#1432)
+* Fix package.json Typings field to point to Declaration file (#1432)
 
 2.5.0
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix crash when changing width/height of SVG canvases (#1380).
 * Fix crash when using `toBuffer('raw')` with large canvases (#1158).
 * Clarified meaning of byte ordering for `toBuffer('raw')` in readme. (#1416)
+* Fixed package.json Typings field (#1432)
 
 2.5.0
 ==================

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "util/",
     "types/index.d.ts"
   ],
-  "types": "types",
+  "types": "types/index.d.ts",
   "dependencies": {
     "nan": "^2.13.2",
     "node-pre-gyp": "^0.11.0",


### PR DESCRIPTION
'typings' in package.json needs to point to the Declaration file. It currently points to the just the folder

As a result IDEs like VSCode will auto import from `'canvas/typings'` instead of `canvas`, This will fix that issue

- [x] Have you updated CHANGELOG.md?