### PR TITLE
Fix crash if exception thrown from onload/onerror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Update typings to support jpg and addPage on NodeCanvasRenderingContext2D (#1509)
 * Fix assertion failure when using Visual Studio Code debugger to inspect Image prototype (#1534)
 * Fix signed/unsigned comparison warning introduced in 2.6.0, and function cast warnings with GCC8+
+* Fix Node.js crash when throwing from an onload or onerror handler.
 
 2.6.1
 ==================

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -272,14 +272,14 @@ NAN_METHOD(Image::SetSource){
         argv[0] = Nan::Error(Nan::New(cairo_status_to_string(status)).ToLocalChecked());
       }
       Local<Context> ctx = Nan::GetCurrentContext();
-      Nan::Call(onerrorFn.As<Function>(), ctx->Global(), 1, argv).ToLocalChecked();
+      Nan::Call(onerrorFn.As<Function>(), ctx->Global(), 1, argv);
     }
   } else {
     img->loaded();
     Local<Value> onloadFn = Nan::Get(info.This(), Nan::New("onload").ToLocalChecked()).ToLocalChecked();
     if (onloadFn->IsFunction()) {
       Local<Context> ctx = Nan::GetCurrentContext();
-      Nan::Call(onloadFn.As<Function>(), ctx->Global(), 0, NULL).ToLocalChecked();
+      Nan::Call(onloadFn.As<Function>(), ctx->Global(), 0, NULL);
     }
   }
 }

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -92,6 +92,28 @@ describe('Image', function () {
     img.src = Buffer.from('89504E470D', 'hex')
   })
 
+  it('propagates exceptions thrown by onload', function () {
+    class MyError extends Error {}
+    const img = new Image()
+    img.onload = () => {
+      throw new MyError()
+    }
+    assert.throws(() => {
+      img.src = jpg_face
+    }, MyError);
+  })
+
+  it('propagates exceptions thrown by onerror', function () {
+    class MyError extends Error {}
+    const img = new Image()
+    img.onerror = () => {
+      throw new MyError()
+    }
+    assert.throws(() => {
+      img.src = Buffer.from('', 'hex')
+    }, MyError);
+  })
+
   it('loads SVG data URL base64', function () {
     if (!HAVE_SVG) this.skip();
     const base64Enc = fs.readFileSync(svg_tree, 'base64')


### PR DESCRIPTION
If a user-provided .onload or .onerror handler on an Image throws an exception, the Node.js process crashes:

    FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal.
     1: 0x94d778 node::Abort() [node]
     2: 0x94edb1 node::OnFatalError(char const*, char const*) [node]
     3: 0xad5b0d v8::Utils::ReportApiFailure(char const*, char const*) [node]
     4: 0x7f98f47799ae Image::SetSource(Nan::FunctionCallbackInfo<v8::Value> const&) [/home/strager/tmp/Projects/node-canvas/build/Release/canvas.node]
     5: 0x7f98f4774fec  [/home/strager/tmp/Projects/node-canvas/build/Release/canvas.node]
     6: 0xb395b9 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [node]
     7: 0xb39970  [node]
     8: 0xb3a1ea  [node]
     9: 0xb3aa99 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
    10: 0x12e89b9  [node]

Fix this issue by not requiring a return value from the .onload and .onerror functions.

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
