### PR TITLE
Binary build fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix assertion failure when using Visual Studio Code debugger to inspect Image prototype (#1534)
 * Fix signed/unsigned comparison warning introduced in 2.6.0, and function cast warnings with GCC8+
 * Fix to compile without JPEG support (#1593).
+* Fix compile errors with cairo
 
 2.6.1
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include "backend/ImageBackend.h"
-#include <cairo/cairo-pdf.h>
+#include <cairo-pdf.h>
 #include "Canvas.h"
 #include "CanvasGradient.h"
 #include "CanvasPattern.h"


### PR DESCRIPTION
Thanks for contributing!

- [x] Have you updated CHANGELOG.md?

----

This pull request fixes a couple errors in the `node-gyp` binary build:

1. There was JPEG-related code that wasn't surrounded by `#ifdef HAVE_JPEG` blocks.
2. `CanvasRenderingContext2d.cc` was including `cairo-pdf.h` with an incorrect path (the `pkg-config` include path provides the path directly to the Cairo includes, so having `cairo/` in the include directive is incorrect).
