### PR TITLE
Update has_lib.js to support Apple M1 with homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Added `deregisterAllFonts` method to free up memory and reduce font conflicts.
 ### Fixed
+* Support Apple M1 Homebrew install that puts canvas install library files in `/opt/homebrew/lib`
 
 2.8.0
 ==================

--- a/util/has_lib.js
+++ b/util/has_lib.js
@@ -8,6 +8,7 @@ var SYSTEM_PATHS = [
   '/usr/lib64',
   '/usr/local/lib',
   '/opt/local/lib',
+  '/opt/homebrew/lib',
   '/usr/lib/x86_64-linux-gnu',
   '/usr/lib/i386-linux-gnu',
   '/usr/lib/arm-linux-gnueabihf',


### PR DESCRIPTION
Stated instructions for compiling on OS X include using homebrew: `brew install pkg-config cairo pango libpng jpeg giflib librsvg`

However on Apple M1 silicon, the compile via binding.gyp will fail to locate the above library packages. This is because on M1, homebrew places all installed libraries at `/opt/homebrew/lib`, unlike on Intel silicon, where it would place them under `/usr/local/lib`.

The simple remedy is  to add `/opt/homebrew/lib` to the SYSTEM_PATHS of `has_lib.js`

Fixes: #1782 

- [X] Have you updated CHANGELOG.md?
