### PR TITLE
fix assertion failure in Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ node_js:
   - '10'
   - '8'
   - '6'
-matrix:
-  allow_failures:
-    - node_js: '12'
 addons:
   apt:
     sources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Fixed
 * Ignore `maxWidth` in `fillText` and `strokeText` if it is undefined
+* Fix crash (assertion failure) in Node 12.x when patterns or gradients are used
 
 2.6.0
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -212,10 +212,6 @@ Context2d::~Context2d() {
 
 void Context2d::resetState(bool init) {
   if (!init) {
-    cairo_pattern_destroy(state->fillPattern);
-    cairo_pattern_destroy(state->strokePattern);
-    cairo_pattern_destroy(state->fillGradient);
-    cairo_pattern_destroy(state->strokeGradient);
     pango_font_description_free(state->fontDescription);
   }
 
@@ -1833,8 +1829,6 @@ NAN_SETTER(Context2d::SetFillStyle) {
     } else if(Nan::New(Pattern::constructor)->HasInstance(obj)){
       Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
       context->state->fillPattern = pattern->pattern();
-    } else {
-      return Nan::ThrowTypeError("Gradient or Pattern expected");
     }
   } else {
     MaybeLocal<String> mstr = Nan::To<String>(value);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -17,6 +17,9 @@ const os = require('os')
 const Readable = require('stream').Readable
 
 describe('Canvas', function () {
+  // Run with --expose-gc and uncomment this line to help find memory problems:
+  // afterEach(gc);
+
   it('Prototype and ctor are well-shaped, don\'t hit asserts on accessors (GH-803)', function () {
     const Canvas = require('../').Canvas;
     var c = new Canvas(10, 10);


### PR DESCRIPTION
These are destroyed in their class destructors. Destroying them here is a double-free.

See https://github.com/Automattic/node-canvas/pull/1455#issuecomment-510852554

I want to mull this over a little bit before merging... @Hakerh400 lmk if you have thoughts as well please.

This is the first time I've witnessed the destructors running, so if something indeed changed in v8/Node.js' GC in 12.x, that would make sense that we're only now seeing a double-free.

Minimal test case:

```js
// run with --expose-gc
const {createCanvas, loadImage} = require(".");

const canvas = createCanvas(100, 200);
const ctx = canvas.getContext('2d');

loadImage(`./test/fixtures/checkers.png`).then(img => {
	const pattern = ctx.createPattern(img, 'repeat');
	ctx.fillStyle = pattern;
	canvas.width = 200; // cause canvas to resurface
	process.nextTick(gc);
});
```

- [x] Have you updated CHANGELOG.md?
