### PR TITLE
tests(): add failing test for direction rtl and textAlign START/END

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -175,6 +175,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   SetProtoAccessor(proto, Nan::New("font").ToLocalChecked(), GetFont, SetFont, ctor);
   SetProtoAccessor(proto, Nan::New("textBaseline").ToLocalChecked(), GetTextBaseline, SetTextBaseline, ctor);
   SetProtoAccessor(proto, Nan::New("textAlign").ToLocalChecked(), GetTextAlign, SetTextAlign, ctor);
+  // SetProtoAccessor(proto, Nan::New("direction").ToLocalChecked(), GetDirection, SetDirection, ctor);
   Local<Context> ctx = Nan::GetCurrentContext();
   Nan::Set(target, Nan::New("CanvasRenderingContext2d").ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
   Nan::Set(target, Nan::New("CanvasRenderingContext2dInit").ToLocalChecked(), Nan::New<Function>(SaveExternalModules));
@@ -2681,6 +2682,36 @@ NAN_SETTER(Context2d::SetTextAlign) {
   context->state->textAlignment = op->second;
   context->_textAlign.Reset(value);
 }
+
+// /*
+//  * Set text direction.
+//  */
+//
+// NAN_SETTER(Context2d::SetDirection) {
+//   if (!value->IsString()) return;
+//   cairo_fill_rule_t rule = CAIRO_FILL_RULE_WINDING;
+//   Nan::Utf8String str(value);
+//   if (std::strcmp(*str, "evenodd") == 0) {
+//     rule = CAIRO_FILL_RULE_EVEN_ODD;
+//   }
+// }
+//
+// /*
+//  * Get text direction.
+//  */
+//
+// NAN_GETTER(Context2d::GetDirection) {
+//   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
+//   Isolate *iso = Isolate::GetCurrent();
+//   Local<Value> direction;
+//
+//   if (context->_direction.IsEmpty())
+//     font = Nan::New("start").ToLocalChecked();
+//   else
+//     font = context->_textAlign.Get(iso);
+//
+//   info.GetReturnValue().Set(font);
+// }
 
 /*
  * Return the given text extents.

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -175,7 +175,6 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   SetProtoAccessor(proto, Nan::New("font").ToLocalChecked(), GetFont, SetFont, ctor);
   SetProtoAccessor(proto, Nan::New("textBaseline").ToLocalChecked(), GetTextBaseline, SetTextBaseline, ctor);
   SetProtoAccessor(proto, Nan::New("textAlign").ToLocalChecked(), GetTextAlign, SetTextAlign, ctor);
-  // SetProtoAccessor(proto, Nan::New("direction").ToLocalChecked(), GetDirection, SetDirection, ctor);
   Local<Context> ctx = Nan::GetCurrentContext();
   Nan::Set(target, Nan::New("CanvasRenderingContext2d").ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
   Nan::Set(target, Nan::New("CanvasRenderingContext2dInit").ToLocalChecked(), Nan::New<Function>(SaveExternalModules));
@@ -2682,36 +2681,6 @@ NAN_SETTER(Context2d::SetTextAlign) {
   context->state->textAlignment = op->second;
   context->_textAlign.Reset(value);
 }
-
-// /*
-//  * Set text direction.
-//  */
-//
-// NAN_SETTER(Context2d::SetDirection) {
-//   if (!value->IsString()) return;
-//   cairo_fill_rule_t rule = CAIRO_FILL_RULE_WINDING;
-//   Nan::Utf8String str(value);
-//   if (std::strcmp(*str, "evenodd") == 0) {
-//     rule = CAIRO_FILL_RULE_EVEN_ODD;
-//   }
-// }
-//
-// /*
-//  * Get text direction.
-//  */
-//
-// NAN_GETTER(Context2d::GetDirection) {
-//   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-//   Isolate *iso = Isolate::GetCurrent();
-//   Local<Value> direction;
-//
-//   if (context->_direction.IsEmpty())
-//     font = Nan::New("start").ToLocalChecked();
-//   else
-//     font = context->_textAlign.Get(iso);
-//
-//   info.GetReturnValue().Set(font);
-// }
 
 /*
  * Return the given text extents.

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -941,7 +941,9 @@ tests['textAlign right'] = function (ctx) {
 
   ctx.font = 'normal 20px Arial'
   ctx.textAlign = 'right'
-  ctx.fillText('right', 100, 100)
+  ctx.fillText('right ltr', 100, 100)
+  ctx.direction = 'rtl'
+  ctx.fillText('right rtl', 100, 130)
 }
 
 tests['textAlign left'] = function (ctx) {
@@ -958,7 +960,47 @@ tests['textAlign left'] = function (ctx) {
 
   ctx.font = 'normal 20px Arial'
   ctx.textAlign = 'left'
-  ctx.fillText('left', 100, 100)
+  ctx.fillText('left ltr', 100, 100)
+  ctx.direction = 'rtl'
+  ctx.fillText('left rtl', 100, 130)
+}
+
+tests['textAlign start'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 100)
+  ctx.lineTo(200, 100)
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.lineTo(100, 0)
+  ctx.lineTo(100, 200)
+  ctx.stroke()
+
+  ctx.font = 'normal 20px Arial'
+  ctx.textAlign = 'start'
+  ctx.fillText('start ltr', 100, 100)
+  ctx.direction = 'rtl'
+  ctx.fillText('start rtl', 100, 130)
+}
+
+tests['textAlign end'] = function (ctx) {
+  ctx.strokeStyle = '#666'
+  ctx.strokeRect(0, 0, 200, 200)
+  ctx.lineTo(0, 100)
+  ctx.lineTo(200, 100)
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.lineTo(100, 0)
+  ctx.lineTo(100, 200)
+  ctx.stroke()
+
+  ctx.font = 'normal 20px Arial'
+  ctx.textAlign = 'end'
+  ctx.fillText('end ltr', 100, 100)
+  ctx.direction = 'rtl'
+  ctx.fillText('end rtl', 100, 130)
 }
 
 tests['textAlign center'] = function (ctx) {

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -939,6 +939,7 @@ tests['textAlign right'] = function (ctx) {
   ctx.lineTo(100, 200)
   ctx.stroke()
   ctx.font = 'normal 20px Arial'
+  ctx.direction = 'ltr'
   ctx.textAlign = 'right'
   ctx.fillText('right ltr', 100, 70)
   ctx.fillText(
@@ -964,6 +965,7 @@ tests['textAlign left'] = function (ctx) {
   ctx.stroke()
 
   ctx.font = 'normal 20px Arial'
+  ctx.direction = 'ltr'
   ctx.textAlign = 'left'
   ctx.fillText('left ltr', 100, 70)
   ctx.fillText(
@@ -989,6 +991,7 @@ tests['textAlign start'] = function (ctx) {
   ctx.stroke()
 
   ctx.font = 'normal 20px Arial'
+  ctx.direction = 'ltr'
   ctx.textAlign = 'start'
   ctx.fillText('start ltr', 100, 70)
   ctx.fillText(
@@ -1014,6 +1017,7 @@ tests['textAlign end'] = function (ctx) {
   ctx.stroke()
 
   ctx.font = 'normal 20px Arial'
+  ctx.direction = 'ltr'
   ctx.textAlign = 'end'
   ctx.fillText('end ltr', 100, 70)
   ctx.fillText(

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -938,12 +938,17 @@ tests['textAlign right'] = function (ctx) {
   ctx.lineTo(100, 0)
   ctx.lineTo(100, 200)
   ctx.stroke()
-
   ctx.font = 'normal 20px Arial'
   ctx.textAlign = 'right'
-  ctx.fillText('right ltr', 100, 100)
+  ctx.fillText('right ltr', 100, 70)
+  ctx.fillText(
+    'الحق ltr',
+    100, 100)
   ctx.direction = 'rtl'
   ctx.fillText('right rtl', 100, 130)
+  ctx.fillText(
+    'rtl الحق',
+    100, 160)
 }
 
 tests['textAlign left'] = function (ctx) {
@@ -960,9 +965,15 @@ tests['textAlign left'] = function (ctx) {
 
   ctx.font = 'normal 20px Arial'
   ctx.textAlign = 'left'
-  ctx.fillText('left ltr', 100, 100)
+  ctx.fillText('left ltr', 100, 70)
+  ctx.fillText(
+    'تركت ltr',
+    100, 100)
   ctx.direction = 'rtl'
   ctx.fillText('left rtl', 100, 130)
+  ctx.fillText(
+    'rtl تركت',
+    100, 160)
 }
 
 tests['textAlign start'] = function (ctx) {
@@ -979,9 +990,15 @@ tests['textAlign start'] = function (ctx) {
 
   ctx.font = 'normal 20px Arial'
   ctx.textAlign = 'start'
-  ctx.fillText('start ltr', 100, 100)
+  ctx.fillText('start ltr', 100, 70)
+  ctx.fillText(
+    'بداية ltr',
+    100, 100)
   ctx.direction = 'rtl'
   ctx.fillText('start rtl', 100, 130)
+  ctx.fillText(
+    'rtl بداية',
+    100, 160)
 }
 
 tests['textAlign end'] = function (ctx) {
@@ -998,9 +1015,15 @@ tests['textAlign end'] = function (ctx) {
 
   ctx.font = 'normal 20px Arial'
   ctx.textAlign = 'end'
-  ctx.fillText('end ltr', 100, 100)
+  ctx.fillText('end ltr', 100, 70)
+  ctx.fillText(
+    'نهاية ltr',
+    100, 100)
   ctx.direction = 'rtl'
-  ctx.fillText('end rtl', 100, 130)
+  ctx.fillText('start rtl', 100, 130)
+  ctx.fillText(
+    'rtl نهاية',
+    100, 160)
 }
 
 tests['textAlign center'] = function (ctx) {


### PR DESCRIPTION
Hi, this is a PR that will add failing tests to show that ctx.direction isn't handled properly when textAlign is either start or end.

I plan to open a PR where with some simple logic between direction and text align start/end we can achieve a basic support.

The test uses also some arab text ( translated from google for the word left,right,start and end) to show that there is additional complexity when handling rtl

I added on purpose the property `ctx.direction = 'ltr'` instead of the default inherit, since inherit requires the canvas to have an attribute to inspect that we don't have anyway.

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/direction


This is how the test looks like now.
![image](https://user-images.githubusercontent.com/1194048/120936863-7dda7000-c70a-11eb-8ea5-b1a53095b613.png)

