### PR TITLE
Add user agent to simple-get

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -49,7 +49,7 @@ Object.defineProperty(Image.prototype, 'src', {
 
         if (!get) get = require('simple-get');
 
-        get.concat(val, (err, res, data) => {
+        get.concat({url:val, headers: {'user-agent': 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion'}}, (err, res, data) => {
           if (err) return onerror(err)
 
           if (res.statusCode < 200 || res.statusCode >= 300) {


### PR DESCRIPTION
Some sites (including Discord now) return a 403 error if no user agent is specified. Adding a user agent to the simple-get fixes the problem.