### PR TITLE
Fix dtslint failing in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Changed
+* Upgrade dtslint
 ### Added
 * Added support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -55,11 +55,12 @@
   "devDependencies": {
     "@types/node": "^10.12.18",
     "assert-rejects": "^1.0.0",
-    "dtslint": "^0.5.3",
+    "dtslint": "^4.0.7",
     "express": "^4.16.3",
     "mocha": "^5.2.0",
     "pixelmatch": "^4.0.2",
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "typescript": "^4.2.2"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Version update needs typescript as a peer dependency.

- [x] Have you updated CHANGELOG.md?
