### PR TITLE
CI fix: make types compatible with typescript 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Stringify CanvasGradient, CanvasPattern and ImageData like browsers do. (#1639, #1646)
 * Add missing include for `toupper`.
 * Throw an error instead of crashing the process if `getImageData` or `putImageData` is called on a PDF or SVG canvas (#1853)
+* Compatibility with Typescript 4.6
 
 2.9.0
 ==================

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -166,12 +166,6 @@ declare class NodeCanvasRenderingContext2D extends CanvasRenderingContext2D {
 	 */
 	textDrawingMode: 'path' | 'glyph'
 
-	/** _'saturate' is non-standard._ */
-	globalCompositeOperation: 'saturate' | 'clear' | 'copy' | 'destination' | 'source-over' | 'destination-over' |
-		'source-in' | 'destination-in' | 'source-out' | 'destination-out' | 'source-atop' | 'destination-atop' |
-		'xor' | 'lighter' | 'multiply' | 'screen' | 'overlay' | 'darken' | 'lighten' | 'color-dodge' | 'color-burn' |
-		'hard-light' | 'soft-light' | 'difference' | 'exclusion' | 'hue' | 'saturation' | 'color' | 'luminosity'
-
 	/** _Non-standard_. Sets the antialiasing mode. */
 	antialias: 'default' | 'gray' | 'none' | 'subpixel'
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -16,7 +16,6 @@ ctx.currentTransform = ctx.getTransform()
 
 ctx.quality = 'best'
 ctx.textDrawingMode = 'glyph'
-ctx.globalCompositeOperation = 'saturate'
 
 const grad: Canvas.CanvasGradient = ctx.createLinearGradient(0, 1, 2, 3)
 grad.addColorStop(0.1, 'red')


### PR DESCRIPTION
Typescript 4.6 seems to have changed `globalCompositeOperation` from `string` to an enum of strings, which means instead of narrowing the type we are now trying to widen it, which is impossible.