### PR TITLE
lib: more strict number checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 Changed `DOMPoint()` constructor to check for parameter nullability.
+
+Changed `/lib/DOMMatrix.js` to have a more strict number checking.
 ### Added
 ### Fixed
 

--- a/lib/DOMMatrix.js
+++ b/lib/DOMMatrix.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const util = require('util')
+const isNum = Number.isInteger
 
 // DOMMatrix per https://drafts.fxtf.org/geometry/#DOMMatrix
 
@@ -15,10 +16,10 @@ function DOMPoint(x, y, z, w) {
     y = x.y
     x = x.x
   }
-  this.x = typeof x === 'number' ? x : 0
-  this.y = typeof y === 'number' ? y : 0
-  this.z = typeof z === 'number' ? z : 0
-  this.w = typeof w === 'number' ? w : 1
+  this.x = isNum(x) ? x : 0
+  this.y = isNum(y) ? y : 0
+  this.z = isNum(z) ? z : 0
+  this.w = isNum(w) ? w : 1
 }
 
 // Constants to index into _values (col-major)
@@ -170,7 +171,7 @@ DOMMatrix.prototype.toString = function () {
  * Checks that `value` is a number and sets the value.
  */
 function setNumber2D(receiver, index, value) {
-  if (typeof value !== 'number') throw new TypeError('Expected number')
+  if (!isNum(value)) throw new TypeError('Expected number')
   return receiver._values[index] = value
 }
 
@@ -179,7 +180,7 @@ function setNumber2D(receiver, index, value) {
  * the value.
  */
 function setNumber3D(receiver, index, value) {
-  if (typeof value !== 'number') throw new TypeError('Expected number')
+  if (!isNum(value)) throw new TypeError('Expected number')
   if (index === M33 || index === M44) {
     if (value !== 1) receiver._is2D = false
   } else if (value !== 0) receiver._is2D = false
@@ -269,9 +270,9 @@ DOMMatrix.prototype.translate = function (tx, ty, tz) {
   return newInstance(this._values).translateSelf(tx, ty, tz)
 }
 DOMMatrix.prototype.translateSelf = function (tx, ty, tz) {
-  if (typeof tx !== 'number') tx = 0
-  if (typeof ty !== 'number') ty = 0
-  if (typeof tz !== 'number') tz = 0
+  if (!isNum(tx)) tx = 0
+  if (!isNum(ty)) ty = 0
+  if (!isNum(tz)) tz = 0
   this._values = multiply([
     1, 0, 0, 0,
     0, 1, 0, 0,
@@ -293,13 +294,13 @@ DOMMatrix.prototype.scale3dSelf = function (scale, originX, originY, originZ) {
 }
 DOMMatrix.prototype.scaleSelf = function (scaleX, scaleY, scaleZ, originX, originY, originZ) {
   // Not redundant with translate's checks because we need to negate the values later.
-  if (typeof originX !== 'number') originX = 0
-  if (typeof originY !== 'number') originY = 0
-  if (typeof originZ !== 'number') originZ = 0
+  if (!isNum(originX)) originX = 0
+  if (!isNum(originY)) originY = 0
+  if (!isNum(originZ)) originZ = 0
   this.translateSelf(originX, originY, originZ)
-  if (typeof scaleX !== 'number') scaleX = 1
-  if (typeof scaleY !== 'number') scaleY = scaleX
-  if (typeof scaleZ !== 'number') scaleZ = 1
+  if (!isNum(scaleX)) scaleX = 1
+  if (!isNum(scaleY)) scaleY = scaleX
+  if (!isNum(scaleZ)) scaleZ = 1
   this._values = multiply([
     scaleX, 0, 0, 0,
     0, scaleY, 0, 0,
@@ -315,8 +316,8 @@ DOMMatrix.prototype.rotateFromVector = function (x, y) {
   return newInstance(this._values).rotateFromVectorSelf(x, y)
 }
 DOMMatrix.prototype.rotateFromVectorSelf = function (x, y) {
-  if (typeof x !== 'number') x = 0
-  if (typeof y !== 'number') y = 0
+  if (!isNum(x)) x = 0
+  if (!isNum(y)) y = 0
   var theta = (x === 0 && y === 0) ? 0 : Math.atan2(y, x) * DEGREE_PER_RAD
   return this.rotateSelf(theta)
 }
@@ -328,8 +329,8 @@ DOMMatrix.prototype.rotateSelf = function (rotX, rotY, rotZ) {
     rotZ = rotX
     rotX = rotY = 0
   }
-  if (typeof rotY !== 'number') rotY = 0
-  if (typeof rotZ !== 'number') rotZ = 0
+  if (!isNum(rotY)) rotY = 0
+  if (!isNum(rotZ)) rotZ = 0
   if (rotX !== 0 || rotY !== 0) this._is2D = false
   rotX *= RAD_PER_DEGREE
   rotY *= RAD_PER_DEGREE
@@ -366,9 +367,9 @@ DOMMatrix.prototype.rotateAxisAngle = function (x, y, z, angle) {
   return newInstance(this._values).rotateAxisAngleSelf(x, y, z, angle)
 }
 DOMMatrix.prototype.rotateAxisAngleSelf = function (x, y, z, angle) {
-  if (typeof x !== 'number') x = 0
-  if (typeof y !== 'number') y = 0
-  if (typeof z !== 'number') z = 0
+  if (!isNum(x)) x = 0
+  if (!isNum(y)) y = 0
+  if (!isNum(z)) z = 0
   // Normalize axis
   var length = Math.sqrt(x * x + y * y + z * z)
   if (length === 0) return this
@@ -399,7 +400,7 @@ DOMMatrix.prototype.skewX = function (sx) {
   return newInstance(this._values).skewXSelf(sx)
 }
 DOMMatrix.prototype.skewXSelf = function (sx) {
-  if (typeof sx !== 'number') return this
+  if (!isNum(sx)) return this
   var t = Math.tan(sx * RAD_PER_DEGREE)
   this._values = multiply([
     1, 0, 0, 0,
@@ -414,7 +415,7 @@ DOMMatrix.prototype.skewY = function (sy) {
   return newInstance(this._values).skewYSelf(sy)
 }
 DOMMatrix.prototype.skewYSelf = function (sy) {
-  if (typeof sy !== 'number') return this
+  if (!isNum(sy)) return this
   var t = Math.tan(sy * RAD_PER_DEGREE)
   this._values = multiply([
     1, t, 0, 0,


### PR DESCRIPTION
Thanks for contributing!

- [x] Have you updated CHANGELOG.md?

In the spec, it is more recommended to use `Number.isInteger()` to check if something is a number rather than checking its primitive type as `NaN` is also a type of `number` which could lead to unexpected issues and errors.