### PR TITLE
Add `deregisterAllFonts` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+* Added `deregisterAllFonts` method to free up memory and reduce font conflicts.
 ### Fixed
 
 2.8.0

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ function registerFont (src, fontFace) {
 /**
  * Unload all fonts from pango to free up memory
  */
-function deregisterAllFonts() {
-  return Canvas._deregisterAllFonts();
+function deregisterAllFonts () {
+  return Canvas._deregisterAllFonts()
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function registerFont (src, fontFace) {
  * Unload all fonts from pango to free up memory
  */
 function deregisterAllFonts() {
-	return Canvas._deregisterAllFonts();
+  return Canvas._deregisterAllFonts();
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,13 @@ function registerFont (src, fontFace) {
   return Canvas._registerFont(fs.realpathSync(src), fontFace)
 }
 
+/**
+ * Unload all fonts from pango to free up memory
+ */
+function deregisterAllFonts() {
+	return Canvas._deregisterAllFonts();
+}
+
 module.exports = {
   Canvas,
   Context2d: CanvasRenderingContext2D, // Legacy/compat export
@@ -63,6 +70,7 @@ module.exports = {
   DOMPoint,
 
   registerFont,
+  deregisterAllFonts,
   parseFont,
 
   createCanvas,

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -754,7 +754,7 @@ NAN_METHOD(Canvas::RegisterFont) {
       FontFace face;
       face.user_desc = user_desc;
       face.sys_desc = sys_desc;
-	  strcpy( (char *)face.file_path, (char *) *filePath );
+      strcpy( (char *)face.file_path, (char *) *filePath );
       font_face_list.push_back(face);
     } else {
       pango_font_description_free(user_desc);
@@ -771,11 +771,15 @@ NAN_METHOD(Canvas::RegisterFont) {
 }
 
 NAN_METHOD(Canvas::DeregisterAllFonts) {
-	// Unload all fonts from pango to free up memory
-	std::for_each(font_face_list.begin(), font_face_list.end(), [&](FontFace& f) {
-      deregister_font( (unsigned char *)f.file_path );
+  // Unload all fonts from pango to free up memory
+  bool success = true;
+  std::for_each(font_face_list.begin(), font_face_list.end(), [&](FontFace& f) {
+      if (!deregister_font( (unsigned char *)f.file_path )) success = false;
+      pango_font_description_free(f.user_desc);
+      pango_font_description_free(f.sys_desc);
     });
-	font_face_list.clear();
+  font_face_list.clear();
+  if (!success) Nan::ThrowError("Could not deregister one or more fonts");
 }
 
 /*

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -79,6 +79,7 @@ Canvas::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 
   // Class methods
   Nan::SetMethod(ctor, "_registerFont", RegisterFont);
+  Nan::SetMethod(ctor, "_deregisterAllFonts", DeregisterAllFonts);
 
   Local<Context> ctx = Nan::GetCurrentContext();
   Nan::Set(target,
@@ -753,6 +754,7 @@ NAN_METHOD(Canvas::RegisterFont) {
       FontFace face;
       face.user_desc = user_desc;
       face.sys_desc = sys_desc;
+	  face.file_path = (unsigned char *) *filePath;
       font_face_list.push_back(face);
     } else {
       pango_font_description_free(user_desc);
@@ -766,6 +768,14 @@ NAN_METHOD(Canvas::RegisterFont) {
   g_free(family);
   g_free(weight);
   g_free(style);
+}
+
+NAN_METHOD(Canvas::DeregisterAllFonts) {
+	// Unload all fonts from pango to free up memory
+	std::for_each(font_face_list.begin(), font_face_list.end(), [&](FontFace& f) {
+      deregister_font( f.file_path );
+    });
+	font_face_list.clear();
 }
 
 /*

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -754,7 +754,7 @@ NAN_METHOD(Canvas::RegisterFont) {
       FontFace face;
       face.user_desc = user_desc;
       face.sys_desc = sys_desc;
-	  face.file_path = (unsigned char *) *filePath;
+	  strcpy( (char *)face.file_path, (char *) *filePath );
       font_face_list.push_back(face);
     } else {
       pango_font_description_free(user_desc);
@@ -773,7 +773,7 @@ NAN_METHOD(Canvas::RegisterFont) {
 NAN_METHOD(Canvas::DeregisterAllFonts) {
 	// Unload all fonts from pango to free up memory
 	std::for_each(font_face_list.begin(), font_face_list.end(), [&](FontFace& f) {
-      deregister_font( f.file_path );
+      deregister_font( (unsigned char *)f.file_path );
     });
 	font_face_list.clear();
 }

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -754,7 +754,7 @@ NAN_METHOD(Canvas::RegisterFont) {
       FontFace face;
       face.user_desc = user_desc;
       face.sys_desc = sys_desc;
-      strcpy( (char *)face.file_path, (char *) *filePath );
+      strncpy((char *)face.file_path, (char *) *filePath, 1023);
       font_face_list.push_back(face);
     } else {
       pango_font_description_free(user_desc);

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -773,11 +773,13 @@ NAN_METHOD(Canvas::RegisterFont) {
 NAN_METHOD(Canvas::DeregisterAllFonts) {
   // Unload all fonts from pango to free up memory
   bool success = true;
+  
   std::for_each(font_face_list.begin(), font_face_list.end(), [&](FontFace& f) {
-      if (!deregister_font( (unsigned char *)f.file_path )) success = false;
-      pango_font_description_free(f.user_desc);
-      pango_font_description_free(f.sys_desc);
-    });
+    if (!deregister_font( (unsigned char *)f.file_path )) success = false;
+    pango_font_description_free(f.user_desc);
+    pango_font_description_free(f.sys_desc);
+  });
+  
   font_face_list.clear();
   if (!success) Nan::ThrowError("Could not deregister one or more fonts");
 }

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -28,6 +28,7 @@ class FontFace {
   public:
     PangoFontDescription *sys_desc = nullptr;
     PangoFontDescription *user_desc = nullptr;
+	unsigned char *file_path;
 };
 
 /*
@@ -50,6 +51,7 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_METHOD(StreamPDFSync);
     static NAN_METHOD(StreamJPEGSync);
     static NAN_METHOD(RegisterFont);
+	static NAN_METHOD(DeregisterAllFonts);
     static v8::Local<v8::Value> Error(cairo_status_t status);
     static void ToPngBufferAsync(uv_work_t *req);
     static void ToJpegBufferAsync(uv_work_t *req);

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -28,7 +28,7 @@ class FontFace {
   public:
     PangoFontDescription *sys_desc = nullptr;
     PangoFontDescription *user_desc = nullptr;
-	unsigned char file_path[1024];
+    unsigned char file_path[1024];
 };
 
 /*
@@ -51,7 +51,7 @@ class Canvas: public Nan::ObjectWrap {
     static NAN_METHOD(StreamPDFSync);
     static NAN_METHOD(StreamJPEGSync);
     static NAN_METHOD(RegisterFont);
-	static NAN_METHOD(DeregisterAllFonts);
+    static NAN_METHOD(DeregisterAllFonts);
     static v8::Local<v8::Value> Error(cairo_status_t status);
     static void ToPngBufferAsync(uv_work_t *req);
     static void ToJpegBufferAsync(uv_work_t *req);

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -28,7 +28,7 @@ class FontFace {
   public:
     PangoFontDescription *sys_desc = nullptr;
     PangoFontDescription *user_desc = nullptr;
-	unsigned char *file_path;
+	unsigned char file_path[1024];
 };
 
 /*

--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -260,3 +260,31 @@ register_font(unsigned char *filepath) {
   return true;
 }
 
+/*
+ * Deregister font from the OS
+ * Note that Linux (FontConfig) can only dereregister ALL fonts at once.
+ */
+
+bool
+deregister_font(unsigned char *filepath) {
+  bool success;
+  
+  #ifdef __APPLE__
+  CFURLRef filepathUrl = CFURLCreateFromFileSystemRepresentation(NULL, filepath, strlen((char*)filepath), false);
+  success = CTFontManagerUnregisterFontsForURL(filepathUrl, kCTFontManagerScopeProcess, NULL);
+  #elif defined(_WIN32)
+  success = RemoveFontResourceExA((LPCSTR)filepath, FR_PRIVATE, 0) != 0;
+  #else
+  FcConfigAppFontClear(FcConfigGetCurrent());
+  success = true;
+  #endif
+
+  if (!success) return false;
+
+  // Tell Pango to throw away the current FontMap and create a new one. This
+  // has the effect of registering the new font in Pango by re-looking up all
+  // font families.
+  pango_cairo_font_map_set_default(NULL);
+
+  return true;
+}

--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -282,7 +282,7 @@ deregister_font(unsigned char *filepath) {
   if (!success) return false;
 
   // Tell Pango to throw away the current FontMap and create a new one. This
-  // has the effect of registering the new font in Pango by re-looking up all
+  // has the effect of deregistering the font in Pango by re-looking up all
   // font families.
   pango_cairo_font_map_set_default(NULL);
 

--- a/src/register_font.h
+++ b/src/register_font.h
@@ -4,3 +4,4 @@
 
 PangoFontDescription *get_pango_font_description(unsigned char *filepath);
 bool register_font(unsigned char *filepath);
+bool deregister_font(unsigned char *filepath);


### PR DESCRIPTION
Thanks for contributing!

- [X] Have you updated CHANGELOG.md?
- [X] Fixes #1762 and #1362.

This PR adds a new API called `deregisterAllFonts()`, which will deregister (unload) all fonts that were previously registered with `registerFont()`.  This can be used to free up memory, and also resolve font conflicts.  Certain font variants clash with each other when Pango has both loaded.  This API allows a long-running process to render potentially hundreds of fonts without memory leaks or font conflicts.

See previous discussion in #1762 and #1362.

Example test script with accompanying fonts available here:
https://pixlcore.com/public/67dfda0807d530f3/node-canvas-deregister-example.zip

Tested on:

- [X] macOS 10.14.6
- [X] AWS Linux 2021
- [ ] Windows 10
