### PR TITLE
Add Windows ARM64 prebuild configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Clean up inf/nan macros and slightly speed up argument checking.
 ### Added
 * Added `deregisterAllFonts` method to free up memory and reduce font conflicts.
+* Added prebuild configuration for Windows ARM64
 ### Fixed
 * Support Apple M1 Homebrew install that puts canvas install library files in `/opt/homebrew/lib`
 

--- a/prebuild/Windows-arm64/binding.gyp
+++ b/prebuild/Windows-arm64/binding.gyp
@@ -1,0 +1,80 @@
+{
+  'targets': [
+    {
+      'target_name': 'canvas',
+      'sources': [
+        'src/backend/Backend.cc',
+        'src/backend/ImageBackend.cc',
+        'src/backend/PdfBackend.cc',
+        'src/backend/SvgBackend.cc',
+        'src/bmp/BMPParser.cc',
+        'src/Backends.cc',
+        'src/Canvas.cc',
+        'src/CanvasGradient.cc',
+        'src/CanvasPattern.cc',
+        'src/CanvasRenderingContext2d.cc',
+        'src/closure.cc',
+        'src/color.cc',
+        'src/Image.cc',
+        'src/ImageData.cc',
+        'src/init.cc',
+        'src/register_font.cc'
+      ],
+      'defines': [
+        'HAVE_GIF',
+        'HAVE_JPEG',
+        'HAVE_RSVG',
+        'HAVE_BOOLEAN', # or jmorecfg.h tries to define it
+        '_USE_MATH_DEFINES' # for M_PI
+      ],
+      'libraries': [
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libcairo-2.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libpng16-16.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libjpeg-8.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libpango-1.0-0.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libpangocairo-1.0-0.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libgobject-2.0-0.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libglib-2.0-0.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libturbojpeg.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libgif-7.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/libfreetype-6.lib',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/librsvg-2-2.lib'
+      ],
+      'include_dirs': [
+        '<!(node -e "require(\'nan\')")',
+        'D:/a/_temp/msys/msys64/clangarm64/include',
+        'D:/a/_temp/msys/msys64/clangarm64/include/pango-1.0',
+        'D:/a/_temp/msys/msys64/clangarm64/include/cairo',
+        'D:/a/_temp/msys/msys64/clangarm64/include/libpng16',
+        'D:/a/_temp/msys/msys64/clangarm64/include/glib-2.0',
+        'D:/a/_temp/msys/msys64/clangarm64/lib/glib-2.0/include',
+        'D:/a/_temp/msys/msys64/clangarm64/include/pixman-1',
+        'D:/a/_temp/msys/msys64/clangarm64/include/freetype2',
+        'D:/a/_temp/msys/msys64/clangarm64/include/fontconfig',
+        'D:/a/_temp/msys/msys64/clangarm64/include/librsvg-2.0',
+        'D:/a/_temp/msys/msys64/clangarm64/include/gdk-pixbuf-2.0',
+        'D:/a/_temp/msys/msys64/clangarm64/include/harfbuzz'
+      ],
+      'configurations': {
+        'Debug': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'WarningLevel': 4,
+              'ExceptionHandling': 1,
+              'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+            }
+          }
+        },
+        'Release': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'WarningLevel': 4,
+              'ExceptionHandling': 1,
+              'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4512]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/prebuild/Windows-arm64/bundle.sh
+++ b/prebuild/Windows-arm64/bundle.sh
@@ -1,0 +1,34 @@
+# dependency walker will help us figure out which DLLs 
+# canvas.node directly and indirectly uses
+#wget --no-verbose --no-clobber http://www.dependencywalker.com/depends22_x64.zip
+#unzip -u depends22_x64.zip
+
+# write recurisve dependencies of canvas.node into depends.csv
+#./depends -c -oc:depends.csv build/Release/canvas.node;
+
+#[ -f depends.csv ] || {
+#  echo "error invoking depends.exe";
+#  exit 1;
+#}
+
+# case-insensitive intersection of 2nd column of depends.csv
+# and all files ending in .dll in the clangarm64 directory
+#copies=$(comm -12 \
+#  <(cat depends.csv | cut -d ',' -f2 | sed 's/"//g' | tr '[:upper:]' '[:lower:]' | sort) \
+#  <(find /clangarm64/bin -name '*.dll' -printf "%f\n" | tr '[:upper:]' '[:lower:]' | sort) \
+#);
+
+# We temporarily hardcode the dependencies as the dependency walker returns incomplete results on ARM64
+copies="libbrotlicommon.dll libbrotlidec.dll libbz2-1.dll libc++.dll libcairo-2.dll
+ libcroco-0.6-3.dll libdatrie-1.dll libexpat-1.dll libffi-7.dll libfontconfig-1.dll
+ libfreetype-6.dll libfribidi-0.dll libgdk_pixbuf-2.0-0.dll libgif-7.dll libgio-2.0-0.dll
+ libglib-2.0-0.dll libgmodule-2.0-0.dll libgobject-2.0-0.dll libgraphite2.dll libharfbuzz-0.dll
+ libiconv-2.dll libintl-8.dll libjpeg-8.dll liblzma-5.dll libpango-1.0-0.dll libpangocairo-1.0-0.dll
+ libpangoft2-1.0-0.dll libpangowin32-1.0-0.dll libpcre-1.dll libpixman-1-0.dll libpng16-16.dll
+ librsvg-2-2.dll libthai-0.dll libunwind.dll libwinpthread-1.dll libxml2-2.dll zlib1.dll"
+
+echo $copies;
+
+for dll in $copies; do
+  cp /clangarm64/bin/$dll build/Release
+done;

--- a/prebuild/Windows-arm64/preinstall.sh
+++ b/prebuild/Windows-arm64/preinstall.sh
@@ -1,0 +1,38 @@
+# expects node, VS, and MSYS environments to be set up already. does everything else.
+
+deps="cairo-2 png16-16 jpeg-8 pango-1.0-0 pangocairo-1.0-0 gobject-2.0-0 glib-2.0-0 turbojpeg gif-7 freetype-6 rsvg-2-2";
+
+# install cairo and tools to create .lib
+
+pacman --noconfirm -S \
+  wget \
+  unzip \
+  clangarm64/mingw-w64-clang-aarch64-binutils \
+  clangarm64/mingw-w64-clang-aarch64-tools \
+  clangarm64/mingw-w64-clang-aarch64-libjpeg-turbo \
+  clangarm64/mingw-w64-clang-aarch64-pango \
+  clangarm64/mingw-w64-clang-aarch64-cairo \
+  clangarm64/mingw-w64-clang-aarch64-giflib \
+  clangarm64/mingw-w64-clang-aarch64-freetype \
+  clangarm64/mingw-w64-clang-aarch64-fontconfig \
+  clangarm64/mingw-w64-clang-aarch64-librsvg \
+  clangarm64/mingw-w64-clang-aarch64-libxml2
+
+# create .lib files for vc++
+
+echo "generating lib files for the MSYS2 dlls"
+for lib in $deps; do
+  /clangarm64/bin/gendef /clangarm64/bin/lib$lib.dll > /dev/null 2>&1 || {
+    echo "could not find lib$lib.dll, have to skip ";
+    continue;
+  }
+
+  /clangarm64/bin/dlltool -d lib$lib.def -l /clangarm64/lib/lib$lib.lib > /dev/null 2>&1 || {
+    echo "could not create dll for lib$lib.dll";
+    continue;
+  }
+
+  echo "created lib$lib.lib from lib$lib.dll";
+
+  rm lib$lib.def
+done


### PR DESCRIPTION
This adds a prebuild configuration for Windows ARM64. I've been adding the necessary packages to MSYS2 `clangarm64` (they will be published in the coming weeks):

- https://github.com/msys2/MINGW-packages/pull/10332 
- https://github.com/msys2/MINGW-packages/pull/10333
- https://github.com/msys2/MINGW-packages/pull/10335
- https://github.com/msys2/MINGW-packages/pull/10336
- https://github.com/msys2/MINGW-packages/pull/10340
- https://github.com/msys2/MINGW-packages/pull/10341
- https://github.com/msys2/MINGW-packages/pull/10377
- https://github.com/msys2/MINGW-packages/pull/10378
- https://github.com/msys2/MINGW-packages/pull/10424

GitHub Actions doesn't have ARM64 runners yet, so for now, this allows folks to create prebuilds locally. An example build can be found here: https://github.com/dennisameling/node-canvas/releases/tag/v2.8.0-arm64

Result of `npm test`:

<details>
<summary>Test results</summary>

```shell
PS C:\repos\node-canvas> npm test

> canvas@2.8.0 test
> mocha test/*.test.js

  Canvas
    √ Prototype and ctor are well-shaped, don't hit asserts on accessors (GH-803)
    √ .parseFont()
    √ registerFont
    √ color serialization
    √ color parser
    √ Canvas#type
    √ Canvas#getContext("2d") (53ms)
    √ Canvas#getContext("2d", {pixelFormat: string})
    √ Canvas#getContext("2d", {alpha: boolean})
    √ Canvas#{width,height}=
    √ Canvas#width= (resurfacing) doesn't crash when fillStyle is a pattern (#1357)
    √ SVG Canvas#width changes don't crash (#1380)
    √ Canvas#stride
    √ Canvas#getContext("invalid")
    √ Context2d#patternQuality
    √ Context2d#imageSmoothingEnabled
    √ Context2d#font=
    √ Context2d#lineWidth=
    √ Context2d#antiAlias=
    √ Context2d#lineCap=
    √ Context2d#lineJoin=
    √ Context2d#globalAlpha=
    √ Context2d#isPointInPath()
    √ Context2d#textAlign
    √ Context2d#fillText()
    √ Context2d#currentTransform
    √ Context2d#createImageData(ImageData)
    √ Context2d#createPattern(Canvas)
    √ Context2d#createPattern(Canvas).setTransform() (75ms)
    √ Context2d#createPattern(Image)
    √ Context2d#createLinearGradient()
    √ Canvas#createPNGStream()
    √ Canvas#createPDFStream()
    √ Canvas#createJPEGStream()
    √ EOI at end of Canvas#createJPEGStream()
    √ Context2d#fill()
    √ Context2d#clip()
    √ Context2d#IsPointInPath()
    √ Context2d#rotate(angle)
    √ Context2d#drawImage()
    √ Context2d#SetFillColor()
    #toBuffer
      √ Canvas#toBuffer()
      √ Canvas#toBuffer("image/png")
      √ Canvas#toBuffer("image/png", {resolution: 96})
      √ Canvas#toBuffer("image/png", {compressionLevel: 5})
      √ Canvas#toBuffer("image/jpeg")
      √ Canvas#toBuffer("image/jpeg", {quality: 0.95})
      √ Canvas#toBuffer(callback)
      √ Canvas#toBuffer(callback, "image/jpeg")
      √ Canvas#toBuffer(callback, "image/jpeg", {quality: 0.95})
      #toBuffer("raw")
        √ should have the correct size
        √ does not premultiply alpha
        √ draws red
        √ draws green
        √ draws black
        √ leaves undrawn pixels black, transparent
        √ is immutable
    #toDataURL()
      √ toDataURL() works and defaults to PNG
      √ toDataURL(0.5) works and defaults to PNG
      √ toDataURL(undefined) works and defaults to PNG
      √ toDataURL("image/png") works
      √ toDataURL("image/png", 0.5) works
      √ toDataURL("iMaGe/PNg") works
      √ toDataURL("image/jpeg") works
      √ toDataURL(function (err, str) {...}) works and defaults to PNG
      √ toDataURL(function (err, str) {...}) is async even with no canvas data
      √ toDataURL(0.5, function (err, str) {...}) works and defaults to PNG
      √ toDataURL(undefined, function (err, str) {...}) works and defaults to PNG
      √ toDataURL("image/png", function (err, str) {...}) works
      √ toDataURL("image/png", 0.5, function (err, str) {...}) works
      √ toDataURL("image/png", {}) works
      √ toDataURL("image/jpeg", {}) works
      √ toDataURL("image/jpeg", function (err, str) {...}) works
      √ toDataURL("iMAge/JPEG", function (err, str) {...}) works
      √ toDataURL("image/jpeg", undefined, function (err, str) {...}) works
      √ toDataURL("image/jpeg", 0.5, function (err, str) {...}) works
      √ toDataURL("image/jpeg", opts, function (err, str) {...}) works
    Context2d#createImageData(width, height)
      √ works
      √ works, A8 format
      √ works, A1 format
      √ works, RGB24 format
      √ works, RGB16_565 format
    Context2d#measureText()
      √ Context2d#measureText().width
      √ works
    Context2d#getImageData()
      √ works, full width, RGBA32
      √ works, full width, RGB24
      √ works, full width, RGB16_565
      √ works, full width, A8
      - works, full width, A1
      - works, full width, RGB30
      √ works, slice, RGBA32
      √ works, slice, RGB24
      √ works, slice, RGB16_565
      √ works, slice, A8
      - works, slice, A1
      - works, slice, RGB30
      √ works, assignment
      √ throws if indexes are invalid
    Context2d#putImageData()
      √ throws for invalid arguments
      √ works for negative source values
      √ works, RGBA32
      √ works, RGB24/alpha:false
      √ works, A8
      √ works, RGB16_565

  DOMMatrix
    constructor, general
      √ aliases a,b,c,d,e,f properly
      √ parses lists of transforms per spec
      √ parses matrix2d(<16 numbers>) per spec
      √ sets is2D to true if matrix2d(<16 numbers>) is 2D
    multiply
      √ performs self.other, returning a new DOMMatrix
    multiplySelf
      √ performs self.other, mutating self
    preMultiplySelf
      √ performs other.self, mutating self
    translateSelf
      √ works, 1 arg
      √ works, 2 args
      √ works, 3 args
    scale
      √ works, 1 arg
      √ works, 2 args
      √ works, 3 args
      √ works, 4 args
      √ works, 5 args
      √ works, 6 args
    scale3d
      √ works, 0 args
      √ works, 1 arg
      √ works, 2 args
      √ works, 3 args
      √ works, 4 args
    rotate
      √ works, 1 arg
      √ works, 2 args
      √ works, 3 args
    rotateFromVector
      √ works, no args and x/y=0
      √ works
    rotateAxisAngle
      √ works, 0 args
      √ works, 4 args
    skewX
      √ works
    skewY
      √ works
    flipX
      √ works
    flipY
      √ works
    invertSelf
      √ works for invertible matrices
      √ works for non-invertible matrices
    inverse
      √ preserves the original DOMMatrix
      √ preserves the original DOMMatrix for non-invertible matrices
    transformPoint
      √ works
    toFloat32Array
      √ works
    toFloat64Array
      √ works
    toString
      √ works, 2d
      √ works, 3d

  Image
    √ Prototype and ctor are well-shaped, don't hit asserts on accessors (GH-803)
    √ loads JPEG image
    √ loads JPEG data URL
    √ loads PNG image
    √ loads PNG data URL
    - detects invalid PNG
    √ propagates exceptions thrown by onload
    √ propagates exceptions thrown by onerror
    √ loads SVG data URL base64
    √ loads SVG data URL utf8
    √ calls Image#onload multiple times
    √ handles errors
    √ returns a nice, coded error for fopen failures
    √ captures errors from libjpeg
    √ calls Image#onerror multiple times
    √ Image#{width,height}
    √ Image#src set empty buffer
    √ should unbind Image#onload
    √ should unbind Image#onerror
    √ does not crash on invalid images
    √ does not contain `source` property
    supports BMP
      √ parses 1-bit image
      √ parses 4-bit image
      - parses 8-bit image
      √ parses 24-bit image
      √ parses 32-bit image
      √ parses minimal BMP
      √ properly handles negative height
      √ color palette
      √ V3 header
      - V5 header
      √ catches BMP errors
      √ BMP bomb

  ImageData
    √ Prototype and ctor are well-shaped, don't hit asserts on accessors (GH-803)
    √ should throw with invalid numeric arguments
    √ should construct with width and height
    √ should throw with invalid typed array
    √ should construct with Uint8ClampedArray
    √ should construct with Uint16Array


  177 passing (634ms)
  7 pending
```
</details>