### PR TITLE
lib: use strings for non-special cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 Changed `DOMPoint()` constructor to check for parameter nullability.
+
+Changed `DOMMatrix.js` to use string literals for non-special cases.
 ### Added
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Changed
-Changed `DOMPoint()` constructor to check for parameter nullability.
-
-Changed `DOMMatrix.js` to use string literals for non-special cases.
+* Changed `DOMPoint()` constructor to check for parameter nullability.
+* Changed `DOMMatrix.js` to use string literals for non-special cases.
 ### Added
 ### Fixed
 

--- a/lib/DOMMatrix.js
+++ b/lib/DOMMatrix.js
@@ -31,8 +31,8 @@ const DEGREE_PER_RAD = 180 / Math.PI
 const RAD_PER_DEGREE = Math.PI / 180
 
 function parseMatrix(init) {
-  var parsed = init.replace(/matrix\(/, '')
-  parsed = parsed.split(/,/, 7) // 6 + 1 to handle too many params
+  var parsed = init.replace('matrix(', '')
+  parsed = parsed.split(',', 7) // 6 + 1 to handle too many params
   if (parsed.length !== 6) throw new Error(`Failed to parse ${init}`)
   parsed = parsed.map(parseFloat)
   return [
@@ -44,14 +44,14 @@ function parseMatrix(init) {
 }
 
 function parseMatrix3d(init) {
-  var parsed = init.replace(/matrix3d\(/, '')
-  parsed = parsed.split(/,/, 17) // 16 + 1 to handle too many params
+  var parsed = init.replace('matrix3d(', '')
+  parsed = parsed.split(',', 17) // 16 + 1 to handle too many params
   if (parsed.length !== 16) throw new Error(`Failed to parse ${init}`)
   return parsed.map(parseFloat)
 }
 
 function parseTransform(tform) {
-  var type = tform.split(/\(/, 1)[0]
+  var type = tform.split('(', 1)[0]
   switch (type) {
     case 'matrix':
       return parseMatrix(tform)


### PR DESCRIPTION
Thanks for contributing!

- [x] Have you updated CHANGELOG.md?

It is better to use string literals in place of regex if the provided regex does not contain any special regex characters for replace or split targets as regex construction is more costly.