### PR TITLE
Add ctx.getTransform() and ctx.setTransform(DOMMatrix) methods

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -123,6 +123,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   Nan::SetPrototypeMethod(ctor, "rotate", Rotate);
   Nan::SetPrototypeMethod(ctor, "translate", Translate);
   Nan::SetPrototypeMethod(ctor, "transform", Transform);
+  Nan::SetPrototypeMethod(ctor, "getTransform", GetTransform);
   Nan::SetPrototypeMethod(ctor, "resetTransform", ResetTransform);
   Nan::SetPrototypeMethod(ctor, "setTransform", SetTransform);
   Nan::SetPrototypeMethod(ctor, "isPointInPath", IsPointInPath);
@@ -1751,11 +1752,11 @@ NAN_SETTER(Context2d::SetQuality) {
 }
 
 /*
- * Get current transform.
+ * Helper for get current transform matrix
  */
 
-NAN_GETTER(Context2d::GetCurrentTransform) {
-  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+Local<Object>
+get_current_transform(Context2d *context) {
   Isolate *iso = Isolate::GetCurrent();
 
   Local<Float64Array> arr = Float64Array::New(ArrayBuffer::New(iso, 48), 0, 6);
@@ -1771,7 +1772,16 @@ NAN_GETTER(Context2d::GetCurrentTransform) {
 
   const int argc = 1;
   Local<Value> argv[argc] = { arr };
-  Local<Object> instance = Nan::NewInstance(_DOMMatrix.Get(iso), argc, argv).ToLocalChecked();
+  return Nan::NewInstance(context->_DOMMatrix.Get(iso), argc, argv).ToLocalChecked();
+}
+
+/*
+ * Get current transform.
+ */
+
+NAN_GETTER(Context2d::GetCurrentTransform) {
+  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+  Local<Object> instance = get_current_transform(context);
 
   info.GetReturnValue().Set(instance);
 }
@@ -2241,6 +2251,17 @@ NAN_METHOD(Context2d::Transform) {
 
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_transform(context->context(), &matrix);
+}
+
+/*
+ * Get the CTM
+ */
+
+NAN_METHOD(Context2d::GetTransform) {
+  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+  Local<Object> instance = get_current_transform(context);
+
+  info.GetReturnValue().Set(instance);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -76,6 +76,7 @@ class Context2d: public Nan::ObjectWrap {
     static NAN_METHOD(Translate);
     static NAN_METHOD(Scale);
     static NAN_METHOD(Transform);
+    static NAN_METHOD(GetTransform);
     static NAN_METHOD(ResetTransform);
     static NAN_METHOD(SetTransform);
     static NAN_METHOD(IsPointInPath);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -992,6 +992,12 @@ describe('Canvas', function () {
     assert.equal(mat3.d, 0.3);
 
     assert.deepEqual(ctx.currentTransform, ctx.getTransform());
+
+    ctx.setTransform(ctx.getTransform());
+    assert.deepEqual(mat3, ctx.getTransform());
+
+    ctx.setTransform(mat3.a, mat3.b, mat3.c, mat3.d, mat3.e, mat3.f);
+    assert.deepEqual(mat3, ctx.getTransform());
   });
 
   it('Context2d#createImageData(ImageData)', function () {

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -990,6 +990,8 @@ describe('Canvas', function () {
     var mat3 = ctx.currentTransform;
     assert.equal(mat3.a, 0.1);
     assert.equal(mat3.d, 0.3);
+
+    assert.deepEqual(ctx.currentTransform, ctx.getTransform());
   });
 
   it('Context2d#createImageData(ImageData)', function () {


### PR DESCRIPTION
Issue: https://github.com/Automattic/node-canvas/issues/1642

- Added getTransform() NAN_METHOD
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getTransform

- Added setTransform(matrix) overload
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setTransform
(before that PR, `setTransform` was just an alias for `ctx.transform`)  
<br/>

- [ ] Have you updated CHANGELOG.md?
- [x] Added unit tests
