### PR TITLE
use libjpeg-dev in Linux CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt update
-          sudo apt install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev librsvg2-dev
+          sudo apt install -y libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
       - name: Install
         run: npm install --build-from-source
       - name: Test


### PR DESCRIPTION
libjpeg-dev is a dummy package that resolves to libjpeg-8 in (current) Ubuntu, and is the correct dep to use. I blindly copied the config from travis when switching to GitHub actions.
