### PR TITLE
Use node pre gyp v1 (as non-scoped version is deprecated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "nan": "^2.14.0",
-    "node-pre-gyp": "^0.15.0",
+    "@mapbox/node-pre-gyp": "^1.0.0",
     "simple-get": "^3.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will receive updates in the future.

I have not updated the changelog. 
