### PR TITLE
Fix crash in Node.js v12 with RGB16_565

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Fixed
 * Ignore `maxWidth` in `fillText` and `strokeText` if it is undefined
-* Fix crash (assertion failure) in Node 12.x when patterns or gradients are used
+* Fix crash (assertion failure) in Node.js 12.x when patterns or gradients are used
+* Fix crash (check failure) in Node.js 12.x when using RGB16_565 format. (The
+  underlying arraybuffer was incorrectly sized.)
 
 2.6.0
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1019,7 +1019,7 @@ NAN_METHOD(Context2d::GetImageData) {
   Local<TypedArray> dataArray;
 
   if (canvas->backend()->getFormat() == CAIRO_FORMAT_RGB16_565) {
-    dataArray = Uint16Array::New(buffer, 0, size);
+    dataArray = Uint16Array::New(buffer, 0, size >> 1);
   } else {
     dataArray = Uint8ClampedArray::New(buffer, 0, size);
   }

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1071,7 +1071,7 @@ describe('Canvas', function () {
       var imageData = ctx.getImageData(0,0,3,6);
       assert.equal(3, imageData.width);
       assert.equal(6, imageData.height);
-      assert.equal(3 * 6 * 2, imageData.data.length);
+      assert.equal(3 * 6, imageData.data.length);
 
       assert.equal((255 & 0b11111) << 11, imageData.data[0]);
       assert.equal((255 & 0b111111) << 5, imageData.data[1]);
@@ -1143,7 +1143,7 @@ describe('Canvas', function () {
       var imageData = ctx.getImageData(0,0,2,1);
       assert.equal(2, imageData.width);
       assert.equal(1, imageData.height);
-      assert.equal(2 * 1 * 2, imageData.data.length);
+      assert.equal(2 * 1, imageData.data.length);
 
       assert.equal((255 & 0b11111) << 11, imageData.data[0]);
       assert.equal((255 & 0b111111) << 5, imageData.data[1]);


### PR DESCRIPTION
This fixes the CI failure.

- [x] Have you updated CHANGELOG.md?
