### PR TITLE
Returns an Object and not a String

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -76,11 +76,12 @@ Object.defineProperty(Image.prototype, 'src', {
 
 // TODO || is for Node.js pre-v6.6.0
 Image.prototype[util.inspect.custom || 'inspect'] = function(){
-  return '[Image'
-    + (this.complete ? ':' + this.width + 'x' + this.height : '')
-    + (this.src ? ' ' + this.src : '')
-    + (this.complete ? ' complete' : '')
-    + ']';
+  return {
+    width: this.complete ? this.width : '',
+    height: this.complete ? this.height : '',
+    src: this.src ? this.src : '',
+    complete: this.complete ? 'complete' : ''
+  };
 };
 
 function getSource(img){


### PR DESCRIPTION
In this way the retrieval of information is much easier. Especially for information about the dimensions.

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
