### PR TITLE
add custom repeat-x/y processing

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -409,6 +409,7 @@ Context2d::fill(bool preserve) {
       cairo_rectangle(_context, 0, 0, width, height);
       cairo_clip(_context);
       cairo_append_path(_context, savedPath);
+      cairo_path_destroy(savedPath);
       cairo_pattern_set_extend(cairo_get_source(_context), CAIRO_EXTEND_REPEAT);
       needsRestore = true;
     }

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -471,6 +471,24 @@ tests['createPattern() with globalAlpha'] = function (ctx, done) {
   img.src = imageSrc('face.jpeg')
 }
 
+tests["createPattern() repeat-x and repeat-y"] = function (ctx, done) {
+  const img = new Image()
+  img.onload = function () {
+    ctx.scale(0.1, 0.1)
+    ctx.lineStyle = "black"
+    ctx.lineWidth = 10
+    ctx.fillStyle = ctx.createPattern(img, "repeat-x")
+    ctx.fillRect(0, 0, 900, 900)
+    ctx.strokeRect(0, 0, 900, 900)
+    ctx.translate(1000, 1000)
+    ctx.fillStyle = ctx.createPattern(img, "repeat-y")
+    ctx.fillRect(0, 0, 900, 900)
+    ctx.strokeRect(0, 0, 900, 900)
+    done()
+  };
+  img.src = imageSrc("face.jpeg")
+}
+
 tests['createPattern() no-repeat'] = function (ctx, done) {
   const img = new Image()
   img.onload = function () {


### PR DESCRIPTION
Fixes `createPattern` repetitions "repeat-x" and "repeat-y" behaving as "repeat."

It seems only fill is necessary to change, as with HTML5 canvas using stroke with either x or y options behaves the same as repeat.

Here's the visual test:
![image](https://user-images.githubusercontent.com/73667022/176067155-1306da48-7466-473d-b970-83fe2fb3c834.png)

- [ ] Have you updated CHANGELOG.md?

closes #2049