### PR TITLE
Fix .complete for errored images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix signed/unsigned comparison warning introduced in 2.6.0, and function cast warnings with GCC8+
 * Fix to compile without JPEG support (#1593).
 * Fix compile errors with cairo
+* Fix Image#complete if the image failed to load.
 
 2.6.1
 ==================

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -100,8 +100,7 @@ NAN_METHOD(Image::New) {
  */
 
 NAN_GETTER(Image::GetComplete) {
-  Image *img = Nan::ObjectWrap::Unwrap<Image>(info.This());
-  info.GetReturnValue().Set(Nan::New<Boolean>(Image::COMPLETE == img->state));
+  info.GetReturnValue().Set(Nan::New<Boolean>(true));
 }
 
 /*

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -88,7 +88,10 @@ describe('Image', function () {
   it('detects invalid PNG', function (done) {
     if (process.platform === 'win32') this.skip(); // TODO
     const img = new Image()
-    img.onerror = () => done()
+    img.onerror = () => {
+      assert.strictEqual(img.complete, true)
+      done()
+    }
     img.src = Buffer.from('89504E470D', 'hex')
   })
 
@@ -156,6 +159,7 @@ describe('Image', function () {
       assert.equal(err.code, 'ENOENT')
       assert.equal(err.path, 'path/to/nothing')
       assert.equal(err.syscall, 'fopen')
+      assert.strictEqual(img.complete, true)
       done()
     }
     img.src = 'path/to/nothing'
@@ -165,6 +169,7 @@ describe('Image', function () {
     const img = new Image()
     img.onerror = err => {
       assert.equal(err.message, "JPEG datastream contains no image")
+      assert.strictEqual(img.complete, true)
       done()
     }
     img.src = `${__dirname}/fixtures/159-crash1.jpg`
@@ -218,6 +223,7 @@ describe('Image', function () {
       img.src = Buffer.alloc(0)
       assert.strictEqual(img.width, 0)
       assert.strictEqual(img.height, 0)
+      assert.strictEqual(img.complete, true)
 
       assert.strictEqual(onerrorCalled, 1)
     })


### PR DESCRIPTION
According to the HTML specification [1], HTMLImageElement#complete indicates whether or not an image is loading. It does not indicate whether or not the image successfully loaded.

When an Image fails to load, we call the onerror callback. However, Image#complete is false, despite the current request's state being 'broken' (according to the spec). This is not spec-compliant.

Because our Image implementation loads images synchronously (as soon as the src property is set, which is not spec-compliant), then the current request's state is only ever 'completely available' or 'broken' [2] (if src is set). This means that, according to the spec, Image#complete must always be true. Fix Image#complete to return true unconditionally.

[1] https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-complete
[2] https://html.spec.whatwg.org/multipage/images.html#img-req-state

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
