### PR TITLE
1593 fix build without jpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Update typings to support jpg and addPage on NodeCanvasRenderingContext2D (#1509)
 * Fix assertion failure when using Visual Studio Code debugger to inspect Image prototype (#1534)
 * Fix signed/unsigned comparison warning introduced in 2.6.0, and function cast warnings with GCC8+
+* Fix to compile without JPEG support (#1593).
 
 2.6.1
 ==================

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -314,12 +314,6 @@ static void parseJPEGArgs(Local<Value> arg, JpegClosure& jpegargs) {
 }
 #endif
 
-static uint32_t getSafeBufSize(Canvas* canvas) {
-  // Don't allow the buffer size to exceed the size of the canvas (#674)
-  // TODO not sure if this is really correct, but it fixed #674
-  return (std::min)(canvas->getWidth() * canvas->getHeight() * 4, static_cast<int>(PAGE_SIZE));
-}
-
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
 
 static inline void setPdfMetaStr(cairo_surface_t* surf, Local<Object> opts,
@@ -679,6 +673,11 @@ NAN_METHOD(Canvas::StreamPDFSync) {
  */
 
 #ifdef HAVE_JPEG
+static uint32_t getSafeBufSize(Canvas* canvas) {
+  // Don't allow the buffer size to exceed the size of the canvas (#674)
+  // TODO not sure if this is really correct, but it fixed #674
+  return (std::min)(canvas->getWidth() * canvas->getHeight() * 4, static_cast<int>(PAGE_SIZE));
+}
 
 NAN_METHOD(Canvas::StreamJPEGSync) {
   if (!info[1]->IsFunction())
@@ -698,7 +697,6 @@ NAN_METHOD(Canvas::StreamJPEGSync) {
   }
   return;
 }
-
 #endif
 
 char *

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -282,6 +282,7 @@ static void parsePNGArgs(Local<Value> arg, PngClosure& pngargs) {
   }
 }
 
+#ifdef HAVE_JPEG
 static void parseJPEGArgs(Local<Value> arg, JpegClosure& jpegargs) {
   // "If Type(quality) is not Number, or if quality is outside that range, the
   // user agent must use its default quality value, as if the quality argument
@@ -311,6 +312,7 @@ static void parseJPEGArgs(Local<Value> arg, JpegClosure& jpegargs) {
     }
   }
 }
+#endif
 
 static uint32_t getSafeBufSize(Canvas* canvas) {
   // Don't allow the buffer size to exceed the size of the canvas (#674)

--- a/src/closure.cc
+++ b/src/closure.cc
@@ -1,7 +1,6 @@
 #include "closure.h"
 
 #ifdef HAVE_JPEG
-
 void JpegClosure::init_destination(j_compress_ptr cinfo) {
   JpegClosure* closure = (JpegClosure*)cinfo->client_data;
   closure->vec.resize(PAGE_SIZE);
@@ -23,5 +22,5 @@ void JpegClosure::term_destination(j_compress_ptr cinfo) {
   size_t finalSize = closure->vec.size() - closure->jpeg_dest_mgr->free_in_buffer;
   closure->vec.resize(finalSize);
 }
-
 #endif
+

--- a/src/closure.cc
+++ b/src/closure.cc
@@ -1,5 +1,7 @@
 #include "closure.h"
 
+#ifdef HAVE_JPEG
+
 void JpegClosure::init_destination(j_compress_ptr cinfo) {
   JpegClosure* closure = (JpegClosure*)cinfo->client_data;
   closure->vec.resize(PAGE_SIZE);
@@ -21,3 +23,5 @@ void JpegClosure::term_destination(j_compress_ptr cinfo) {
   size_t finalSize = closure->vec.size() - closure->jpeg_dest_mgr->free_in_buffer;
   closure->vec.resize(finalSize);
 }
+
+#endif

--- a/src/closure.h
+++ b/src/closure.h
@@ -3,7 +3,11 @@
 #pragma once
 
 #include "Canvas.h"
+
+#ifdef HAVE_JPEG
 #include <jpeglib.h>
+#endif
+
 #include <nan.h>
 #include <png.h>
 #include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
@@ -52,6 +56,7 @@ struct PngClosure : Closure {
   PngClosure(Canvas* canvas) : Closure(canvas) {};
 };
 
+#ifdef HAVE_JPEG
 struct JpegClosure : Closure {
   uint32_t quality = 75;
   uint32_t chromaSubsampling = 2;
@@ -73,3 +78,4 @@ struct JpegClosure : Closure {
     delete jpeg_dest_mgr;
   }
 };
+#endif


### PR DESCRIPTION
Fixes compilation when HAVE_JPEG is not defined, adds #ifdefs for JPEG specific code that didn't have them.

- [x] Have you updated CHANGELOG.md?
