### PR TITLE
Make module context-aware and use global toupper

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -28,6 +28,6 @@ inline void SetProtoAccessor(
 
 inline bool streq_casein(std::string& str1, std::string& str2) {
   return str1.size() == str2.size() && std::equal(str1.begin(), str1.end(), str2.begin(), [](char& c1, char& c2) {
-    return c1 == c2 || std::toupper(c1) == std::toupper(c2);
+    return c1 == c2 || ::toupper(c1) == ::toupper(c2);
   });
 }

--- a/src/init.cc
+++ b/src/init.cc
@@ -89,4 +89,8 @@ NAN_MODULE_INIT(init) {
   Nan::Set(target, Nan::New<String>("freetypeVersion").ToLocalChecked(), Nan::New<String>(freetype_version).ToLocalChecked()).Check();
 }
 
-NODE_MODULE(canvas, init);
+// Switch to using a context-aware module
+//NODE_MODULE(canvas, init);
+NODE_MODULE_INIT() {
+  init(exports);
+}


### PR DESCRIPTION
Fixes #1394 

Also includes a fix where std::toupper is not defined, so building was failing
