### PR TITLE
Move prebuilds to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,12 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - ".github/workflows/prebuild.yaml"
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/prebuild.yaml"
+    
 
 jobs: 
   Linux:

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -1,0 +1,238 @@
+# Triggering prebuilds:
+# 1. Create a draft release manually using the GitHub UI.
+# 2. Set the `jobs.*.strategy.matrix.node` arrays to the set of Node.js versions
+#    to build for.
+# 3. Set the `jobs.*.strategy.matrix.canvas_tag` arrays to the set of Canvas
+#    tags to build. (Usually this is a single tag, but can be an array when a
+#    new version of Node.js is released and older versions of Canvas need to be
+#    built.)
+# 4. Commit and push this file to master.
+# 5. Once the builds succeed, promote the draft release to a full release.
+
+name: Make Prebuilds
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/prebuild.yaml'
+# UPLOAD_TO can be specified to upload the release assets under a different tag
+# name (e.g. for testing). If omitted, the assets are published under the same
+# release tag as the canvas version being built.
+# env:
+#   UPLOAD_TO: "v0.0.1"
+
+jobs:
+  Linux:
+    strategy:
+      matrix:
+        node: [8, 9, 10, 11, 12, 13, 14]
+        canvas_tag: [] # e.g. "v2.6.1"
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Linux
+    runs-on: ubuntu-latest
+    container:
+      image: chearon/canvas-prebuilt:7
+    env:
+      CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.canvas_tag }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Build
+        run: |
+          npm install -g node-gyp
+          npm install --ignore-scripts
+          . prebuild/Linux/preinstall.sh
+          cp prebuild/Linux/binding.gyp binding.gyp
+          node-gyp rebuild -j 2
+          . prebuild/Linux/bundle.sh
+
+      - name: Test binary
+        run: |
+          cd /root/harfbuzz-* && make uninstall
+          cd /root/cairo-* && make uninstall
+          cd /root/pango-* && make uninstall
+          cd /root/libpng-* && make uninstall
+          cd /root/libjpeg-* && make uninstall
+          cd /root/giflib-* && make uninstall
+          cd $GITHUB_WORKSPACE && npm test
+
+      - name: Make bundle
+        id: make_bundle
+        run: . prebuild/tarball.sh
+
+      - name: Upload
+        uses: actions/github-script@0.9.0
+        with:
+          script: |
+            const fs = require("fs");
+            const assetName = "${{ steps.make_bundle.outputs.asset_name }}";
+            const tagName = process.env.UPLOAD_TO || process.env.CANVAS_VERSION_TO_BUILD;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+            const releases = await github.repos.listReleases({owner, repo});
+            const release = releases.data.find(r => r.tag_name === tagName);
+            if (!release)
+              throw new Error(`Tag ${tagName} not found. Did you make the GitHub release?`);
+
+            const oldAsset = release.assets.find(a => a.name === assetName);
+            if (oldAsset)
+              await github.repos.deleteReleaseAsset({owner, repo, asset_id: oldAsset.id});
+
+            // (This is equivalent to actions/upload-release-asset. We're
+            // already in a script, so might as well do it here.)
+            const r = await github.repos.uploadReleaseAsset({
+              url: release.upload_url,
+              headers: {
+                "content-type": "application/x-gzip",
+                "content-length": `${fs.statSync(assetName).size}`
+              },
+              name: assetName,
+              data: fs.readFileSync(assetName)
+            });
+
+  macOS:
+    strategy:
+      matrix:
+        node: [8, 9, 10, 11, 12, 13, 14]
+        canvas_tag: [] # e.g. "v2.6.1"
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
+    runs-on: macos-latest
+    env:
+      CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.canvas_tag }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Build
+        run: |
+          npm install -g node-gyp
+          npm install --ignore-scripts
+          . prebuild/macOS/preinstall.sh
+          cp prebuild/macOS/binding.gyp binding.gyp
+          node-gyp rebuild -j 2
+          . prebuild/macOS/bundle.sh
+
+      - name: Test binary
+        run: |
+          brew uninstall --force cairo pango librsvg giflib harfbuzz
+          npm test
+
+      - name: Make bundle
+        id: make_bundle
+        run: . prebuild/tarball.sh
+
+      - name: Upload
+        uses: actions/github-script@0.9.0
+        with:
+          script: |
+            const fs = require("fs");
+            const assetName = "${{ steps.make_bundle.outputs.asset_name }}";
+            const tagName = process.env.UPLOAD_TO || process.env.CANVAS_VERSION_TO_BUILD;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+            const releases = await github.repos.listReleases({owner, repo});
+            const release = releases.data.find(r => r.tag_name === tagName);
+            if (!release)
+              throw new Error(`Tag ${tagName} not found. Did you make the GitHub release?`);
+
+            const oldAsset = release.assets.find(a => a.name === assetName);
+            if (oldAsset)
+              await github.repos.deleteReleaseAsset({owner, repo, asset_id: oldAsset.id});
+
+            // (This is equivalent to actions/upload-release-asset. We're
+            // already in a script, so might as well do it here.)
+            const r = await github.repos.uploadReleaseAsset({
+              url: release.upload_url,
+              headers: {
+                "content-type": "application/x-gzip",
+                "content-length": `${fs.statSync(assetName).size}`
+              },
+              name: assetName,
+              data: fs.readFileSync(assetName)
+            });
+
+  Win:
+    strategy:
+      matrix:
+        node: [8, 9, 10, 11, 12, 13, 14]
+        canvas_tag: [] # e.g. "v2.6.1"
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Windows
+    runs-on: windows-latest
+    env:
+      CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
+    steps:
+      # TODO drop when https://github.com/actions/virtual-environments/pull/632 lands
+      - uses: numworks/setup-msys2@v1
+        with:
+          update: true
+          path-type: inherit
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.canvas_tag }}
+
+      - name: Build
+        run: |
+          npm install -g node-gyp
+          npm install --ignore-scripts
+          msys2do . prebuild/Windows/preinstall.sh
+          msys2do cp prebuild/Windows/binding.gyp binding.gyp
+          msys2do node-gyp configure
+          msys2do node-gyp rebuild -j 2
+
+      - name: Bundle
+        run: msys2do . prebuild/Windows/bundle.sh
+
+      - name: Test binary
+        # By not running in msys2, this doesn't have access to the msys2 libs
+        run: npm test
+
+      - name: Make asset
+        id: make_bundle
+        # I can't figure out why this isn't an env var already. It shows up with `env`.
+        run: msys2do UPLOAD_TO=${{ env.UPLOAD_TO }} CANVAS_VERSION_TO_BUILD=${{ env.CANVAS_VERSION_TO_BUILD}} . prebuild/tarball.sh
+
+      - name: Upload
+        uses: actions/github-script@0.9.0
+        with:
+          script: |
+            const fs = require("fs");
+            const assetName = "${{ steps.make_bundle.outputs.asset_name }}";
+            const tagName = process.env.UPLOAD_TO || process.env.CANVAS_VERSION_TO_BUILD;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+            const releases = await github.repos.listReleases({owner, repo});
+            const release = releases.data.find(r => r.tag_name === tagName);
+            if (!release)
+              throw new Error(`Tag ${tagName} not found. Did you make the GitHub release?`);
+
+            const oldAsset = release.assets.find(a => a.name === assetName);
+            if (oldAsset)
+              await github.repos.deleteReleaseAsset({owner, repo, asset_id: oldAsset.id});
+
+            // (This is equivalent to actions/upload-release-asset. We're
+            // already in a script, so might as well do it here.)
+            const r = await github.repos.uploadReleaseAsset({
+              url: release.upload_url,
+              headers: {
+                "content-type": "application/x-gzip",
+                "content-length": `${fs.statSync(assetName).size}`
+              },
+              name: assetName,
+              data: fs.readFileSync(assetName)
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 * Switch CI to Github Actions. (Adds Windows and macOS builds.)
+* Switch prebuilds to GitHub actions in the Automattic/node-canvas repository.
+  Previously these were in the [node-gfx/node-canvas-prebuilt](https://github.com/node-gfx/node-canvas-prebuilt)
+  and triggered manually.
 ### Added
 * Export `rsvgVersion`.
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "binary": {
     "module_name": "canvas",
     "module_path": "build/Release",
-    "host": "https://github.com/node-gfx/node-canvas-prebuilt/releases/download/",
+    "host": "https://github.com/Automattic/node-canvas/releases/download/",
     "remote_path": "v{version}",
     "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{libc}-{arch}.tar.gz"
   },

--- a/prebuild/Linux/binding.gyp
+++ b/prebuild/Linux/binding.gyp
@@ -1,0 +1,53 @@
+{
+  'targets': [
+    {
+      'target_name': 'canvas',
+      'sources': [
+        'src/backend/Backend.cc',
+        'src/backend/ImageBackend.cc',
+        'src/backend/PdfBackend.cc',
+        'src/backend/SvgBackend.cc',
+        'src/bmp/BMPParser.cc',
+        'src/Backends.cc',
+        'src/Canvas.cc',
+        'src/CanvasGradient.cc',
+        'src/CanvasPattern.cc',
+        'src/CanvasRenderingContext2d.cc',
+        'src/closure.cc',
+        'src/color.cc',
+        'src/Image.cc',
+        'src/ImageData.cc',
+        'src/init.cc',
+        'src/register_font.cc'
+      ],
+      'defines': [
+        'HAVE_GIF',
+        'HAVE_JPEG',
+        'HAVE_RSVG'
+      ],
+      'libraries': [
+        '<!@(pkg-config pixman-1 --libs)',
+        '<!@(pkg-config cairo --libs)',
+        '<!@(pkg-config libpng --libs)',
+        '<!@(pkg-config pangocairo --libs)',
+        '<!@(pkg-config freetype2 --libs)',
+        '<!@(pkg-config librsvg-2.0 --libs)',
+        '-ljpeg',
+        '-lgif'
+      ],
+      'include_dirs': [
+        '<!(node -e "require(\'nan\')")',
+        '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)'
+      ],
+      'ldflags': [
+        '-Wl,-rpath \'-Wl,$$ORIGIN\''
+      ],
+      'cflags!': ['-fno-exceptions'],
+      'cflags_cc!': ['-fno-exceptions']
+    }
+  ]
+}

--- a/prebuild/Linux/bundle.sh
+++ b/prebuild/Linux/bundle.sh
@@ -1,0 +1,5 @@
+copies=$(lddtree.sh -l build/Release/canvas.node | sed -r -e '/^\/lib/d' -e '/canvas.node$/d');
+
+for so in $copies; do
+  cp $so build/Release
+done;

--- a/prebuild/Linux/preinstall.sh
+++ b/prebuild/Linux/preinstall.sh
@@ -1,0 +1,8 @@
+# apt-get-style dependencies aren't done here since the
+# linux build is done on a docker image that has them
+
+git clone git://anongit.gentoo.org/proj/pax-utils.git
+cd pax-utils
+PATH=$PATH:$PWD
+make
+cd ..

--- a/prebuild/Windows/binding.gyp
+++ b/prebuild/Windows/binding.gyp
@@ -1,0 +1,79 @@
+{
+  'targets': [
+    {
+      'target_name': 'canvas',
+      'sources': [
+        'src/backend/Backend.cc',
+        'src/backend/ImageBackend.cc',
+        'src/backend/PdfBackend.cc',
+        'src/backend/SvgBackend.cc',
+        'src/bmp/BMPParser.cc',
+        'src/Backends.cc',
+        'src/Canvas.cc',
+        'src/CanvasGradient.cc',
+        'src/CanvasPattern.cc',
+        'src/CanvasRenderingContext2d.cc',
+        'src/closure.cc',
+        'src/color.cc',
+        'src/Image.cc',
+        'src/ImageData.cc',
+        'src/init.cc',
+        'src/register_font.cc'
+      ],
+      'defines': [
+        'HAVE_GIF',
+        'HAVE_JPEG',
+        'HAVE_RSVG',
+        'HAVE_BOOLEAN', # or jmorecfg.h tries to define it
+        '_USE_MATH_DEFINES' # for M_PI
+      ],
+      'libraries': [
+        'D:/a/_temp/msys/msys64/mingw64/lib/libcairo-2.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libpng16-16.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libjpeg-8.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libpango-1.0-0.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libpangocairo-1.0-0.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libgobject-2.0-0.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libglib-2.0-0.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libturbojpeg.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libgif-7.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/libfreetype-6.lib',
+        'D:/a/_temp/msys/msys64/mingw64/lib/librsvg-2-2.lib'
+      ],
+      'include_dirs': [
+        '<!(node -e "require(\'nan\')")',
+        'D:/a/_temp/msys/msys64/mingw64/include',
+        'D:/a/_temp/msys/msys64/mingw64/include/pango-1.0',
+        'D:/a/_temp/msys/msys64/mingw64/include/cairo',
+        'D:/a/_temp/msys/msys64/mingw64/include/libpng16',
+        'D:/a/_temp/msys/msys64/mingw64/include/glib-2.0',
+        'D:/a/_temp/msys/msys64/mingw64/lib/glib-2.0/include',
+        'D:/a/_temp/msys/msys64/mingw64/include/pixman-1',
+        'D:/a/_temp/msys/msys64/mingw64/include/freetype2',
+        'D:/a/_temp/msys/msys64/mingw64/include/fontconfig',
+        'D:/a/_temp/msys/msys64/mingw64/include/librsvg-2.0',
+        'D:/a/_temp/msys/msys64/mingw64/include/gdk-pixbuf-2.0'
+      ],
+      'configurations': {
+        'Debug': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'WarningLevel': 4,
+              'ExceptionHandling': 1,
+              'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+            }
+          }
+        },
+        'Release': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'WarningLevel': 4,
+              'ExceptionHandling': 1,
+              'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/prebuild/Windows/bundle.sh
+++ b/prebuild/Windows/bundle.sh
@@ -1,0 +1,23 @@
+# dependency walker will help us figure out which DLLs 
+# canvas.node directly and indirectly uses
+wget --no-verbose --no-clobber http://www.dependencywalker.com/depends22_x64.zip
+unzip -u depends22_x64.zip
+
+# write recurisve dependencies of canvas.node into depends.csv
+./depends -c -oc:depends.csv build/Release/canvas.node;
+
+[ -f depends.csv ] || {
+  echo "error invoking depends.exe";
+  exit 1;
+}
+
+# case-insensitive intersection of 2nd column of depends.csv
+# and all files ending in .dll in the mingw64 directory
+copies=$(comm -12 \
+  <(cat depends.csv | cut -d ',' -f2 | sed 's/"//g' | tr '[:upper:]' '[:lower:]' | sort) \
+  <(find /mingw64/bin -name '*.dll' -printf "%f\n" | tr '[:upper:]' '[:lower:]' | sort) \
+);
+
+for dll in $copies; do
+  cp /mingw64/bin/$dll build/Release
+done;

--- a/prebuild/Windows/preinstall.sh
+++ b/prebuild/Windows/preinstall.sh
@@ -1,0 +1,38 @@
+# expects node, VS, and MSYS environments to be set up already. does everything else.
+
+deps="cairo-2 png16-16 jpeg-8 pango-1.0-0 pangocairo-1.0-0 gobject-2.0-0 glib-2.0-0 turbojpeg gif-7 freetype-6 rsvg-2-2";
+
+# install cairo and tools to create .lib
+
+pacman --noconfirm -S \
+  wget \
+  unzip \
+  mingw64/mingw-w64-x86_64-binutils \
+  mingw64/mingw-w64-x86_64-tools \
+  mingw64/mingw-w64-x86_64-libjpeg-turbo \
+  mingw64/mingw-w64-x86_64-pango \
+  mingw64/mingw-w64-x86_64-cairo \
+  mingw64/mingw-w64-x86_64-giflib \
+  mingw64/mingw-w64-x86_64-freetype \
+  mingw64/mingw-w64-x86_64-fontconfig \
+  mingw64/mingw-w64-x86_64-librsvg \
+  mingw64/mingw-w64-x86_64-libxml2
+
+# create .lib files for vc++
+
+echo "generating lib files for the MSYS2 dlls"
+for lib in $deps; do
+  gendef /mingw64/bin/lib$lib.dll > /dev/null 2>&1 || {
+    echo "could not find lib$lib.dll, have to skip ";
+    continue;
+  }
+
+  dlltool -d lib$lib.def -l /mingw64/lib/lib$lib.lib > /dev/null 2>&1 || {
+    echo "could not create dll for lib$lib.dll";
+    continue;
+  }
+
+  echo "created lib$lib.lib from lib$lib.dll";
+
+  rm lib$lib.def
+done

--- a/prebuild/macOS/binding.gyp
+++ b/prebuild/macOS/binding.gyp
@@ -1,0 +1,51 @@
+{
+  'targets': [
+    {
+      'target_name': 'canvas',
+      'sources': [
+        'src/backend/Backend.cc',
+        'src/backend/ImageBackend.cc',
+        'src/backend/PdfBackend.cc',
+        'src/backend/SvgBackend.cc',
+        'src/bmp/BMPParser.cc',
+        'src/Backends.cc',
+        'src/Canvas.cc',
+        'src/CanvasGradient.cc',
+        'src/CanvasPattern.cc',
+        'src/CanvasRenderingContext2d.cc',
+        'src/closure.cc',
+        'src/color.cc',
+        'src/Image.cc',
+        'src/ImageData.cc',
+        'src/init.cc',
+        'src/register_font.cc'
+      ],
+      'defines': [
+        'HAVE_GIF',
+        'HAVE_JPEG',
+        'HAVE_RSVG'
+      ],
+      'libraries': [
+        '<!@(pkg-config pixman-1 --libs)',
+        '<!@(pkg-config cairo --libs)',
+        '<!@(pkg-config libpng --libs)',
+        '<!@(pkg-config pangocairo --libs)',
+        '<!@(pkg-config freetype2 --libs)',
+        '<!@(pkg-config librsvg-2.0 --libs)',
+        '-ljpeg',
+        '-lgif'
+      ],
+      'include_dirs': [
+        '<!(node -e "require(\'nan\')")',
+        '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)'
+      ],
+      'xcode_settings': {
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+      }
+    }
+  ]
+}

--- a/prebuild/macOS/bundle.sh
+++ b/prebuild/macOS/bundle.sh
@@ -1,0 +1,4 @@
+build=build/Release
+
+~/Library/Python/*/bin/macpack build/Release/canvas.node -d .
+

--- a/prebuild/macOS/preinstall.sh
+++ b/prebuild/macOS/preinstall.sh
@@ -1,0 +1,4 @@
+brew update
+brew install pkg-config cairo pango librsvg python3 giflib # python3 is for macpack
+brew upgrade python # activates python 3
+pip3 install --user macpack

--- a/prebuild/tarball.sh
+++ b/prebuild/tarball.sh
@@ -1,0 +1,18 @@
+# Generate the node-gyp formatted filename from the node environment
+FILENAME=$(
+  node -e "
+    var p = process, v = p.versions, libc = require('detect-libc').family || 'unknown';
+    const tagName = p.env.UPLOAD_TO || p.env.CANVAS_VERSION_TO_BUILD;
+    console.log(['canvas', tagName, 'node-v' + v.modules, p.platform, libc, p.arch].join('-'));
+  "
+).tar.gz;
+
+# Zip up the release
+tar -C build -czvf $FILENAME Release
+
+if [ $? -ne 0 ]; then
+  echo "failed to make tarball $FILENAME from node-canvas/build"
+  exit 1;
+else
+  echo "::set-output name=asset_name::$FILENAME"
+fi


### PR DESCRIPTION
@chearon this basically copies your `ci/` folder into `prebuild/`, and ports the travis config + `install.sh` to GitHub actions. I haven't started Windows yet (and I've never used msys, but was reading through https://github.com/actions/virtual-environments/issues/30 and it looks definitely possible).

[There's no manual trigger for GitHub actions yet](https://github.community/t5/GitHub-Actions/GitHub-Actions-Manual-Trigger-Approvals/td-p/31504), but hopefully builds are reliable enough that doing this on release creation, or at least push, is viable.