### PR TITLE
Clean up isnan/isinf, use isfinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Changed `DOMPoint()` constructor to check for parameter nullability.
 * Changed `DOMMatrix.js` to use string literals for non-special cases.
 * Remove semicolons from Dommatrix.js.
+* Clean up inf/nan macros and slightly speed up argument checking.
 ### Added
 * Added `deregisterAllFonts` method to free up memory and reduce font conflicts.
 ### Fixed


### PR DESCRIPTION
Cleans up funky C code and uses std::isfinite, which also compiles to fewer instructions (https://godbolt.org/z/qMT8bMTKn).

- [x] Have you updated CHANGELOG.md?
