### PR TITLE
Speed up `fillStyle=` and `strokeStyle=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Switch prebuilds to GitHub actions in the Automattic/node-canvas repository.
   Previously these were in the [node-gfx/node-canvas-prebuilt](https://github.com/node-gfx/node-canvas-prebuilt)
   and triggered manually.
+* Speed up `fillStyle=` and `strokeStyle=`
 ### Added
 * Export `rsvgVersion`.
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix compile errors with cairo
 * Fix Image#complete if the image failed to load.
 * Upgrade node-pre-gyp to v0.15.0 to use latest version of needle to fix error when downloading prebuilds.
+* Don't throw if `fillStyle` or `strokeStyle` is set to an object, but that object is not a Gradient or Pattern. (This behavior was non-standard: invalid inputs are supposed to be ignored.)
 
 2.6.1
 ==================

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -65,7 +65,9 @@ function done (benchmark, times, start, isAsync) {
 // node-canvas
 
 bm('fillStyle= name', function () {
-  ctx.fillStyle = 'transparent'
+  for (let i = 0; i < 10000; i++) {
+    ctx.fillStyle = '#fefefe'
+  }
 })
 
 bm('lineTo()', function () {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1844,9 +1844,6 @@ NAN_SETTER(Context2d::SetFillStyle) {
       context->_fillStyle.Reset(value);
       Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
       context->state->fillPattern = pattern->pattern();
-    } else {
-      // TODO this is non-standard
-      Nan::ThrowTypeError("Gradient or Pattern expected");
     }
   }
 }
@@ -1890,9 +1887,6 @@ NAN_SETTER(Context2d::SetStrokeStyle) {
       context->_strokeStyle.Reset(value);
       Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
       context->state->strokePattern = pattern->pattern();
-    } else {
-      // TODO this is non-standard
-      return Nan::ThrowTypeError("Gradient or Pattern expected");
     }
   }
 }

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1828,24 +1828,26 @@ NAN_GETTER(Context2d::GetFillStyle) {
 NAN_SETTER(Context2d::SetFillStyle) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
 
-  if (Nan::New(Gradient::constructor)->HasInstance(value) ||
-      Nan::New(Pattern::constructor)->HasInstance(value)) {
-    context->_fillStyle.Reset(value);
-
-    Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    if (Nan::New(Gradient::constructor)->HasInstance(obj)){
-      Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(obj);
-      context->state->fillGradient = grad->pattern();
-    } else if(Nan::New(Pattern::constructor)->HasInstance(obj)){
-      Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
-      context->state->fillPattern = pattern->pattern();
-    }
-  } else {
+  if (value->IsString()) {
     MaybeLocal<String> mstr = Nan::To<String>(value);
     if (mstr.IsEmpty()) return;
     Local<String> str = mstr.ToLocalChecked();
     context->_fillStyle.Reset();
     context->_setFillColor(str);
+  } else if (value->IsObject()) {
+    Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
+    if (Nan::New(Gradient::constructor)->HasInstance(obj)) {
+      context->_fillStyle.Reset(value);
+      Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(obj);
+      context->state->fillGradient = grad->pattern();
+    } else if (Nan::New(Pattern::constructor)->HasInstance(obj)) {
+      context->_fillStyle.Reset(value);
+      Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
+      context->state->fillPattern = pattern->pattern();
+    } else {
+      // TODO this is non-standard
+      Nan::ThrowTypeError("Gradient or Pattern expected");
+    }
   }
 }
 
@@ -1872,26 +1874,26 @@ NAN_GETTER(Context2d::GetStrokeStyle) {
 NAN_SETTER(Context2d::SetStrokeStyle) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
 
-  if (Nan::New(Gradient::constructor)->HasInstance(value) ||
-      Nan::New(Pattern::constructor)->HasInstance(value)) {
-    context->_strokeStyle.Reset(value);
-
-    Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    if (Nan::New(Gradient::constructor)->HasInstance(obj)){
-      Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(obj);
-      context->state->strokeGradient = grad->pattern();
-    } else if(Nan::New(Pattern::constructor)->HasInstance(obj)){
-      Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
-      context->state->strokePattern = pattern->pattern();
-    } else {
-      return Nan::ThrowTypeError("Gradient or Pattern expected");
-    }
-  } else {
+  if (value->IsString()) {
     MaybeLocal<String> mstr = Nan::To<String>(value);
     if (mstr.IsEmpty()) return;
     Local<String> str = mstr.ToLocalChecked();
     context->_strokeStyle.Reset();
     context->_setStrokeColor(str);
+  } else if (value->IsObject()) {
+    Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
+    if (Nan::New(Gradient::constructor)->HasInstance(obj)) {
+      context->_strokeStyle.Reset(value);
+      Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(obj);
+      context->state->strokeGradient = grad->pattern();
+    } else if (Nan::New(Pattern::constructor)->HasInstance(obj)) {
+      context->_strokeStyle.Reset(value);
+      Pattern *pattern = Nan::ObjectWrap::Unwrap<Pattern>(obj);
+      context->state->strokePattern = pattern->pattern();
+    } else {
+      // TODO this is non-standard
+      return Nan::ThrowTypeError("Gradient or Pattern expected");
+    }
   }
 }
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1756,7 +1756,7 @@ describe('Canvas', function () {
     var canvas = createCanvas(2, 2);
     var ctx = canvas.getContext('2d');
 
-    ctx.fillStyle = ['#808080'];
+    ctx.fillStyle = '#808080';
     ctx.fillRect(0, 0, 2, 2);
     var data = ctx.getImageData(0, 0, 2, 2).data;
 

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1766,10 +1766,6 @@ describe('Canvas', function () {
       else
         assert.strictEqual(byte, 255);
     });
-
-    assert.throws(function () {
-      ctx.fillStyle = Object.create(null);
-    });
   });
 
 });


### PR DESCRIPTION
I was confused why I was seeing CanvasPattern show up in CPU profiles when we never use them. Turns out it's from these setters.

Roughly 2x performance improvement.
- Don't create extra `Local<FunctionTemplate>` handles
- Don't create any `Local<FunctionTemplate>` handles if the value is a string

- [x] Have you updated CHANGELOG.md?
