### PR TITLE
Update instructions for OSX local build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ For detailed installation information, see the [wiki](https://github.com/Automat
 
 OS | Command
 ----- | -----
-OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib librsvg`
+OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman`
 Ubuntu | `sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev`
 Fedora | `sudo yum install gcc-c++ cairo-devel pango-devel libjpeg-turbo-devel giflib-devel`
 Solaris | `pkgin install cairo pango pkg-config xproto renderproto kbproto xextproto`


### PR DESCRIPTION
### Issue 
While testing the solution for a local build, I got the next output:
```sh
Package pixman-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `pixman-1.pc'
to the PKG_CONFIG_PATH environment variable
No package 'pixman-1' found
gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
```

### Solution
After updating the command to the following: `brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman`, I was able to generate a successful build.

```sh
brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman;
cd /node_modules/canva && npx node-gyp rebuild;
```

Thanks for contributing!

- [ ] Have you updated CHANGELOG.md?
