### PR TITLE
Parse rgba(r,g,b) correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Export `pangoVersion`
 ### Added
 ### Fixed
+* `rgba(r,g,b)` with no alpha should parse as opaque, not transparent. ([#2029](https://github.com/Automattic/node-canvas/issues/2029))
 
 2.9.3
 ==================

--- a/src/color.cc
+++ b/src/color.cc
@@ -225,12 +225,13 @@ parse_clipped_percentage(const char** pStr, float *pFraction) {
 #define LIGHTNESS(NAME) SATURATION(NAME)
 
 #define ALPHA(NAME) \
-  if (*str >= '1' && *str <= '9') { \
+    if (*str >= '1' && *str <= '9') { \
       NAME = 1; \
     } else { \
       if ('0' == *str) ++str; \
       if ('.' == *str) { \
         ++str; \
+        NAME = 0; \
         float n = .1f; \
         while (*str >= '0' && *str <= '9') { \
           NAME += (*str++ - '0') * n; \
@@ -630,7 +631,7 @@ rgba_from_rgba_string(const char *str, short *ok) {
     str += 5;
     WHITESPACE;
     uint8_t r = 0, g = 0, b = 0;
-    float a = 0;
+    float a = 1.f;
     CHANNEL(r);
     WHITESPACE_OR_COMMA;
     CHANNEL(g);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -202,6 +202,9 @@ describe('Canvas', function () {
     ctx.fillStyle = 'rgba(0, 0, 0, 42.42)'
     assert.equal('#000000', ctx.fillStyle)
 
+    ctx.fillStyle = 'rgba(255, 250, 255)';
+    assert.equal('#fffaff', ctx.fillStyle);
+
     // hsl / hsla tests
 
     ctx.fillStyle = 'hsl(0, 0%, 0%)'


### PR DESCRIPTION
`rgb()` and `rgba()` are supposed to have identical grammar and behavior: https://www.w3.org/TR/css-color-4/#rgb-functions.

Fixes #2029

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
