### PR TITLE
Fix assertion failure when using VSCode debugger to inspect Image proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Fix BMP issues. (#1497)
 * Update typings to support jpg and addPage on NodeCanvasRenderingContext2D (#1509)
+* Fix assertion failure when using Visual Studio Code debugger to inspect Image prototype (#1534)
 
 2.6.1
 ==================

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -187,6 +187,11 @@ NAN_SETTER(Image::SetHeight) {
  */
 
 NAN_METHOD(Image::GetSource){
+  if (!Image::constructor.Get(info.GetIsolate())->HasInstance(info.This())) {
+    // #1534
+    Nan::ThrowTypeError("Method Image.GetSource called on incompatible receiver");
+    return;
+  }
   Image *img = Nan::ObjectWrap::Unwrap<Image>(info.This());
   info.GetReturnValue().Set(Nan::New<String>(img->filename ? img->filename : "").ToLocalChecked());
 }
@@ -227,6 +232,11 @@ Image::clearData() {
  */
 
 NAN_METHOD(Image::SetSource){
+  if (!Image::constructor.Get(info.GetIsolate())->HasInstance(info.This())) {
+    // #1534
+    Nan::ThrowTypeError("Method Image.SetSource called on incompatible receiver");
+    return;
+  }
   Image *img = Nan::ObjectWrap::Unwrap<Image>(info.This());
   cairo_status_t status = CAIRO_STATUS_READ_ERROR;
 


### PR DESCRIPTION
GetSource and SetSource are sort of weird plain functions that require the `this` context to be an Image instance.

Fixes #1534

- [x] Have you updated CHANGELOG.md?
