### PR TITLE
Update nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Changed `DOMPoint()` constructor to check for parameter nullability.
 * Changed `DOMMatrix.js` to use string literals for non-special cases.
 * Remove semicolons from Dommatrix.js.
+* Update nan to v2.15.0 to ensure Node.js v14+ support.
 ### Added
 * Added `deregisterAllFonts` method to free up memory and reduce font conflicts.
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
-    "nan": "^2.14.0",
     "@mapbox/node-pre-gyp": "^1.0.0",
+    "nan": "^2.15.0",
     "simple-get": "^3.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
v14 requires 2.14.1. The semver range in package.json already allowed for that version, but this requires at least that version.

None of the other changes (2.14.2, 2.15.0) matter for us.

- [x] Have you updated CHANGELOG.md?
