### PR TITLE
update setSource in nextTick

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -84,12 +84,14 @@ Image.prototype[util.inspect.custom || 'inspect'] = function(){
 };
 
 function getSource(img){
-  return img._originalSource || GetSource.call(img);
+  return img._originalSource || img._src || GetSource.call(img);
 }
 
 function setSource(img, src, origSrc){
-  process.nextTick(function(){
+  clearImmediate(img._setSourceTimer);
+  img._setSourceTimer = setImmediate(() => {
     SetSource.call(img, src);
   });
+  img._src = src;
   img._originalSource = origSrc;
 }

--- a/lib/image.js
+++ b/lib/image.js
@@ -88,6 +88,8 @@ function getSource(img){
 }
 
 function setSource(img, src, origSrc){
-  SetSource.call(img, src);
+  process.nextTick(function(){
+    SetSource.call(img, src);
+  });
   img._originalSource = origSrc;
 }


### PR DESCRIPTION
When set `img.src=some_buffer` the `onload` callback function may not be called.

Demo code:
```javascript
const img = new Image();
img.src = some_image_buffer;
img.onload = () => { alert('success'); }
```

In this case, `onload` will never be called.
After I check the code below:
https://github.com/Automattic/node-canvas/blob/master/src/Image.cc#L278-L281


I change the code to:

```
const img = new Image();
img.onload = () => { alert('success'); }
img.src = some_image_buffer;
```
And this code works well.

Fixes #2264


- [ ] Have you updated CHANGELOG.md?
No, I will update it after the pr was approved.
