### PR TITLE
Speed up putImageData for RGBA canvases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Switch prebuilds to GitHub actions in the Automattic/node-canvas repository.
   Previously these were in the [node-gfx/node-canvas-prebuilt](https://github.com/node-gfx/node-canvas-prebuilt)
   and triggered manually.
+* Speed up `putImageData` for RGBA32 canvases.
 ### Added
 * Export `rsvgVersion`.
 ### Fixed

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -4,7 +4,7 @@
  * milliseconds to complete.
  */
 
-var createCanvas = require('../').createCanvas
+var { createCanvas, ImageData } = require('../')
 var canvas = createCanvas(200, 200)
 var largeCanvas = createCanvas(1000, 1000)
 var ctx = canvas.getContext('2d')
@@ -63,6 +63,28 @@ function done (benchmark, times, start, isAsync) {
 }
 
 // node-canvas
+
+const id0 = new ImageData(200, 200)
+
+bm('putImageData, all a=0', function () {
+  ctx.putImageData(id0, 0, 0)
+})
+
+const id255 = new ImageData(200, 200)
+id255.data.fill(0xFF)
+
+bm('putImageData, all a=0xFF', function () {
+  ctx.putImageData(id255, 0, 0)
+})
+
+const idRand = new ImageData(200, 200)
+for (let i = 0; i < idRand.data.length; i++) {
+  idRand.data[i] = 255 * Math.random()
+}
+
+bm('putImageData, mixed a', function () {
+  ctx.putImageData(idRand, 0, 0)
+})
 
 bm('fillStyle= name', function () {
   ctx.fillStyle = 'transparent'


### PR DESCRIPTION
Replaces the byte-wise version with both a faster portable version and a specific version for x86/64 (SSE2).

```
# ops/sec, higher is better
      before   portable      sse2
a=0   19,024     33,935    71,080
a=FF  16,546     13,847    30,995
a=__   7,537      9,175    22,998
```

@pcordes I know you had work on this from three years ago. Any comments would be welcome. I stuck with SSE2 for now to avoid dispatching.

Ref #909 

- [x] Have you updated CHANGELOG.md?
