### PR TITLE
Fix always-false comparison warning in Canvas.cc in Node 15+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Upgrade dtslint
 * Add Node.js v15 to CI.
+* The C++ class method `nBytes()` now returns a size_t. (Because this is a C++
+  method only, this is not considered a breaking change.)
 ### Added
 * Added support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
 ### Fixed
 * Fix Pango logging "expect ugly output" on Windows (#1643)
 * Fix benchmark for createPNGStream (#1672)
 * Fix dangling reference in BackendOperationNotAvailable exception (#1740)
+* Fix always-false comparison warning in Canvas.cc.
 
 2.7.0
 ==================

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -408,7 +408,7 @@ NAN_METHOD(Canvas::ToBuffer) {
   if (info[0]->StrictEquals(Nan::New<String>("raw").ToLocalChecked())) {
     cairo_surface_t *surface = canvas->surface();
     cairo_surface_flush(surface);
-    if (static_cast<uint32_t>(canvas->nBytes()) > node::Buffer::kMaxLength) {
+    if (canvas->nBytes() > node::Buffer::kMaxLength) {
       Nan::ThrowError("Data exceeds maximum buffer length.");
       return;
     }
@@ -597,6 +597,9 @@ streamPDF(void *c, const uint8_t *data, unsigned len) {
   Nan::HandleScope scope;
   Nan::AsyncResource async("canvas:StreamPDF");
   PdfStreamInfo* streaminfo = static_cast<PdfStreamInfo*>(c);
+  // TODO this is technically wrong, we're returning a pointer to the data in a
+  // vector in a class with automatic storage duration. If the canvas goes out
+  // of scope while we're in the handler, a use-after-free could happen.
   Local<Object> buf = Nan::NewBuffer(const_cast<char *>(reinterpret_cast<const char *>(data)), len, stream_pdf_free, 0).ToLocalChecked();
   Local<Value> argv[3] = {
       Nan::Null()

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -9,6 +9,7 @@
 #include <pango/pangocairo.h>
 #include <v8.h>
 #include <vector>
+#include <cstddef>
 
 /*
  * Maxmimum states per context.
@@ -63,7 +64,9 @@ class Canvas: public Nan::ObjectWrap {
 
     DLL_PUBLIC inline uint8_t *data(){ return cairo_image_surface_get_data(surface()); }
     DLL_PUBLIC inline int stride(){ return cairo_image_surface_get_stride(surface()); }
-    DLL_PUBLIC inline int nBytes(){ return getHeight() * stride(); }
+    DLL_PUBLIC inline std::size_t nBytes(){
+      return static_cast<std::size_t>(getHeight()) * stride();
+    }
 
     DLL_PUBLIC inline int getWidth() { return backend()->getWidth(); }
     DLL_PUBLIC inline int getHeight() { return backend()->getHeight(); }


### PR DESCRIPTION
Node.js v15 (V8 8.6) has kMaxLength of u64{1}<<32, which is statically determinable to be larger than the largest uint32_t:

```
warning: comparison is always false due to limited range of data type [-Wtype-limits]
     if (static_cast<uint32_t>(canvas->nBytes()) > node::Buffer::kMaxLength) {
```

---

- [x] Have you updated CHANGELOG.md?
