### PR TITLE
Support worker env.[aka: context aware]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+* support nodejs worker
 ### Fixed
 * Stringify CanvasGradient, CanvasPattern and ImageData like browsers do. (#1639, #1646)
 * Add missing include for `toupper`.

--- a/binding.gyp
+++ b/binding.gyp
@@ -60,6 +60,7 @@
       'include_dirs': ["<!(node -e \"require('nan')\")"],
       'sources': [
         'src/AddonData.cc',
+        'src/lock.cc',
         'src/backend/Backend.cc',
         'src/backend/ImageBackend.cc',
         'src/backend/PdfBackend.cc',

--- a/binding.gyp
+++ b/binding.gyp
@@ -59,6 +59,7 @@
       'target_name': 'canvas',
       'include_dirs': ["<!(node -e \"require('nan')\")"],
       'sources': [
+        'src/AddonData.cc',
         'src/backend/Backend.cc',
         'src/backend/ImageBackend.cc',
         'src/backend/PdfBackend.cc',

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dtslint": "^4.0.7",
     "express": "^4.16.3",
     "mocha": "^5.2.0",
+    "piscina": "^3.2.0",
     "pixelmatch": "^4.0.2",
     "standard": "^12.0.1",
     "typescript": "^4.2.2"

--- a/src/AddonData.cc
+++ b/src/AddonData.cc
@@ -1,0 +1,25 @@
+#include "AddonData.h"
+
+AddonData::AddonData()
+{
+  node::AddEnvironmentCleanupHook(v8::Isolate::GetCurrent(), Dispose, this);
+}
+
+void AddonData::Dispose(void* ins)
+{
+  AddonData *data = static_cast<AddonData*>(ins);
+  data->canvas_ctor_tpl.Reset();
+  data->context2d_ctor_tpl.Reset();
+  data->context2d_dom_matrix.Reset();
+  data->context2d_parse_font.Reset();
+  data->gradient_ctor_tpl.Reset();
+  data->image_ctor_tpl.Reset();
+  data->image_data_ctor_tpl.Reset();
+  data->image_backend_ctor_tpl.Reset();
+  data->pdf_backend_ctor_tpl.Reset();
+  data->svg_backend_ctor_tpl.Reset();
+  data->pattern_ctor_tpl.Reset();
+  data->pattern_dom_matrix.Reset();
+
+  delete data;
+}

--- a/src/AddonData.h
+++ b/src/AddonData.h
@@ -29,7 +29,6 @@ class AddonData {
     Nan::Persistent<v8::Function> context2d_dom_matrix;
     Nan::Persistent<v8::Function> context2d_parse_font;
     Nan::Persistent<v8::Function> pattern_dom_matrix;
-    std::vector<FontFace> font_face_list;
   
     AddonData();
 

--- a/src/AddonData.h
+++ b/src/AddonData.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <pango/pangocairo.h>
+#include <v8.h>
+#include <nan.h>
+
+/*
+ * FontFace describes a font file in terms of one PangoFontDescription that
+ * will resolve to it and one that the user describes it as (like @font-face)
+ */
+class FontFace {
+  public:
+    PangoFontDescription *sys_desc = nullptr;
+    PangoFontDescription *user_desc = nullptr;
+    unsigned char file_path[1024];
+};
+
+class AddonData {
+  public:
+    Nan::Persistent<v8::FunctionTemplate> canvas_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> gradient_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> context2d_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> image_data_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> image_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> pattern_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> image_backend_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> pdf_backend_ctor_tpl;
+    Nan::Persistent<v8::FunctionTemplate> svg_backend_ctor_tpl;
+    Nan::Persistent<v8::Function> context2d_dom_matrix;
+    Nan::Persistent<v8::Function> context2d_parse_font;
+    Nan::Persistent<v8::Function> pattern_dom_matrix;
+    std::vector<FontFace> font_face_list;
+  
+    AddonData();
+
+    static void Dispose(void*);
+};

--- a/src/Backends.cc
+++ b/src/Backends.cc
@@ -6,13 +6,13 @@
 
 using namespace v8;
 
-void Backends::Initialize(Local<Object> target) {
+void Backends::Initialize(Local<Object> target, AddonData* data) {
   Nan::HandleScope scope;
 
   Local<Object> obj = Nan::New<Object>();
-  ImageBackend::Initialize(obj);
-  PdfBackend::Initialize(obj);
-  SvgBackend::Initialize(obj);
+  ImageBackend::Initialize(obj, data);
+  PdfBackend::Initialize(obj, data);
+  SvgBackend::Initialize(obj, data);
 
   Nan::Set(target, Nan::New<String>("Backends").ToLocalChecked(), obj).Check();
 }

--- a/src/Backends.h
+++ b/src/Backends.h
@@ -3,8 +3,9 @@
 #include "backend/Backend.h"
 #include <nan.h>
 #include <v8.h>
+#include "AddonData.h"
 
 class Backends : public Nan::ObjectWrap {
   public:
-    static void Initialize(v8::Local<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target, AddonData*);
 };

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -38,8 +38,6 @@
 using namespace v8;
 using namespace std;
 
-Nan::Persistent<FunctionTemplate> Canvas::constructor;
-
 std::vector<FontFace> font_face_list;
 
 /*
@@ -52,7 +50,6 @@ Canvas::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Canvas::New);
-  constructor.Reset(ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(Nan::New("Canvas").ToLocalChecked());
 

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -38,6 +38,8 @@
 using namespace v8;
 using namespace std;
 
+const char *Canvas::ctor_name = "Canvas";
+
 std::vector<FontFace> font_face_list;
 
 /*
@@ -51,7 +53,7 @@ Canvas::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Canvas::New);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("Canvas").ToLocalChecked());
+  ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
@@ -80,7 +82,7 @@ Canvas::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 
   Local<Context> ctx = Nan::GetCurrentContext();
   Nan::Set(target,
-           Nan::New("Canvas").ToLocalChecked(),
+           Nan::New(ctor_name).ToLocalChecked(),
            ctor->GetFunction(ctx).ToLocalChecked());
 }
 

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -719,7 +719,6 @@ str_value(Local<Value> val, const char *fallback, bool can_be_number) {
 }
 
 NAN_METHOD(Canvas::RegisterFont) {
-  AddonData *addon_data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   if (!info[0]->IsString()) {
     return Nan::ThrowError("Wrong argument type");
   } else if (!info[1]->IsObject()) {
@@ -731,6 +730,7 @@ NAN_METHOD(Canvas::RegisterFont) {
 
   if (!sys_desc) return Nan::ThrowError("Could not parse font file");
 
+  AddonData *addon_data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   PangoFontDescription *user_desc = pango_font_description_new();
 
   // now check the attrs, there are many ways to be wrong

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -114,13 +114,13 @@ NAN_METHOD(Canvas::New) {
   }
   else if (info[0]->IsObject()) {
     Local<Object> backends_obj = getFromExports("Backends").As<Object>();
-    Local<Function> image_backend = Nan::Get(Nan::GetCurrentContext(), Nan::New<String>(ImageBackend::ctor_name).ToLocalChecked())
-      .ToLocalChecked()
-      .As<Object>();
-    Local<Function> pdf_backend = Nan::Get(Nan::GetCurrentContext(), Nan::New<String>(PdfBackend::ctor_name).ToLocalChecked())
+    Local<Function> image_backend = Nan::Get(backends_obj, Nan::New<String>(ImageBackend::ctor_name).ToLocalChecked())
       .ToLocalChecked()
       .As<Function>();
-    Local<Function> svg_backend = Nan::Get(Nan::GetCurrentContext(), Nan::New<String>(SvgBackend::ctor_name).ToLocalChecked())
+    Local<Function> pdf_backend = Nan::Get(backends_obj, Nan::New<String>(PdfBackend::ctor_name).ToLocalChecked())
+      .ToLocalChecked()
+      .As<Function>();
+    Local<Function> svg_backend = Nan::Get(backends_obj, Nan::New<String>(SvgBackend::ctor_name).ToLocalChecked())
       .ToLocalChecked()
       .As<Function>();
     if (info[0]->InstanceOf(Nan::GetCurrentContext(), image_backend).FromJust() ||

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -113,9 +113,19 @@ NAN_METHOD(Canvas::New) {
       backend = new ImageBackend(width, height);
   }
   else if (info[0]->IsObject()) {
-    if (Nan::New(ImageBackend::constructor)->HasInstance(info[0]) ||
-        Nan::New(PdfBackend::constructor)->HasInstance(info[0]) ||
-        Nan::New(SvgBackend::constructor)->HasInstance(info[0])) {
+    Local<Object> backends_obj = getFromExports("Backends").As<Object>();
+    Local<Function> image_backend = Nan::Get(Nan::GetCurrentContext(), Nan::New<String>(ImageBackend::ctor_name).ToLocalChecked())
+      .ToLocalChecked()
+      .As<Object>();
+    Local<Function> pdf_backend = Nan::Get(Nan::GetCurrentContext(), Nan::New<String>(PdfBackend::ctor_name).ToLocalChecked())
+      .ToLocalChecked()
+      .As<Function>();
+    Local<Function> svg_backend = Nan::Get(Nan::GetCurrentContext(), Nan::New<String>(SvgBackend::ctor_name).ToLocalChecked())
+      .ToLocalChecked()
+      .As<Function>();
+    if (info[0]->InstanceOf(Nan::GetCurrentContext(), image_backend).FromJust() ||
+        info[0]->InstanceOf(Nan::GetCurrentContext(), pdf_backend).FromJust() ||
+        info[0]->InstanceOf(Nan::GetCurrentContext(), svg_backend).FromJust()) {
       backend = Nan::ObjectWrap::Unwrap<Backend>(Nan::To<Object>(info[0]).ToLocalChecked());
     }else{
       return Nan::ThrowTypeError("Invalid arguments");

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -77,8 +77,8 @@ Canvas::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData* add
   Nan::SetTemplate(proto, "PNG_ALL_FILTERS", Nan::New<Uint32>(PNG_ALL_FILTERS));
 
   // Class methods
-  Nan::SetMethod(ctor, "_registerFont", RegisterFont);
-  Nan::SetMethod(ctor, "_deregisterAllFonts", DeregisterAllFonts);
+  Nan::SetMethod(ctor, "_registerFont", RegisterFont, data_holder);
+  Nan::SetMethod(ctor, "_deregisterAllFonts", DeregisterAllFonts, data_holder);
 
   Local<Context> ctx = Nan::GetCurrentContext();
   Nan::Set(target,
@@ -719,7 +719,7 @@ str_value(Local<Value> val, const char *fallback, bool can_be_number) {
 }
 
 NAN_METHOD(Canvas::RegisterFont) {
-  AddonData *addon_data = get_data_from_if1(info.This());
+  AddonData *addon_data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   if (!info[0]->IsString()) {
     return Nan::ThrowError("Wrong argument type");
   } else if (!info[1]->IsObject()) {
@@ -778,7 +778,7 @@ NAN_METHOD(Canvas::RegisterFont) {
 NAN_METHOD(Canvas::DeregisterAllFonts) {
   // Unload all fonts from pango to free up memory
   bool success = true;
-  AddonData* addon_data = get_data_from_if1(info.This());
+  AddonData* addon_data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   
   std::for_each(addon_data->font_face_list.begin(), addon_data->font_face_list.end(), [&](FontFace& f) {
     if (!deregister_font( (unsigned char *)f.file_path )) success = false;

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -37,6 +37,7 @@ class FontFace {
 
 class Canvas: public Nan::ObjectWrap {
   public:
+    static const char *ctor_name;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(ToBuffer);

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -37,7 +37,6 @@ class FontFace {
 
 class Canvas: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(ToBuffer);

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -10,6 +10,7 @@
 #include <v8.h>
 #include <vector>
 #include <cstddef>
+#include "AddonData.h"
 
 /*
  * Maxmimum states per context.
@@ -20,16 +21,6 @@
 #define CANVAS_MAX_STATES 64
 #endif
 
-/*
- * FontFace describes a font file in terms of one PangoFontDescription that
- * will resolve to it and one that the user describes it as (like @font-face)
- */
-class FontFace {
-  public:
-    PangoFontDescription *sys_desc = nullptr;
-    PangoFontDescription *user_desc = nullptr;
-    unsigned char file_path[1024];
-};
 
 /*
  * Canvas.
@@ -38,7 +29,7 @@ class FontFace {
 class Canvas: public Nan::ObjectWrap {
   public:
     static const char *ctor_name;
-    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData*);
     static NAN_METHOD(New);
     static NAN_METHOD(ToBuffer);
     static NAN_GETTER(GetType);
@@ -58,7 +49,7 @@ class Canvas: public Nan::ObjectWrap {
     static void ToBufferAsyncAfter(uv_work_t *req);
     static PangoWeight GetWeightFromCSSString(const char *weight);
     static PangoStyle GetStyleFromCSSString(const char *style);
-    static PangoFontDescription *ResolveFontDescription(const PangoFontDescription *desc);
+    static PangoFontDescription *ResolveFontDescription(const PangoFontDescription *desc, AddonData*);
 
     DLL_PUBLIC inline Backend* backend() { return _backend; }
     DLL_PUBLIC inline cairo_surface_t* surface(){ return backend()->getSurface(); }

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -7,8 +7,6 @@
 
 using namespace v8;
 
-Nan::Persistent<FunctionTemplate> Gradient::constructor;
-
 /*
  * Initialize CanvasGradient.
  */
@@ -19,7 +17,6 @@ Gradient::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Gradient::New);
-  constructor.Reset(ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(Nan::New("CanvasGradient").ToLocalChecked());
 

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -14,13 +14,15 @@ const char *Gradient::ctor_name = "CanvasGradient";
  */
 
 void
-Gradient::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
+Gradient::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData *addon_data) {
   Nan::HandleScope scope;
 
+  Local<External> data_holder = Nan::New<External>(addon_data);
   // Constructor
-  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Gradient::New);
-  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Gradient::New, data_holder);
+  ctor->InstanceTemplate()->SetInternalFieldCount(2);
   ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
+  addon_data->gradient_ctor_tpl.Reset(ctor);
 
   // Prototype
   Nan::SetPrototypeMethod(ctor, "addColorStop", AddColorStop);
@@ -39,6 +41,7 @@ NAN_METHOD(Gradient::New) {
     return Nan::ThrowTypeError("Class constructors cannot be invoked without 'new'");
   }
 
+  info.This()->SetInternalField(1, info.Data());
   // Linear
   if (4 == info.Length()) {
     Gradient *grad = new Gradient(

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -7,6 +7,8 @@
 
 using namespace v8;
 
+const char *Gradient::ctor_name = "CanvasGradient";
+
 /*
  * Initialize CanvasGradient.
  */
@@ -18,13 +20,13 @@ Gradient::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Gradient::New);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("CanvasGradient").ToLocalChecked());
+  ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
 
   // Prototype
   Nan::SetPrototypeMethod(ctor, "addColorStop", AddColorStop);
   Local<Context> ctx = Nan::GetCurrentContext();
   Nan::Set(target,
-           Nan::New("CanvasGradient").ToLocalChecked(),
+           Nan::New(ctor_name).ToLocalChecked(),
            ctor->GetFunction(ctx).ToLocalChecked());
 }
 

--- a/src/CanvasGradient.h
+++ b/src/CanvasGradient.h
@@ -5,10 +5,10 @@
 #include <nan.h>
 #include <v8.h>
 #include <cairo.h>
+#include <map>
 
 class Gradient: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(AddColorStop);

--- a/src/CanvasGradient.h
+++ b/src/CanvasGradient.h
@@ -6,11 +6,12 @@
 #include <v8.h>
 #include <cairo.h>
 #include <map>
+#include "AddonData.h"
 
 class Gradient: public Nan::ObjectWrap {
   public:
     static const char *ctor_name;
-    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData*);
     static NAN_METHOD(New);
     static NAN_METHOD(AddColorStop);
     Gradient(double x0, double y0, double x1, double y1);

--- a/src/CanvasGradient.h
+++ b/src/CanvasGradient.h
@@ -9,6 +9,7 @@
 
 class Gradient: public Nan::ObjectWrap {
   public:
+    static const char *ctor_name;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(AddColorStop);

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -9,6 +9,8 @@
 using namespace v8;
 
 const cairo_user_data_key_t *pattern_repeat_key;
+const char *Pattern::ctor_name = "CanvasPattern";
+const char *Pattern::dom_matrix_name = "CanvasPattern_DOMMatrix";
 
 /*
  * Initialize CanvasPattern.
@@ -21,12 +23,12 @@ Pattern::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Pattern::New);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("CanvasPattern").ToLocalChecked());
+  ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
   Nan::SetPrototypeMethod(ctor, "setTransform", SetTransform);
 
   // Prototype
   Local<Context> ctx = Nan::GetCurrentContext();
-  Nan::Set(target, Nan::New("CanvasPattern").ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
+  Nan::Set(target, Nan::New(ctor_name).ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
   Nan::Set(target, Nan::New("CanvasPatternInit").ToLocalChecked(), Nan::New<Function>(SaveExternalModules));
 }
 
@@ -56,8 +58,8 @@ NAN_METHOD(Pattern::New) {
   cairo_surface_t *surface;
 
   Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
-  Local<Function> canvas_ctor = getFromExports("Canvas").As<Function>();
-  Local<Function> image_ctor = getFromExports("Image").As<Function>();
+  Local<Function> canvas_ctor = getFromExports(Canvas::ctor_name).As<Function>();
+  Local<Function> image_ctor = getFromExports(Image::ctor_name).As<Function>();
 
   // Image
   if (obj->InstanceOf(Nan::GetCurrentContext(), image_ctor).FromJust()) {
@@ -97,7 +99,7 @@ NAN_METHOD(Pattern::SetTransform) {
   Local<Object> mat = Nan::To<Object>(info[0]).ToLocalChecked();
 
 #if NODE_MAJOR_VERSION >= 8
-  Local<Function> _DOMMatrix = getFromExports("CanvasPattern_DOMMatrix").As<Function>();
+  Local<Function> _DOMMatrix = getFromExports(dom_matrix_name).As<Function>();
   if (!mat->InstanceOf(ctx, _DOMMatrix).ToChecked()) {
     return Nan::ThrowTypeError("Expected DOMMatrix");
   }

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -21,6 +21,8 @@ extern const cairo_user_data_key_t *pattern_repeat_key;
 
 class Pattern: public Nan::ObjectWrap {
   public:
+    static const char *ctor_name;
+    static const char *dom_matrix_name;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(SaveExternalModules);

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -21,8 +21,6 @@ extern const cairo_user_data_key_t *pattern_repeat_key;
 
 class Pattern: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
-    static Nan::Persistent<v8::Function> _DOMMatrix;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(SaveExternalModules);

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -5,6 +5,7 @@
 #include <cairo.h>
 #include <nan.h>
 #include <v8.h>
+#include "AddonData.h"
 
 /*
  * Canvas types.
@@ -23,7 +24,7 @@ class Pattern: public Nan::ObjectWrap {
   public:
     static const char *ctor_name;
     static const char *dom_matrix_name;
-    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData*);
     static NAN_METHOD(New);
     static NAN_METHOD(SaveExternalModules);
     static NAN_METHOD(SetTransform);

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -719,7 +719,7 @@ NAN_METHOD(Context2d::SaveExternalModules) {
   Local<String> DOMMatrixName = Nan::New<String>("CanvasRenderingContext2D_DOMMatrix").ToLocalChecked();
   Local<String> parseFontName = Nan::New<String>("CanvasRenderingContext2D_parseFont").ToLocalChecked();
   Nan::Set(exports, DOMMatrixName, Nan::To<Function>(info[0]).ToLocalChecked());
-  Nan::Set(exports, parseFontName, Nan::To<Function>(info[0]).ToLocalChecked());
+  Nan::Set(exports, parseFontName, Nan::To<Function>(info[1]).ToLocalChecked());
 }
 
 /*

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1855,10 +1855,10 @@ NAN_SETTER(Context2d::SetFillStyle) {
     context->_fillStyle.Reset();
     context->_setFillColor(str);
   } else if (value->IsObject()) {
-    Local<FunctionTemplate> canvas_ctor_tpl = Nan::New(addon_data->canvas_ctor_tpl);
+    Local<FunctionTemplate> gradient_ctor_tpl = Nan::New(addon_data->gradient_ctor_tpl);
     Local<FunctionTemplate> pattern_ctor_tpl = Nan::New(addon_data->pattern_ctor_tpl);
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    if (canvas_ctor_tpl->HasInstance(obj)) {
+    if (gradient_ctor_tpl->HasInstance(obj)) {
       context->_fillStyle.Reset(value);
       Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(obj);
       context->state->fillGradient = grad->pattern();

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -21,6 +21,10 @@
 
 using namespace v8;
 
+const char *Context2d::ctor_name = "CanvasRenderingContext2d";
+const char *Context2d::dom_matrix_name = "CanvasRenderingContext2D_DOMMatrix";
+const char *Context2d::parse_font_name = "CanvasRenderingContext2D_parseFont";
+
 /*
  * Rectangle arg assertions.
  */
@@ -90,7 +94,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Context2d::New);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("CanvasRenderingContext2D").ToLocalChecked());
+  ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
@@ -157,7 +161,7 @@ Context2d::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   SetProtoAccessor(proto, Nan::New("textBaseline").ToLocalChecked(), GetTextBaseline, SetTextBaseline, ctor);
   SetProtoAccessor(proto, Nan::New("textAlign").ToLocalChecked(), GetTextAlign, SetTextAlign, ctor);
   Local<Context> ctx = Nan::GetCurrentContext();
-  Nan::Set(target, Nan::New("CanvasRenderingContext2d").ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
+  Nan::Set(target, Nan::New(ctor_name).ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
   Nan::Set(target, Nan::New("CanvasRenderingContext2dInit").ToLocalChecked(), Nan::New<Function>(SaveExternalModules));
 }
 
@@ -669,7 +673,7 @@ NAN_METHOD(Context2d::New) {
   if (!info[0]->IsObject())
     return Nan::ThrowTypeError("Canvas expected");
   Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
-  Local<Function> canvas_ctor = getFromExports("Canvas").As<Function>();
+  Local<Function> canvas_ctor = getFromExports(Canvas::ctor_name).As<Function>();
   if (!obj->InstanceOf(Nan::GetCurrentContext(), canvas_ctor).FromJust())
     return Nan::ThrowTypeError("Canvas expected");
   Canvas *canvas = Nan::ObjectWrap::Unwrap<Canvas>(obj);
@@ -716,10 +720,10 @@ NAN_METHOD(Context2d::SaveExternalModules) {
   Local<Object> exports = Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New<String>("__node_canvas").ToLocalChecked())
     .ToLocalChecked()
     .As<Object>();
-  Local<String> DOMMatrixName = Nan::New<String>("CanvasRenderingContext2D_DOMMatrix").ToLocalChecked();
-  Local<String> parseFontName = Nan::New<String>("CanvasRenderingContext2D_parseFont").ToLocalChecked();
-  Nan::Set(exports, DOMMatrixName, Nan::To<Function>(info[0]).ToLocalChecked());
-  Nan::Set(exports, parseFontName, Nan::To<Function>(info[1]).ToLocalChecked());
+  Local<String> DOMMatrixNameKey = Nan::New<String>(dom_matrix_name).ToLocalChecked();
+  Local<String> parseFontNameKey = Nan::New<String>(parse_font_name).ToLocalChecked();
+  Nan::Set(exports, DOMMatrixNameKey, Nan::To<Function>(info[0]).ToLocalChecked());
+  Nan::Set(exports, parseFontNameKey, Nan::To<Function>(info[1]).ToLocalChecked());
 }
 
 /*
@@ -773,7 +777,7 @@ NAN_METHOD(Context2d::PutImageData) {
   if (!info[0]->IsObject())
     return Nan::ThrowTypeError("ImageData expected");
   Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
-  Local<Function> image_data_ctor = getFromExports("ImageData").As<Function>();
+  Local<Function> image_data_ctor = getFromExports(ImageData::ctor_name).As<Function>();
   if (!obj->InstanceOf(Nan::GetCurrentContext(), image_data_ctor).FromJust())
     return Nan::ThrowTypeError("ImageData expected");
 
@@ -1122,7 +1126,7 @@ NAN_METHOD(Context2d::GetImageData) {
   Local<Int32> shHandle = Nan::New(sh);
   Local<Value> argv[argc] = { dataArray, swHandle, shHandle };
 
-  Local<Function> ctor = getFromExports("ImageData").As<Function>();
+  Local<Function> ctor = getFromExports(ImageData::ctor_name).As<Function>();
   Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 
   info.GetReturnValue().Set(instance);
@@ -1163,7 +1167,7 @@ NAN_METHOD(Context2d::CreateImageData){
   const int argc = 3;
   Local<Value> argv[argc] = { arr, Nan::New(width), Nan::New(height) };
 
-  Local<Function> ctor = getFromExports("ImageData").As<Function>();
+  Local<Function> ctor = getFromExports(ImageData::ctor_name).As<Function>();
   Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 
   info.GetReturnValue().Set(instance);
@@ -1218,8 +1222,8 @@ NAN_METHOD(Context2d::DrawImage) {
   cairo_surface_t *surface;
 
   Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
-  Local<Function> canvas_ctor = getFromExports("Canvas").As<Function>();
-  Local<Function> image_ctor = getFromExports("Image").As<Function>();
+  Local<Function> canvas_ctor = getFromExports(Canvas::ctor_name).As<Function>();
+  Local<Function> image_ctor = getFromExports(Image::ctor_name).As<Function>();
 
   // Image
   if (obj->InstanceOf(Nan::GetCurrentContext(), image_ctor).FromJust()) {
@@ -1764,7 +1768,7 @@ get_current_transform(Context2d *context) {
 
   const int argc = 1;
   Local<Value> argv[argc] = { arr };
-  Local<Function> _DOMMatrix = getFromExports("CanvasRenderingContext2D_DOMMatrix").As<Function>();
+  Local<Function> _DOMMatrix = getFromExports(Context2d::dom_matrix_name).As<Function>();
   return Nan::NewInstance(_DOMMatrix, argc, argv).ToLocalChecked();
 }
 
@@ -1803,7 +1807,7 @@ NAN_SETTER(Context2d::SetCurrentTransform) {
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
   Local<Context> ctx = Nan::GetCurrentContext();
   Local<Object> mat = Nan::To<Object>(value).ToLocalChecked();
-  Local<Function> _DOMMatrix = getFromExports("CanvasRenderingContext2D_DOMMatrix").As<Function>();
+  Local<Function> _DOMMatrix = getFromExports(dom_matrix_name).As<Function>();
 
 #if NODE_MAJOR_VERSION >= 8
   if (!mat->InstanceOf(ctx, _DOMMatrix).ToChecked()) {
@@ -1848,8 +1852,8 @@ NAN_SETTER(Context2d::SetFillStyle) {
     context->_fillStyle.Reset();
     context->_setFillColor(str);
   } else if (value->IsObject()) {
-    Local<Function> canvas_ctor = getFromExports("Canvas").As<Function>();
-    Local<Function> pattern_ctor = getFromExports("CanvasPattern").As<Function>();
+    Local<Function> canvas_ctor = getFromExports(Canvas::ctor_name).As<Function>();
+    Local<Function> pattern_ctor = getFromExports(Pattern::ctor_name).As<Function>();
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
     if (obj->InstanceOf(Nan::GetCurrentContext(), canvas_ctor).FromJust()) {
       context->_fillStyle.Reset(value);
@@ -1894,8 +1898,8 @@ NAN_SETTER(Context2d::SetStrokeStyle) {
     context->_setStrokeColor(str);
   } else if (value->IsObject()) {
     Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-    Local<Function> pattern_ctor = getFromExports("CanvasPattern").As<Function>();
-    Local<Function> gradient_ctor = getFromExports("CanvasGradient").As<Function>();
+    Local<Function> pattern_ctor = getFromExports(Pattern::ctor_name).As<Function>();
+    Local<Function> gradient_ctor = getFromExports(Gradient::ctor_name).As<Function>();
     if (obj->InstanceOf(Nan::GetCurrentContext(), gradient_ctor).FromJust()) {
       context->_strokeStyle.Reset(value);
       Gradient *grad = Nan::ObjectWrap::Unwrap<Gradient>(obj);
@@ -2112,7 +2116,7 @@ NAN_METHOD(Context2d::CreatePattern) {
   const int argc = 2;
   Local<Value> argv[argc] = { image, repetition };
 
-  Local<Function> ctor = getFromExports("CanvasPattern").As<Function>();
+  Local<Function> ctor = getFromExports(Pattern::ctor_name).As<Function>();
   Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 
   info.GetReturnValue().Set(instance);
@@ -2121,7 +2125,7 @@ NAN_METHOD(Context2d::CreatePattern) {
 NAN_METHOD(Context2d::CreateLinearGradient) {
   const int argc = 4;
   Local<Value> argv[argc] = { info[0], info[1], info[2], info[3] };
-  Local<Function> ctor = getFromExports("CanvasGradient").As<Function>();
+  Local<Function> ctor = getFromExports(Gradient::ctor_name).As<Function>();
 
   Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 
@@ -2132,7 +2136,7 @@ NAN_METHOD(Context2d::CreateRadialGradient) {
   const int argc = 6;
   Local<Value> argv[argc] = { info[0], info[1], info[2], info[3], info[4], info[5] };
 
-  Local<Function> ctor = getFromExports("CanvasGradient").As<Function>();
+  Local<Function> ctor = getFromExports(Gradient::ctor_name).As<Function>();
   Local<Object> instance = Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 
   info.GetReturnValue().Set(instance);
@@ -2291,7 +2295,7 @@ NAN_METHOD(Context2d::SetTransform) {
 
     #if NODE_MAJOR_VERSION >= 8
       Local<Context> ctx = Nan::GetCurrentContext();
-      Local<Function> _DOMMatrix = getFromExports("CanvasRenderingContext2D_DOMMatrix").As<Function>();
+      Local<Function> _DOMMatrix = getFromExports(dom_matrix_name).As<Function>();
       if (!mat->InstanceOf(ctx, _DOMMatrix).ToChecked()) {
         return Nan::ThrowTypeError("Expected DOMMatrix");
       }
@@ -2557,7 +2561,7 @@ NAN_SETTER(Context2d::SetFont) {
 
   const int argc = 1;
   Local<Value> argv[argc] = { value };
-  Local<Function> _parseFont = getFromExports("CanvasRenderingContext2D_parseFont").As<Function>();
+  Local<Function> _parseFont = getFromExports(parse_font_name).As<Function>();
 
   Local<Value> mparsed = Nan::Call(_parseFont, ctx->Global(), argc, argv).ToLocalChecked();
   // parseFont returns undefined for invalid CSS font strings

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -62,9 +62,8 @@ class Context2d: public Nan::ObjectWrap {
     canvas_state_t *states[CANVAS_MAX_STATES];
     canvas_state_t *state;
     Context2d(Canvas *canvas);
-    static Nan::Persistent<v8::Function> _DOMMatrix;
-    static Nan::Persistent<v8::Function> _parseFont;
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    // static Nan::Persistent<v8::Function> _DOMMatrix;
+    // static Nan::Persistent<v8::Function> _parseFont;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_METHOD(SaveExternalModules);

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -7,6 +7,7 @@
 #include "color.h"
 #include "nan.h"
 #include <pango/pangocairo.h>
+#include "AddonData.h"
 
 typedef enum {
   TEXT_DRAW_PATHS,
@@ -62,12 +63,7 @@ class Context2d: public Nan::ObjectWrap {
     canvas_state_t *states[CANVAS_MAX_STATES];
     canvas_state_t *state;
     Context2d(Canvas *canvas);
-    static const char *ctor_name;
-    static const char *dom_matrix_name;
-    static const char *parse_font_name;
-    // static Nan::Persistent<v8::Function> _DOMMatrix;
-    // static Nan::Persistent<v8::Function> _parseFont;
-    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData*);
     static NAN_METHOD(New);
     static NAN_METHOD(SaveExternalModules);
     static NAN_METHOD(DrawImage);

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -62,6 +62,9 @@ class Context2d: public Nan::ObjectWrap {
     canvas_state_t *states[CANVAS_MAX_STATES];
     canvas_state_t *state;
     Context2d(Canvas *canvas);
+    static const char *ctor_name;
+    static const char *dom_matrix_name;
+    static const char *parse_font_name;
     // static Nan::Persistent<v8::Function> _DOMMatrix;
     // static Nan::Persistent<v8::Function> _parseFont;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -43,8 +43,6 @@ typedef struct {
 
 using namespace v8;
 
-Nan::Persistent<FunctionTemplate> Image::constructor;
-
 /*
  * Initialize Image.
  */
@@ -54,7 +52,6 @@ Image::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Image::New);
-  constructor.Reset(ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(Nan::New("Image").ToLocalChecked());
 
@@ -186,7 +183,8 @@ NAN_SETTER(Image::SetHeight) {
  */
 
 NAN_METHOD(Image::GetSource){
-  if (!Image::constructor.Get(info.GetIsolate())->HasInstance(info.This())) {
+  Local<Function> ctor = getFromExports("Image").As<Function>();
+  if (!info.This()->InstanceOf(Nan::GetCurrentContext(), ctor).FromJust()) {
     // #1534
     Nan::ThrowTypeError("Method Image.GetSource called on incompatible receiver");
     return;
@@ -231,7 +229,8 @@ Image::clearData() {
  */
 
 NAN_METHOD(Image::SetSource){
-  if (!Image::constructor.Get(info.GetIsolate())->HasInstance(info.This())) {
+  Local<Function> ctor = getFromExports("Image").As<Function>();
+  if (!info.This()->InstanceOf(Nan::GetCurrentContext(), ctor).FromJust()) {
     // #1534
     Nan::ThrowTypeError("Method Image.SetSource called on incompatible receiver");
     return;

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -50,12 +50,14 @@ const char *Image::ctor_name = "Image";
  */
 
 void
-Image::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
+Image::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData *addon_data) {
   Nan::HandleScope scope;
 
-  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Image::New);
-  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  Local<External> data_holder = Nan::New<External>(addon_data);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Image::New, data_holder);
+  ctor->InstanceTemplate()->SetInternalFieldCount(2);
   ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
+  addon_data->image_ctor_tpl.Reset(ctor);
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
@@ -89,6 +91,7 @@ NAN_METHOD(Image::New) {
   Image *img = new Image;
   img->data_mode = DATA_IMAGE;
   img->Wrap(info.This());
+  info.This()->SetInternalField(1, info.Data());
   Nan::Set(info.This(), Nan::New("onload").ToLocalChecked(), Nan::Null()).Check();
   Nan::Set(info.This(), Nan::New("onerror").ToLocalChecked(), Nan::Null()).Check();
   info.GetReturnValue().Set(info.This());
@@ -185,8 +188,9 @@ NAN_SETTER(Image::SetHeight) {
  */
 
 NAN_METHOD(Image::GetSource){
-  Local<Function> ctor = getFromExports(ctor_name).As<Function>();
-  if (!info.This()->InstanceOf(Nan::GetCurrentContext(), ctor).FromJust()) {
+  AddonData *addon_data = get_data_from_if1(info.This());
+  Local<FunctionTemplate> ctor_tpl = Nan::New(addon_data->image_ctor_tpl);
+  if (!ctor_tpl->HasInstance(info.This())) {
     // #1534
     Nan::ThrowTypeError("Method Image.GetSource called on incompatible receiver");
     return;
@@ -231,8 +235,9 @@ Image::clearData() {
  */
 
 NAN_METHOD(Image::SetSource){
-  Local<Function> ctor = getFromExports(ctor_name).As<Function>();
-  if (!info.This()->InstanceOf(Nan::GetCurrentContext(), ctor).FromJust()) {
+  AddonData *addon_data = get_data_from_if1(info.This());
+  Local<FunctionTemplate> ctor_tpl = Nan::New(addon_data->image_ctor_tpl);
+  if (!ctor_tpl->HasInstance(info.This())) {
     // #1534
     Nan::ThrowTypeError("Method Image.SetSource called on incompatible receiver");
     return;

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -43,6 +43,8 @@ typedef struct {
 
 using namespace v8;
 
+const char *Image::ctor_name = "Image";
+
 /*
  * Initialize Image.
  */
@@ -53,7 +55,7 @@ Image::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(Image::New);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("Image").ToLocalChecked());
+  ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
@@ -183,7 +185,7 @@ NAN_SETTER(Image::SetHeight) {
  */
 
 NAN_METHOD(Image::GetSource){
-  Local<Function> ctor = getFromExports("Image").As<Function>();
+  Local<Function> ctor = getFromExports(ctor_name).As<Function>();
   if (!info.This()->InstanceOf(Nan::GetCurrentContext(), ctor).FromJust()) {
     // #1534
     Nan::ThrowTypeError("Method Image.GetSource called on incompatible receiver");
@@ -229,7 +231,7 @@ Image::clearData() {
  */
 
 NAN_METHOD(Image::SetSource){
-  Local<Function> ctor = getFromExports("Image").As<Function>();
+  Local<Function> ctor = getFromExports(ctor_name).As<Function>();
   if (!info.This()->InstanceOf(Nan::GetCurrentContext(), ctor).FromJust()) {
     // #1534
     Nan::ThrowTypeError("Method Image.SetSource called on incompatible receiver");

--- a/src/Image.h
+++ b/src/Image.h
@@ -39,7 +39,6 @@ class Image: public Nan::ObjectWrap {
     char *filename;
     int width, height;
     int naturalWidth, naturalHeight;
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetComplete);

--- a/src/Image.h
+++ b/src/Image.h
@@ -8,6 +8,7 @@
 #include <nan.h>
 #include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
 #include <v8.h>
+#include "AddonData.h"
 
 #ifdef HAVE_JPEG
 #include <jpeglib.h>
@@ -40,7 +41,7 @@ class Image: public Nan::ObjectWrap {
     int width, height;
     int naturalWidth, naturalHeight;
     static const char *ctor_name;
-    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData*);
     static NAN_METHOD(New);
     static NAN_GETTER(GetComplete);
     static NAN_GETTER(GetWidth);

--- a/src/Image.h
+++ b/src/Image.h
@@ -39,6 +39,7 @@ class Image: public Nan::ObjectWrap {
     char *filename;
     int width, height;
     int naturalWidth, naturalHeight;
+    static const char *ctor_name;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetComplete);

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -6,6 +6,8 @@
 
 using namespace v8;
 
+const char *ImageData::ctor_name = "ImageData";
+
 /*
  * Initialize ImageData.
  */
@@ -17,14 +19,14 @@ ImageData::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageData::New);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("ImageData").ToLocalChecked());
+  ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
   SetProtoAccessor(proto, Nan::New("width").ToLocalChecked(), GetWidth, NULL, ctor);
   SetProtoAccessor(proto, Nan::New("height").ToLocalChecked(), GetHeight, NULL, ctor);
   Local<Context> ctx = Nan::GetCurrentContext();
-  Nan::Set(target, Nan::New("ImageData").ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
+  Nan::Set(target, Nan::New(ctor_name).ToLocalChecked(), ctor->GetFunction(ctx).ToLocalChecked());
 }
 
 /*

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -13,13 +13,15 @@ const char *ImageData::ctor_name = "ImageData";
  */
 
 void
-ImageData::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
+ImageData::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData *addon_data) {
   Nan::HandleScope scope;
 
+  Local<External> data_holder = Nan::New<External>(addon_data);
   // Constructor
-  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageData::New);
-  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageData::New, data_holder);
+  ctor->InstanceTemplate()->SetInternalFieldCount(2);
   ctor->SetClassName(Nan::New(ctor_name).ToLocalChecked());
+  addon_data->image_data_ctor_tpl.Reset(ctor);
 
   // Prototype
   Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
@@ -116,6 +118,7 @@ NAN_METHOD(ImageData::New) {
 
   ImageData *imageData = new ImageData(reinterpret_cast<uint8_t*>(*dataPtr), width, height);
   imageData->Wrap(info.This());
+  info.This()->SetInternalField(1, info.Data());
   Nan::Set(info.This(), Nan::New("data").ToLocalChecked(), dataArray).Check();
   info.GetReturnValue().Set(info.This());
 }

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -6,8 +6,6 @@
 
 using namespace v8;
 
-Nan::Persistent<FunctionTemplate> ImageData::constructor;
-
 /*
  * Initialize ImageData.
  */
@@ -18,7 +16,6 @@ ImageData::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 
   // Constructor
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageData::New);
-  constructor.Reset(ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(Nan::New("ImageData").ToLocalChecked());
 

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -8,7 +8,6 @@
 
 class ImageData: public Nan::ObjectWrap {
   public:
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetWidth);

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -5,11 +5,12 @@
 #include <nan.h>
 #include <stdint.h> // node < 7 uses libstdc++ on macOS which lacks complete c++11
 #include <v8.h>
+#include "AddonData.h"
 
 class ImageData: public Nan::ObjectWrap {
   public:
     static const char *ctor_name;
-    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
+    static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target, AddonData*);
     static NAN_METHOD(New);
     static NAN_GETTER(GetWidth);
     static NAN_GETTER(GetHeight);

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -8,6 +8,7 @@
 
 class ImageData: public Nan::ObjectWrap {
   public:
+    static const char *ctor_name;
     static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
     static NAN_METHOD(New);
     static NAN_GETTER(GetWidth);

--- a/src/Util.h
+++ b/src/Util.h
@@ -32,3 +32,13 @@ inline bool streq_casein(std::string& str1, std::string& str2) {
     return c1 == c2 || std::toupper(c1) == std::toupper(c2);
   });
 }
+
+inline v8::Local<v8::Value> getFromExports(const char* key)
+{
+	v8::Local<v8::Object> exports = Nan::Get(
+			Nan::GetCurrentContext()->Global(), 
+			Nan::New<v8::String>("__node_canvas").ToLocalChecked())
+		.ToLocalChecked().As<v8::Object>();
+		
+	return Nan::Get(exports, Nan::New<v8::String>(key).ToLocalChecked()).ToLocalChecked();
+}

--- a/src/Util.h
+++ b/src/Util.h
@@ -3,6 +3,7 @@
 #include <nan.h>
 #include <v8.h>
 #include <cctype>
+#include "AddonData.h"
 
 // Wrapper around Nan::SetAccessor that makes it easier to change the last
 // argument (signature). Getters/setters must be accessed only when there is
@@ -33,12 +34,12 @@ inline bool streq_casein(std::string& str1, std::string& str2) {
   });
 }
 
-inline v8::Local<v8::Value> getFromExports(const char* key)
+inline AddonData* get_data_from_if1(v8::Local<v8::Object> obj)
 {
-	v8::Local<v8::Object> exports = Nan::Get(
-			Nan::GetCurrentContext()->Global(), 
-			Nan::New<v8::String>("__node_canvas").ToLocalChecked())
-		.ToLocalChecked().As<v8::Object>();
-		
-	return Nan::Get(exports, Nan::New<v8::String>(key).ToLocalChecked()).ToLocalChecked();
+	if (obj->InternalFieldCount() < 2)
+		return nullptr;
+	if (!obj->GetInternalField(1)->IsExternal())
+		return nullptr;
+
+	return reinterpret_cast<AddonData*>(obj->GetInternalField(1).As<v8::External>()->Value());
 }

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -21,6 +21,7 @@ void Backend::init(const Nan::FunctionCallbackInfo<v8::Value> &info) {
   Backend *backend = construct(width, height);
 
   backend->Wrap(info.This());
+  info.This()->SetInternalField(1, info.Data());
   info.GetReturnValue().Set(info.This());
 }
 

--- a/src/backend/ImageBackend.cc
+++ b/src/backend/ImageBackend.cc
@@ -57,12 +57,13 @@ void ImageBackend::setFormat(cairo_format_t _format) {
 
 const char *ImageBackend::ctor_name = "ImageBackend";
 
-void ImageBackend::Initialize(Local<Object> target) {
+void ImageBackend::Initialize(Local<Object> target, AddonData *addon_data) {
 	Nan::HandleScope scope;
 
 	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageBackend::New);
 
-	ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  addon_data->image_backend_ctor_tpl.Reset(ctor);
+	ctor->InstanceTemplate()->SetInternalFieldCount(2);
 	ctor->SetClassName(Nan::New<String>(ctor_name).ToLocalChecked());
   Nan::Set(target,
            Nan::New<String>(ctor_name).ToLocalChecked(),

--- a/src/backend/ImageBackend.cc
+++ b/src/backend/ImageBackend.cc
@@ -55,17 +55,17 @@ void ImageBackend::setFormat(cairo_format_t _format) {
 	this->format = _format;
 }
 
-Nan::Persistent<FunctionTemplate> ImageBackend::constructor;
+const char *ImageBackend::ctor_name = "ImageBackend";
 
 void ImageBackend::Initialize(Local<Object> target) {
 	Nan::HandleScope scope;
 
 	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(ImageBackend::New);
-	ImageBackend::constructor.Reset(ctor);
+
 	ctor->InstanceTemplate()->SetInternalFieldCount(1);
-	ctor->SetClassName(Nan::New<String>("ImageBackend").ToLocalChecked());
+	ctor->SetClassName(Nan::New<String>(ctor_name).ToLocalChecked());
   Nan::Set(target,
-           Nan::New<String>("ImageBackend").ToLocalChecked(),
+           Nan::New<String>(ctor_name).ToLocalChecked(),
            Nan::GetFunction(ctor).ToLocalChecked()).Check();
 }
 

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Backend.h"
+#include "../AddonData.h"
 #include <v8.h>
 
 class ImageBackend : public Backend
@@ -20,7 +21,7 @@ class ImageBackend : public Backend
     int32_t approxBytesPerPixel();
 
     static const char *ctor_name;
-    static void Initialize(v8::Local<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target, AddonData*);
     static NAN_METHOD(New);
     const static cairo_format_t DEFAULT_FORMAT = CAIRO_FORMAT_ARGB32;
 };

--- a/src/backend/ImageBackend.h
+++ b/src/backend/ImageBackend.h
@@ -19,7 +19,7 @@ class ImageBackend : public Backend
 
     int32_t approxBytesPerPixel();
 
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static const char *ctor_name;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
     const static cairo_format_t DEFAULT_FORMAT = CAIRO_FORMAT_ARGB32;

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -36,12 +36,14 @@ cairo_surface_t* PdfBackend::recreateSurface() {
 
 const char *PdfBackend::ctor_name = "PdfBackend";
 
-void PdfBackend::Initialize(Local<Object> target) {
+void PdfBackend::Initialize(Local<Object> target, AddonData *addon_data) {
   Nan::HandleScope scope;
 
-  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New);
+  Local<External> data_holder = Nan::New<External>(addon_data);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New, data_holder);
 
-  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  addon_data->pdf_backend_ctor_tpl.Reset(ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(2);
   ctor->SetClassName(Nan::New<String>(ctor_name).ToLocalChecked());
   Nan::Set(target,
            Nan::New<String>(ctor_name).ToLocalChecked(),

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -34,17 +34,17 @@ cairo_surface_t* PdfBackend::recreateSurface() {
 }
 
 
-Nan::Persistent<FunctionTemplate> PdfBackend::constructor;
+const char *PdfBackend::ctor_name = "PdfBackend";
 
 void PdfBackend::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(PdfBackend::New);
-  PdfBackend::constructor.Reset(ctor);
+
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New<String>("PdfBackend").ToLocalChecked());
+  ctor->SetClassName(Nan::New<String>(ctor_name).ToLocalChecked());
   Nan::Set(target,
-           Nan::New<String>("PdfBackend").ToLocalChecked(),
+           Nan::New<String>(ctor_name).ToLocalChecked(),
            Nan::GetFunction(ctor).ToLocalChecked()).Check();
 }
 

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -2,6 +2,7 @@
 
 #include "Backend.h"
 #include "../closure.h"
+#include "../AddonData.h"
 #include <v8.h>
 
 class PdfBackend : public Backend
@@ -19,6 +20,6 @@ class PdfBackend : public Backend
     static Backend *construct(int width, int height);
 
     static const char* ctor_name;
-    static void Initialize(v8::Local<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target, AddonData*);
     static NAN_METHOD(New);
 };

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -18,7 +18,7 @@ class PdfBackend : public Backend
     ~PdfBackend();
     static Backend *construct(int width, int height);
 
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static const char* ctor_name;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
 };

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -42,17 +42,17 @@ cairo_surface_t* SvgBackend::recreateSurface() {
  }
 
 
-Nan::Persistent<FunctionTemplate> SvgBackend::constructor;
+const char *SvgBackend::ctor_name = "SvgBackend";
 
 void SvgBackend::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(SvgBackend::New);
-  SvgBackend::constructor.Reset(ctor);
+
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New<String>("SvgBackend").ToLocalChecked());
+  ctor->SetClassName(Nan::New<String>(ctor_name).ToLocalChecked());
   Nan::Set(target,
-           Nan::New<String>("SvgBackend").ToLocalChecked(),
+           Nan::New<String>(ctor_name).ToLocalChecked(),
            Nan::GetFunction(ctor).ToLocalChecked()).Check();
 }
 

--- a/src/backend/SvgBackend.cc
+++ b/src/backend/SvgBackend.cc
@@ -44,12 +44,13 @@ cairo_surface_t* SvgBackend::recreateSurface() {
 
 const char *SvgBackend::ctor_name = "SvgBackend";
 
-void SvgBackend::Initialize(Local<Object> target) {
+void SvgBackend::Initialize(Local<Object> target, AddonData *addon_data) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(SvgBackend::New);
 
-  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  addon_data->svg_backend_ctor_tpl.Reset(ctor);
+  ctor->InstanceTemplate()->SetInternalFieldCount(2);
   ctor->SetClassName(Nan::New<String>(ctor_name).ToLocalChecked());
   Nan::Set(target,
            Nan::New<String>(ctor_name).ToLocalChecked(),

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -2,6 +2,7 @@
 
 #include "Backend.h"
 #include "../closure.h"
+#include "../AddonData.h"
 #include <v8.h>
 
 class SvgBackend : public Backend
@@ -19,6 +20,6 @@ class SvgBackend : public Backend
     static Backend *construct(int width, int height);
 
     static const char *ctor_name;
-    static void Initialize(v8::Local<v8::Object> target);
+    static void Initialize(v8::Local<v8::Object> target, AddonData*);
     static NAN_METHOD(New);
 };

--- a/src/backend/SvgBackend.h
+++ b/src/backend/SvgBackend.h
@@ -18,7 +18,7 @@ class SvgBackend : public Backend
     ~SvgBackend();
     static Backend *construct(int width, int height);
 
-    static Nan::Persistent<v8::FunctionTemplate> constructor;
+    static const char *ctor_name;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
 };

--- a/src/init.cc
+++ b/src/init.cc
@@ -33,13 +33,14 @@ using namespace v8;
 #endif
 
 NAN_MODULE_INIT(init) {
-  Backends::Initialize(target);
-  Canvas::Initialize(target);
-  Image::Initialize(target);
-  ImageData::Initialize(target);
-  Context2d::Initialize(target);
-  Gradient::Initialize(target);
-  Pattern::Initialize(target);
+  AddonData *data = new AddonData();
+  Backends::Initialize(target, data);
+  Canvas::Initialize(target, data);
+  Image::Initialize(target, data);
+  ImageData::Initialize(target, data);
+  Context2d::Initialize(target, data);
+  Gradient::Initialize(target, data);
+  Pattern::Initialize(target, data);
 
   Nan::Set(target, Nan::New<String>("cairoVersion").ToLocalChecked(), Nan::New<String>(cairo_version_string()).ToLocalChecked()).Check();
 #ifdef HAVE_JPEG
@@ -90,10 +91,6 @@ NAN_MODULE_INIT(init) {
 }
 
 NODE_MODULE_INIT()
-{
-  Local<Object> js_global = context->Global();
-
-  Nan::Set(js_global, Nan::New<String>("__node_canvas").ToLocalChecked(), exports).Check();
-  
+{ 
   init(exports);
 }

--- a/src/init.cc
+++ b/src/init.cc
@@ -89,4 +89,11 @@ NAN_MODULE_INIT(init) {
   Nan::Set(target, Nan::New<String>("freetypeVersion").ToLocalChecked(), Nan::New<String>(freetype_version).ToLocalChecked()).Check();
 }
 
-NODE_MODULE(canvas, init);
+NODE_MODULE_INIT()
+{
+  Local<Object> js_global = context->Global();
+
+  Nan::Set(js_global, Nan::New<String>("__node_canvas").ToLocalChecked(), exports).Check();
+  
+  init(exports);
+}

--- a/src/lock.cc
+++ b/src/lock.cc
@@ -1,0 +1,61 @@
+#include "lock.h"
+
+UVLockHandle::UVLockHandle()
+{
+  uv_rwlock_init(&rw_lock);
+  uv_mutex_init(&mutex);
+}
+
+UVLockHandle::~UVLockHandle()
+{
+  uv_rwlock_destroy(&rw_lock);
+  uv_mutex_destroy(&mutex);
+}
+
+UVLocker::UVLocker(UVLockHandle &rwlock, LockerType t) : _type{t}
+{
+  handle = &rwlock;
+
+  switch (t)
+  {
+  case rd:
+    uv_rwlock_rdlock(&handle->rw_lock);
+    break;
+
+  case wr:
+    uv_rwlock_wrlock(&handle->rw_lock);
+    break;
+
+  case mutex:
+    uv_mutex_lock(&handle->mutex);
+    break;
+  }
+}
+
+UVLocker::~UVLocker()
+{
+  clean();
+}
+
+void UVLocker::clean()
+{
+  if (handle == nullptr)
+    return;
+
+  switch (_type)
+  {
+  case rd:
+    uv_rwlock_rdunlock(&handle->rw_lock);
+    break;
+
+  case wr:
+    uv_rwlock_wrunlock(&handle->rw_lock);
+    break;
+
+  case mutex:
+    uv_mutex_unlock(&handle->mutex);
+    break;
+  }
+
+  handle = nullptr;
+}

--- a/src/lock.h
+++ b/src/lock.h
@@ -1,0 +1,34 @@
+#include "uv.h"
+
+class UVLockHandle
+{
+public:
+  uv_rwlock_t rw_lock;
+  uv_mutex_t mutex;
+  UVLockHandle();
+  ~UVLockHandle();
+};
+
+/**
+ * [RAII] Promise to unlock when there are exception throw
+ */
+class UVLocker
+{
+
+public:
+  enum LockerType
+  {
+    rd = 0,
+    wr,
+    mutex
+  };
+
+  UVLocker(UVLockHandle &, LockerType);
+  ~UVLocker();
+
+  void clean();
+
+private:
+  UVLockHandle *handle;
+  LockerType _type;
+};

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,0 +1,47 @@
+const { resolve } = require("path");
+const { createCanvas, registerFont } = require("../");
+
+function create({ width, height } = { width: 800, height: 600 }) {
+  let canvas, context;
+  canvas = createCanvas(width, height);
+  context = canvas.getContext("2d");
+
+  return {
+    canvas,
+    context,
+  };
+}
+
+exports.getCanvasSize = ({ width, height }) => {
+  const { canvas, context } = create({
+    width,
+    height,
+  });
+
+  return {
+    width: canvas.width,
+    height: canvas.height,
+  };
+};
+
+exports.updateContext = (options) => {
+  const { canvas, context } = create();
+
+  for (const key in options) {
+    context[key] = options[key];
+  }
+
+  return Object.keys(options).reduce(
+    (acm, cur) => ({
+      ...acm,
+      [cur]: context[cur],
+    }),
+    {}
+  );
+};
+
+exports.registerFont = (options) => {
+  registerFont(options.path, {
+    family: options.fontFamily,
+  });
+};

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1,0 +1,73 @@
+const assert = require("assert");
+const { resolve } = require("path");
+const Piscina = require("piscina");
+
+const filename = resolve(__dirname, "./worker.js");
+
+describe("worker:Canvas", () => {
+  it("create success", async () => {
+    const pool = new Piscina({
+      filename,
+    });
+
+    const first = await pool.run(
+      { width: 800, height: 600 },
+      { name: "getCanvasSize" }
+    );
+
+    const second = await pool.run(
+      { width: 900, height: 500 },
+      { name: "getCanvasSize" }
+    );
+
+    assert(
+      first.width == 800 && first.height == 600,
+      "invalid first canvas size"
+    );
+    assert(
+      second.width == 900 && second.height == 500,
+      "invalid second canvas size"
+    );
+  });
+
+  it("context are independent", async () => {
+    const pool = new Piscina({
+      filename,
+    });
+    const ctx1 = {
+      font: "20px Helvetica",
+      fill: "red",
+    };
+    const ctx2 = {
+      fill: "green",
+    };
+    const ctxResult1 = await pool.run(ctx1, {
+      name: "updateContext",
+    });
+    const ctxResult2 = await pool.run(ctx2, { name: "updateContext" });
+
+    assert(ctxResult1.font === ctx1.font, "ctx1 font didn't match");
+    assert(ctxResult1.fill === ctx1.fill, "ctx1 fill did't match");
+    assert(ctxResult2.fill === ctx2.fill, "ctx2 fill did't match");
+  });
+
+  it("register font", async () => {
+    const pool = new Piscina({
+      filename,
+    });
+    pool.run(
+      {
+        path: resolve(__dirname, "../examples/pfennigFont/Pfennig.ttf"),
+        fontFamily: "pfenning",
+      },
+      { name: "registerFont" }
+    );
+    pool.run(
+      {
+        path: resolve(__dirname, "../examples/pfennigFont/PfennigItalic.sfd"),
+        fontFamily: "pfenning_italic",
+      },
+      { name: "registerFont" }
+    );
+  });
+});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -64,7 +64,7 @@ describe("worker:Canvas", () => {
     );
     pool.run(
       {
-        path: resolve(__dirname, "../examples/pfennigFont/PfennigItalic.sfd"),
+        path: resolve(__dirname, "../examples/pfennigFont/PfennigItalic.ttf"),
         fontFamily: "pfenning_italic",
       },
       { name: "registerFont" }


### PR DESCRIPTION
This `PR` removes all function template, instead, keep trace of js constructor for each individual v8::Context. To achieve this, it holds all necessary js constructor under global property `__node_canvas` in each context. It may not that graceful, but is relatively safer than type casting many void* pointer.