### PR TITLE
lib: check for parameter nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Changed
+Changed `DOMPoint()` constructor to check for parameter nullability.
 ### Added
 ### Fixed
 

--- a/lib/DOMMatrix.js
+++ b/lib/DOMMatrix.js
@@ -9,7 +9,7 @@ function DOMPoint(x, y, z, w) {
     throw new TypeError("Class constructors cannot be invoked without 'new'")
   }
 
-  if (typeof x === 'object') {
+  if (typeof x === 'object' && x !== null) {
     w = x.w
     z = x.z
     y = x.y


### PR DESCRIPTION
Thanks for contributing!

- [x] Have you updated CHANGELOG.md?

Value `null` is also a type of `object` so that could cause a type error here if passed, This PR fixes this issue.