### PR TITLE
translate "sans-serif" to "sans" for Pango

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Fix Pango logging "expect ugly output" on Windows (#1643)
 
 2.7.0
 ==================

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -837,12 +837,6 @@ Canvas::GetWeightFromCSSString(const char *weight) {
   return w;
 }
 
-bool streq_casein(std::string& str1, std::string& str2) {
-  return str1.size() == str2.size() && std::equal(str1.begin(), str1.end(), str2.begin(), [](char& c1, char& c2) {
-    return c1 == c2 || std::toupper(c1) == std::toupper(c2);
-  });
-}
-
 /*
  * Given a user description, return a description that will select the
  * font either from the system or @font-face

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -232,7 +232,7 @@ void Context2d::resetState(bool init) {
   state->patternQuality = CAIRO_FILTER_GOOD;
   state->imageSmoothingEnabled = true;
   state->textDrawingMode = TEXT_DRAW_PATHS;
-  state->fontDescription = pango_font_description_from_string("sans serif");
+  state->fontDescription = pango_font_description_from_string("sans");
   pango_font_description_set_absolute_size(state->fontDescription, 10 * PANGO_SCALE);
   pango_layout_set_font_description(_layout, state->fontDescription);
 
@@ -2533,7 +2533,16 @@ NAN_SETTER(Context2d::SetFont) {
   pango_font_description_set_style(desc, Canvas::GetStyleFromCSSString(*style));
   pango_font_description_set_weight(desc, Canvas::GetWeightFromCSSString(*weight));
 
-  if (strlen(*family) > 0) pango_font_description_set_family(desc, *family);
+  if (strlen(*family) > 0) {
+    // See #1643 - Pango understands "sans" whereas CSS uses "sans-serif"
+    std::string s1(*family);
+    std::string s2("sans-serif");
+    if (streq_casein(s1, s2)) {
+      pango_font_description_set_family(desc, "sans");
+    } else {
+      pango_font_description_set_family(desc, *family);
+    }
+  }
 
   PangoFontDescription *sys_desc = Canvas::ResolveFontDescription(desc);
   pango_font_description_free(desc);

--- a/src/Util.h
+++ b/src/Util.h
@@ -25,3 +25,9 @@ inline void SetProtoAccessor(
 		v8::AccessorSignature::New(v8::Isolate::GetCurrent(), ctor)
 	);
 }
+
+inline bool streq_casein(std::string& str1, std::string& str2) {
+  return str1.size() == str2.size() && std::equal(str1.begin(), str1.end(), str2.begin(), [](char& c1, char& c2) {
+    return c1 == c2 || std::toupper(c1) == std::toupper(c2);
+  });
+}


### PR DESCRIPTION
Might change the default font for users on macOS and Linux, but that might be okay if they're not specifying `ctx.font`.

Fixes #1643