### PR TITLE
Ignore maxWidth in fillText and strokeText if it is undefined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: node_js
 install:
   - npm install --build-from-source
 node_js:
+  - '12'
   - '10'
   - '8'
   - '6'
+matrix:
+  allow_failures:
+    - node_js: '12'
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 install:
   - npm install --build-from-source
 node_js:
-  - '12'
   - '10'
   - '8'
   - '6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Ignore `maxWidth` in `fillText` and `strokeText` if it is undefined
 
 2.6.0
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2338,6 +2338,10 @@ get_text_scale(PangoLayout *layout, double maxWidth) {
 void
 paintText(const Nan::FunctionCallbackInfo<Value> &info, bool stroke) {
   int argsNum = info.Length() >= 4 ? 3 : 2;
+
+  if (argsNum == 3 && info[3]->IsUndefined())
+    argsNum--;
+
   double args[3];
   if(!checkArgs(info, args, argsNum, 1))
     return;

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2340,7 +2340,7 @@ paintText(const Nan::FunctionCallbackInfo<Value> &info, bool stroke) {
   int argsNum = info.Length() >= 4 ? 3 : 2;
 
   if (argsNum == 3 && info[3]->IsUndefined())
-    argsNum--;
+    argsNum = 2;
 
   double args[3];
   if(!checkArgs(info, args, argsNum, 1))

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -948,6 +948,23 @@ describe('Canvas', function () {
     });
   });
 
+  it('Context2d#fillText()', function () {
+    [
+      [['A', 10, 10], true],
+      [['A', 10, 10, undefined], true],
+      [['A', 10, 10, NaN], false],
+    ].forEach(([args, shouldDraw]) => {
+      const canvas = createCanvas(20, 20)
+      const ctx = canvas.getContext('2d')
+
+      ctx.textBaseline = 'middle'
+      ctx.textAlign = 'center'
+      ctx.fillText(...args)
+
+      assert.strictEqual(ctx.getImageData(0, 0, 20, 20).data.some(a => a), shouldDraw)
+    })
+  })
+
   it('Context2d#currentTransform', function () {
     var canvas = createCanvas(20, 20);
     var ctx = canvas.getContext('2d');


### PR DESCRIPTION
Fixes #1454

As it turned out that Chrome's behavior is correct, we can now safely update our implementation. 

- [x] Have you updated CHANGELOG.md?