### PR TITLE
improve multi-family output in font desc resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Wrong fonts used when calling `registerFont` multiple times with the same family name (#2041)
 
 2.9.1
 ==================

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -879,18 +879,21 @@ Canvas::ResolveFontDescription(const PangoFontDescription *desc) {
       if (streq_casein(family, pangofamily)) {
         const char* sys_desc_family_name = pango_font_description_get_family(ff.sys_desc);
         bool unseen = seen_families.find(sys_desc_family_name) == seen_families.end();
+        bool better = best.user_desc == nullptr || pango_font_description_better_match(desc, best.user_desc, ff.user_desc);
 
         // Avoid sending duplicate SFNT font names due to a bug in Pango for macOS:
         // https://bugzilla.gnome.org/show_bug.cgi?id=762873
         if (unseen) {
           seen_families.insert(sys_desc_family_name);
-          if (renamed_families.size()) renamed_families += ',';
-          renamed_families += sys_desc_family_name;
+
+          if (better) {
+            renamed_families = string(sys_desc_family_name) + (renamed_families.size() ? "," : "") + renamed_families;
+          } else {
+            renamed_families = renamed_families + (renamed_families.size() ? "," : "") + sys_desc_family_name;
+          }
         }
 
-        if (first && (best.user_desc == nullptr || pango_font_description_better_match(desc, best.user_desc, ff.user_desc))) {
-          best = ff;
-        }
+        if (first && better) best = ff;
       }
     }
 


### PR DESCRIPTION
This bug can be understood without considering the changes from #1987. When the user adds multiple TTFs and assigns them the same family name, we send the system families from the TTFs in a comma separated list, but we weren't correctly ordering that system-family list by the best matches on the user-description side. #1987 exposed it because it almost guarantees each file will have a unique system family.

<hr>

If the user registers fonts like this:

```is
registerFont("OpenSans-Bold.ttf", {family: "Open Sans", weight: 300});
registerFont("Arimo-Regular.ttf", {family: "Open Sans", weight: 600});
```

The `font_face_list` will look like this (approximated system descriptions):

| OpenSans-Bold.ttf | sys desc | user desc |
| -- | -- | -- |
| family | Open Sans | Open Sans |
| weight | 600 | 300 |

| Arimo-Regular.ttf | sys desc | user desc |
| -- | -- | -- |
| family | Arimo | Open Sans |
| weight | 400 | 600 |

When the user does this:

```is
ctx.font = "600 Open Sans";
```

We should send this to the OS:

| Arimo-Regular.ttf | sys desc |
| -- | -- |
| family | Arimo, Open Sans |
| weight | 400 |

But we were sending this:

| Arimo-Regular.ttf | user desc |
| -- | -- |
| family | Open Sans, Arimo |
| weight | 400 |

fixes #2041
