### PR TITLE
Fix Windows CI build, add Node.js v15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
     paths-ignore:
       - ".github/workflows/prebuild.yaml"
-    
 
 jobs: 
   Linux:
@@ -14,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 15]
     steps:
       - uses: actions/setup-node@v1
         with:
@@ -34,7 +33,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 15]
     steps:
       - uses: actions/setup-node@v1
         with:
@@ -42,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
-          Invoke-WebRequest "http://ftp.gnome.org/pub/GNOME/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip" -OutFile "gtk.zip"
+          Invoke-WebRequest "https://ftp-osl.osuosl.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip" -OutFile "gtk.zip"
           Expand-Archive gtk.zip -DestinationPath "C:\GTK"
           Invoke-WebRequest "https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-2.0.4-vc64.exe" -OutFile "libjpeg.exe" -UserAgent NativeHost
           .\libjpeg.exe /S
@@ -56,7 +55,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 15]
     steps:
       - uses: actions/setup-node@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 * Upgrade dtslint
+* Add Node.js v15 to CI.
 ### Added
 * Added support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Fix Pango logging "expect ugly output" on Windows (#1643)
 * Fix benchmark for createPNGStream (#1672)
+* Fix dangling reference in BackendOperationNotAvailable exception (#1740)
 
 2.7.0
 ==================


### PR DESCRIPTION
I don't know why redirects aren't working here. It's possible that the GitHub Actions runner is getting redirected to HTTP, which fails (https://github.com/PowerShell/PowerShell/issues/2896), but Invoke-WebRequest has no way to log what it's doing. Hard-coding a mirror works (for now).

With #1751, all checks pass.

- [x] Have you updated CHANGELOG.md?
