### PR TITLE
Export NodeCanvasRenderingContext2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Add Node.js v15 to CI.
 * The C++ class method `nBytes()` now returns a size_t. (Because this is a C++
   method only, this is not considered a breaking change.)
+* Export type NodeCanvasRenderingContext2D so you can pass the current context
+  to functions (TypeScript).
 ### Added
 * Added support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Added support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
 ### Fixed
+* Fix `actualBoundingBoxLeft` and `actualBoundingBoxRight` returned by `measureText` to be the ink rect ([#1776](https://github.com/Automattic/node-canvas/pull/1776), fixes [#1703](https://github.com/Automattic/node-canvas/issues/1703)).
 * Fix Pango logging "expect ugly output" on Windows (#1643)
 * Fix benchmark for createPNGStream (#1672)
 * Fix dangling reference in BackendOperationNotAvailable exception (#1740)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Export type NodeCanvasRenderingContext2D so you can pass the current context
   to functions (TypeScript).
 ### Added
-* Added support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
+* Add support for  `inverse()` and `invertSelf()` to `DOMMatrix` (#1648)
+* Add support for `context.getTransform()` ([#1769](https://github.com/Automattic/node-canvas/pull/1769))
+* Add support for `context.setTransform(dommatrix)` ([#1769](https://github.com/Automattic/node-canvas/pull/1769))
 ### Fixed
 * Fix `actualBoundingBoxLeft` and `actualBoundingBoxRight` returned by `measureText` to be the ink rect ([#1776](https://github.com/Automattic/node-canvas/pull/1776), fixes [#1703](https://github.com/Automattic/node-canvas/issues/1703)).
 * Fix Pango logging "expect ugly output" on Windows (#1643)

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2698,10 +2698,10 @@ NAN_METHOD(Context2d::MeasureText) {
            Nan::New<Number>(logical_rect.width)).Check();
   Nan::Set(obj,
            Nan::New<String>("actualBoundingBoxLeft").ToLocalChecked(),
-           Nan::New<Number>(x_offset - PANGO_LBEARING(logical_rect))).Check();
+           Nan::New<Number>(x_offset - PANGO_LBEARING(ink_rect))).Check();
   Nan::Set(obj,
            Nan::New<String>("actualBoundingBoxRight").ToLocalChecked(),
-           Nan::New<Number>(x_offset + PANGO_RBEARING(logical_rect))).Check();
+           Nan::New<Number>(x_offset + PANGO_RBEARING(ink_rect))).Check();
   Nan::Set(obj,
            Nan::New<String>("actualBoundingBoxAscent").ToLocalChecked(),
            Nan::New<Number>(y_offset + PANGO_ASCENT(ink_rect))).Check();

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -123,6 +123,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   Nan::SetPrototypeMethod(ctor, "rotate", Rotate);
   Nan::SetPrototypeMethod(ctor, "translate", Translate);
   Nan::SetPrototypeMethod(ctor, "transform", Transform);
+  Nan::SetPrototypeMethod(ctor, "getTransform", GetTransform);
   Nan::SetPrototypeMethod(ctor, "resetTransform", ResetTransform);
   Nan::SetPrototypeMethod(ctor, "setTransform", SetTransform);
   Nan::SetPrototypeMethod(ctor, "isPointInPath", IsPointInPath);
@@ -1751,11 +1752,11 @@ NAN_SETTER(Context2d::SetQuality) {
 }
 
 /*
- * Get current transform.
+ * Helper for get current transform matrix
  */
 
-NAN_GETTER(Context2d::GetCurrentTransform) {
-  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+Local<Object>
+get_current_transform(Context2d *context) {
   Isolate *iso = Isolate::GetCurrent();
 
   Local<Float64Array> arr = Float64Array::New(ArrayBuffer::New(iso, 48), 0, 6);
@@ -1771,7 +1772,16 @@ NAN_GETTER(Context2d::GetCurrentTransform) {
 
   const int argc = 1;
   Local<Value> argv[argc] = { arr };
-  Local<Object> instance = Nan::NewInstance(_DOMMatrix.Get(iso), argc, argv).ToLocalChecked();
+  return Nan::NewInstance(context->_DOMMatrix.Get(iso), argc, argv).ToLocalChecked();
+}
+
+/*
+ * Get current transform.
+ */
+
+NAN_GETTER(Context2d::GetCurrentTransform) {
+  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+  Local<Object> instance = get_current_transform(context);
 
   info.GetReturnValue().Set(instance);
 }
@@ -2241,6 +2251,17 @@ NAN_METHOD(Context2d::Transform) {
 
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   cairo_transform(context->context(), &matrix);
+}
+
+/*
+ * Get the CTM
+ */
+
+NAN_METHOD(Context2d::GetTransform) {
+  Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+  Local<Object> instance = get_current_transform(context);
+
+  info.GetReturnValue().Set(instance);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -76,6 +76,7 @@ class Context2d: public Nan::ObjectWrap {
     static NAN_METHOD(Translate);
     static NAN_METHOD(Scale);
     static NAN_METHOD(Transform);
+    static NAN_METHOD(GetTransform);
     static NAN_METHOD(ResetTransform);
     static NAN_METHOD(SetTransform);
     static NAN_METHOD(IsPointInPath);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -934,8 +934,9 @@ describe('Canvas', function () {
 
       ctx.textBaseline = "alphabetic"
       var metrics = ctx.measureText("Alphabet")
-      // Zero if the given baseline is the alphabetic baseline
-      assert.equal(metrics.alphabeticBaseline, 0)
+      // Actual value depends on font library version. Have observed values
+      // between 0 and 0.769.
+      assert.ok(metrics.alphabeticBaseline >= 0 && metrics.alphabeticBaseline <= 1);
       // Positive = going up from the baseline
       assert.ok(metrics.actualBoundingBoxAscent > 0)
       // Positive = going down from the baseline

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -991,6 +991,8 @@ describe('Canvas', function () {
     var mat3 = ctx.currentTransform;
     assert.equal(mat3.a, 0.1);
     assert.equal(mat3.d, 0.3);
+
+    assert.deepEqual(ctx.currentTransform, ctx.getTransform());
   });
 
   it('Context2d#createImageData(ImageData)', function () {

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -993,6 +993,12 @@ describe('Canvas', function () {
     assert.equal(mat3.d, 0.3);
 
     assert.deepEqual(ctx.currentTransform, ctx.getTransform());
+
+    ctx.setTransform(ctx.getTransform());
+    assert.deepEqual(mat3, ctx.getTransform());
+
+    ctx.setTransform(mat3.a, mat3.b, mat3.c, mat3.d, mat3.e, mat3.f);
+    assert.deepEqual(mat3, ctx.getTransform());
   });
 
   it('Context2d#createImageData(ImageData)', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -128,7 +128,7 @@ export class Canvas {
 	toDataURL(mimeType: 'image/jpeg', quality: number, cb: (err: Error|null, result: string) => void): void
 }
 
-export declare class NodeCanvasRenderingContext2D extends CanvasRenderingContext2D {
+export class NodeCanvasRenderingContext2D extends CanvasRenderingContext2D {
 	/**
 	 * _Non-standard_. Defaults to 'good'. Affects pattern (gradient, image,
 	 * etc.) rendering quality.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -128,7 +128,7 @@ export class Canvas {
 	toDataURL(mimeType: 'image/jpeg', quality: number, cb: (err: Error|null, result: string) => void): void
 }
 
-declare class NodeCanvasRenderingContext2D extends CanvasRenderingContext2D {
+export declare class NodeCanvasRenderingContext2D extends CanvasRenderingContext2D {
 	/**
 	 * _Non-standard_. Defaults to 'good'. Affects pattern (gradient, image,
 	 * etc.) rendering quality.


### PR DESCRIPTION
Hello! I'd like to propose exporting the `NodeCanvasRenderingContext2DP` type so one can create helper functions for drawing specific shapes using the current context, for the sake of organisation.

Code example:

```typescript
function drawTriangle(ctx: NodeCanvasRenderingContext2D, pointX: number, pointY: number) {
    ctx.beginPath()
    ctx.moveTo(pointX, pointY)
    ctx.lineTo(pointX - 8, pointY - 11)
    ctx.lineTo(pointX + 8, pointY - 11)
    ctx.fill()
}
```

- [x] Have you updated CHANGELOG.md?
