### PR TITLE
docs: Update dependencies for Ubuntu 18~20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 * Switch CI to Github Actions. (Adds Windows and macOS builds.)
+* Updated dependencies in documentation for ubuntu 18~20.
 ### Added
 * Export `rsvgVersion`.
 ### Fixed

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ OS | Command
 ----- | -----
 OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib librsvg`
 Ubuntu | `sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`
+Ubuntu (18~20) | `sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg8-dev libgif-dev librsvg2-dev`
 Fedora | `sudo yum install gcc-c++ cairo-devel pango-devel libjpeg-turbo-devel giflib-devel`
 Solaris | `pkgin install cairo pango pkg-config xproto renderproto kbproto xextproto`
 OpenBSD | `doas pkg_add cairo pango png jpeg giflib`


### PR DESCRIPTION
~~**DO_NOT_MERGE**: New discovery on https://github.com/Automattic/node-canvas/pull/1582#issuecomment-629827179~~

Based on my research i've concluded that using `libjpeg-dev` breaks the canvas on Ubuntu 18~20 -> Updating docs for `libjpeg8-dev`

Relevant: https://github.com/gitpod-io/gitpod/issues/1520

Relevant: https://github.com/Automattic/node-canvas/issues/1496

Signed-off-by: Jacob Hrbek <kreyren@member.fsf.org>

Thanks for contributing!

- [X] Have you updated CHANGELOG.md?
