### PR TITLE
Add WPT tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "test": "mocha test/*.test.js",
     "pretest-server": "node-gyp build",
     "test-server": "node test/server.js",
+    "generate-wpt": "node ./test/wpt/generate.js",
+    "test-wpt": "mocha test/wpt/generated/*.js",
     "install": "node-pre-gyp install --fallback-to-build --update-binary",
     "dtslint": "dtslint types"
   },
@@ -57,6 +59,7 @@
     "assert-rejects": "^1.0.0",
     "dtslint": "^4.0.7",
     "express": "^4.16.3",
+    "js-yaml": "^4.1.0",
     "mocha": "^5.2.0",
     "pixelmatch": "^4.0.2",
     "standard": "^12.0.1",

--- a/test/wpt/drawing-text-to-the-canvas.yaml
+++ b/test/wpt/drawing-text-to-the-canvas.yaml
@@ -1,0 +1,1061 @@
+- name: 2d.text.draw.fill.basic
+  desc: fillText draws filled text
+  manual:
+  testing:
+  - 2d.text.draw
+  - 2d.text.draw.fill
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('PASS', 5, 35);
+  expected: &passfill |
+    size 100 50
+    cr.set_source_rgb(0, 0, 0)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    cr.set_source_rgb(0, 1, 0)
+    cr.select_font_face("Arial")
+    cr.set_font_size(35)
+    cr.translate(5, 35)
+    cr.text_path("PASS")
+    cr.fill()
+
+- name: 2d.text.draw.fill.unaffected
+  desc: fillText does not start a new path or subpath
+  testing:
+  - 2d.text.draw.fill
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('FAIL', 5, 35);
+
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 5,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.text.draw.fill.rtl
+  desc: fillText respects Right-To-Left Override characters
+  manual:
+  testing:
+  - 2d.text.draw
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('\u202eFAIL \xa0 \xa0 SSAP', 5, 35);
+  expected: *passfill
+- name: 2d.text.draw.fill.maxWidth.large
+  desc: fillText handles maxWidth correctly
+  manual:
+  testing:
+  - 2d.text.draw.maxwidth
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('PASS', 5, 35, 200);
+  expected: *passfill
+- name: 2d.text.draw.fill.maxWidth.small
+  desc: fillText handles maxWidth correctly
+  testing:
+  - 2d.text.draw.maxwidth
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('fail fail fail fail fail', -100, 35, 90);
+    _assertGreen(ctx, 100, 50);
+  expected: green
+
+- name: 2d.text.draw.fill.maxWidth.zero
+  desc: fillText handles maxWidth correctly
+  testing:
+  - 2d.text.draw.maxwidth
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('fail fail fail fail fail', 5, 35, 0);
+    _assertGreen(ctx, 100, 50);
+  expected: green
+
+- name: 2d.text.draw.fill.maxWidth.negative
+  desc: fillText handles maxWidth correctly
+  testing:
+  - 2d.text.draw.maxwidth
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('fail fail fail fail fail', 5, 35, -1);
+    _assertGreen(ctx, 100, 50);
+  expected: green
+
+- name: 2d.text.draw.fill.maxWidth.NaN
+  desc: fillText handles maxWidth correctly
+  testing:
+  - 2d.text.draw.maxwidth
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.font = '35px Arial, sans-serif';
+    ctx.fillText('fail fail fail fail fail', 5, 35, NaN);
+    _assertGreen(ctx, 100, 50);
+  expected: green
+
+- name: 2d.text.draw.stroke.basic
+  desc: strokeText draws stroked text
+  manual:
+  testing:
+  - 2d.text.draw
+  - 2d.text.draw.stroke
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.fillStyle = '#f00';
+    ctx.lineWidth = 1;
+    ctx.font = '35px Arial, sans-serif';
+    ctx.strokeText('PASS', 5, 35);
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0, 0, 0)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    cr.set_source_rgb(0, 1, 0)
+    cr.select_font_face("Arial")
+    cr.set_font_size(35)
+    cr.set_line_width(1)
+    cr.translate(5, 35)
+    cr.text_path("PASS")
+    cr.stroke()
+
+- name: 2d.text.draw.stroke.unaffected
+  desc: strokeText does not start a new path or subpath
+  testing:
+  - 2d.text.draw.stroke
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+
+    ctx.font = '35px Arial, sans-serif';
+    ctx.strokeStyle = '#f00';
+    ctx.strokeText('FAIL', 5, 35);
+
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 5,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.text.draw.kern.consistent
+  desc: Stroked and filled text should have exactly the same kerning so it overlaps
+  manual:
+  testing:
+  - 2d.text.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 3;
+    ctx.font = '20px Arial, sans-serif';
+    ctx.fillText('VAVAVAVAVAVAVA', -50, 25);
+    ctx.fillText('ToToToToToToTo', -50, 45);
+    ctx.strokeText('VAVAVAVAVAVAVA', -50, 25);
+    ctx.strokeText('ToToToToToToTo', -50, 45);
+  expected: green
+
+# CanvasTest is:
+#   A = (0, 0) to (1em, 0.75em)       (above baseline)
+#   B = (0, 0) to (1em, -0.25em)      (below baseline)
+#   C = (0, -0.25em) to (1em, 0.75em) (the em square) plus some Xs above and below
+#   D = (0, -0.25em) to (1em, 0.75em) (the em square) plus some Xs left and right
+#   E = (0, -0.25em) to (1em, 0.75em) (the em square)
+#   space = empty, 1em wide
+#
+# At 50px, "E" will fill the canvas vertically
+# At 67px, "A" will fill the canvas vertically
+#
+# Ideographic baseline  is 0.125em above alphabetic
+# Mathematical baseline is 0.375em above alphabetic
+# Hanging baseline      is 0.500em above alphabetic
+
+# WebKit doesn't block onload on font loads, so we try to make it a bit more reliable
+# by waiting with step_timeout after load before drawing
+
+- name: 2d.text.draw.fill.maxWidth.fontface
+  desc: fillText works on @font-face fonts
+  testing:
+  - 2d.text.draw.maxwidth
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#0f0';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#f00';
+        ctx.fillText('EEEE', -50, 37.5, 40);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.fill.maxWidth.bound
+  desc: fillText handles maxWidth based on line size, not bounding box size
+  testing:
+  - 2d.text.draw.maxwidth
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('DD', 0, 37.5, 100);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.fontface
+  testing:
+  - 2d.text.font.fontface
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '67px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('AA', 0, 50);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.fontface.repeat
+  desc: Draw with the font immediately, then wait a bit until and draw again. (This
+    crashes some version of WebKit.)
+  testing:
+  - 2d.text.font.fontface
+  fonts:
+  - CanvasTest
+  fonthack: 0
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.font = '67px CanvasTest';
+    ctx.fillStyle = '#0f0';
+    ctx.fillText('AA', 0, 50);
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillText('AA', 0, 50);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.fontface.notinpage
+  desc: '@font-face fonts should work even if they are not used in the page'
+  testing:
+  - 2d.text.font.fontface
+  fonts:
+  - CanvasTest
+  fonthack: 0
+  code: |
+    ctx.font = '67px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('AA', 0, 50);
+        @assert pixel 5,5 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 95,5 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 25,25 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 75,25 ==~ 0,255,0,255; @moz-todo
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.left
+  desc: textAlign left is the left of the first em square (not the bounding box)
+  testing:
+  - 2d.text.align.left
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'left';
+        ctx.fillText('DD', 0, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.right
+  desc: textAlign right is the right of the last em square (not the bounding box)
+  testing:
+  - 2d.text.align.right
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'right';
+        ctx.fillText('DD', 100, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.start.ltr
+  desc: textAlign start with ltr is the left edge
+  testing:
+  - 2d.text.align.left
+  fonts:
+  - CanvasTest
+  canvas: width="100" height="50" dir="ltr"
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'start';
+        ctx.fillText('DD', 0, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.start.rtl
+  desc: textAlign start with rtl is the right edge
+  testing:
+  - 2d.text.align.right
+  - 2d.text.draw.direction
+  fonts:
+  - CanvasTest
+  canvas: width="100" height="50" dir="rtl"
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'start';
+        ctx.fillText('DD', 100, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.end.ltr
+  desc: textAlign end with ltr is the right edge
+  testing:
+  - 2d.text.align.right
+  fonts:
+  - CanvasTest
+  canvas: width="100" height="50" dir="ltr"
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'end';
+        ctx.fillText('DD', 100, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.end.rtl
+  desc: textAlign end with rtl is the left edge
+  testing:
+  - 2d.text.align.left
+  - 2d.text.draw.direction
+  fonts:
+  - CanvasTest
+  canvas: width="100" height="50" dir="rtl"
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'end';
+        ctx.fillText('DD', 0, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.align.center
+  desc: textAlign center is the center of the em squares (not the bounding box)
+  testing:
+  - 2d.text.align.center
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'center';
+        ctx.fillText('DD', 50, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+
+- name: 2d.text.draw.space.basic
+  desc: U+0020 is rendered the correct size (1em wide)
+  testing:
+  - 2d.text.draw.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('E EE', -100, 37.5);
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.space.collapse.nonspace
+  desc: Non-space characters are not converted to U+0020 and collapsed
+  testing:
+  - 2d.text.draw.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('E\x0b EE', -150, 37.5);
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.measure.width.basic
+  desc: The width of character is same as font used
+  testing:
+  - 2d.text.measure
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            @assert ctx.measureText('A').width === 50;
+            @assert ctx.measureText('AA').width === 100;
+            @assert ctx.measureText('ABCD').width === 200;
+
+            ctx.font = '100px CanvasTest';
+            @assert ctx.measureText('A').width === 100;
+        }), 500);
+    });
+
+- name: 2d.text.measure.width.empty
+  desc: The empty string has zero width
+  testing:
+  - 2d.text.measure
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            @assert ctx.measureText("").width === 0;
+        }), 500);
+    });
+
+- name: 2d.text.measure.advances
+  desc: Testing width advances
+  testing:
+  - 2d.text.measure.advances
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            ctx.direction = 'ltr';
+            ctx.align = 'left'
+            // Some platforms may return '-0'.
+            @assert Math.abs(ctx.measureText('Hello').advances[0]) === 0;
+            // Different platforms may render text slightly different.
+            @assert ctx.measureText('Hello').advances[1] >= 36;
+            @assert ctx.measureText('Hello').advances[2] >= 58;
+            @assert ctx.measureText('Hello').advances[3] >= 70;
+            @assert ctx.measureText('Hello').advances[4] >= 80;
+
+            var tm = ctx.measureText('Hello');
+            @assert ctx.measureText('Hello').advances[0] === tm.advances[0];
+            @assert ctx.measureText('Hello').advances[1] === tm.advances[1];
+            @assert ctx.measureText('Hello').advances[2] === tm.advances[2];
+            @assert ctx.measureText('Hello').advances[3] === tm.advances[3];
+            @assert ctx.measureText('Hello').advances[4] === tm.advances[4];
+        }), 500);
+    });
+
+- name: 2d.text.measure.actualBoundingBox
+  desc: Testing actualBoundingBox
+  testing:
+  - 2d.text.measure.actualBoundingBox
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            ctx.direction = 'ltr';
+            ctx.align = 'left'
+            ctx.baseline = 'alphabetic'
+            // Different platforms may render text slightly different.
+            // Values that are nominally expected to be zero might actually vary by a pixel or so
+            // if the UA accounts for antialiasing at glyph edges, so we allow a slight deviation.
+            @assert Math.abs(ctx.measureText('A').actualBoundingBoxLeft) <= 1;
+            @assert ctx.measureText('A').actualBoundingBoxRight >= 50;
+            @assert ctx.measureText('A').actualBoundingBoxAscent >= 35;
+            @assert Math.abs(ctx.measureText('A').actualBoundingBoxDescent) <= 1;
+
+            @assert ctx.measureText('D').actualBoundingBoxLeft >= 48;
+            @assert ctx.measureText('D').actualBoundingBoxLeft <= 52;
+            @assert ctx.measureText('D').actualBoundingBoxRight >= 75;
+            @assert ctx.measureText('D').actualBoundingBoxRight <= 80;
+            @assert ctx.measureText('D').actualBoundingBoxAscent >= 35;
+            @assert ctx.measureText('D').actualBoundingBoxAscent <= 40;
+            @assert ctx.measureText('D').actualBoundingBoxDescent >= 12;
+            @assert ctx.measureText('D').actualBoundingBoxDescent <= 15;
+
+            @assert Math.abs(ctx.measureText('ABCD').actualBoundingBoxLeft) <= 1;
+            @assert ctx.measureText('ABCD').actualBoundingBoxRight >= 200;
+            @assert ctx.measureText('ABCD').actualBoundingBoxAscent >= 85;
+            @assert ctx.measureText('ABCD').actualBoundingBoxDescent >= 37;
+        }), 500);
+    });
+
+- name: 2d.text.measure.fontBoundingBox
+  desc: Testing fontBoundingBox
+  testing:
+  - 2d.text.measure.fontBoundingBox
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            ctx.direction = 'ltr';
+            ctx.align = 'left'
+            @assert ctx.measureText('A').fontBoundingBoxAscent === 85;
+            @assert ctx.measureText('A').fontBoundingBoxDescent === 39;
+
+            @assert ctx.measureText('ABCD').fontBoundingBoxAscent === 85;
+            @assert ctx.measureText('ABCD').fontBoundingBoxDescent === 39;
+        }), 500);
+    });
+
+- name: 2d.text.measure.fontBoundingBox.ahem
+  desc: Testing fontBoundingBox for font ahem
+  testing:
+  - 2d.text.measure.fontBoundingBox
+  fonts:
+  - Ahem
+  code: |
+    deferTest();
+    var f = new FontFace("Ahem", "/fonts/Ahem.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px Ahem';
+            ctx.direction = 'ltr';
+            ctx.align = 'left'
+            @assert ctx.measureText('A').fontBoundingBoxAscent === 40;
+            @assert ctx.measureText('A').fontBoundingBoxDescent === 10;
+
+            @assert ctx.measureText('ABCD').fontBoundingBoxAscent === 40;
+            @assert ctx.measureText('ABCD').fontBoundingBoxDescent === 10;
+        }), 500);
+    });
+
+- name: 2d.text.measure.emHeights
+  desc: Testing emHeights
+  testing:
+  - 2d.text.measure.emHeights
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+         step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            ctx.direction = 'ltr';
+            ctx.align = 'left'
+            @assert ctx.measureText('A').emHeightAscent === 37.5;
+            @assert ctx.measureText('A').emHeightDescent === 12.5;
+            @assert ctx.measureText('A').emHeightDescent + ctx.measureText('A').emHeightAscent === 50;
+
+            @assert ctx.measureText('ABCD').emHeightAscent === 37.5;
+            @assert ctx.measureText('ABCD').emHeightDescent === 12.5;
+            @assert ctx.measureText('ABCD').emHeightDescent + ctx.measureText('ABCD').emHeightAscent === 50;
+        }), 500);
+    });
+
+- name: 2d.text.measure.baselines
+  desc: Testing baselines
+  testing:
+  - 2d.text.measure.baselines
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+         step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            ctx.direction = 'ltr';
+            ctx.align = 'left'
+            @assert Math.abs(ctx.measureText('A').getBaselines().alphabetic) === 0;
+            @assert ctx.measureText('A').getBaselines().ideographic === -39;
+            @assert ctx.measureText('A').getBaselines().hanging === 68;
+
+            @assert Math.abs(ctx.measureText('ABCD').getBaselines().alphabetic) === 0;
+            @assert ctx.measureText('ABCD').getBaselines().ideographic === -39;
+            @assert ctx.measureText('ABCD').getBaselines().hanging === 68;
+        }), 500);
+    });
+
+- name: 2d.text.drawing.style.spacing
+  desc: Testing letter spacing and word spacing
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+
+    ctx.letterSpacing = '3px';
+    @assert ctx.letterSpacing === '3px';
+    @assert ctx.wordSpacing === '0px';
+
+    ctx.wordSpacing = '5px';
+    @assert ctx.letterSpacing === '3px';
+    @assert ctx.wordSpacing === '5px';
+
+    ctx.letterSpacing = '-1px';
+    ctx.wordSpacing = '-1px';
+    @assert ctx.letterSpacing === '-1px';
+    @assert ctx.wordSpacing === '-1px';
+
+    ctx.letterSpacing = '1PX';
+    ctx.wordSpacing = '1EM';
+    @assert ctx.letterSpacing === '1px';
+    @assert ctx.wordSpacing === '1em';
+
+- name: 2d.text.drawing.style.nonfinite.spacing
+  desc: Testing letter spacing and word spacing with nonfinite inputs
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+
+    function test_word_spacing(value) {
+      ctx.wordSpacing = value;
+      ctx.letterSpacing = value;
+      @assert ctx.wordSpacing === '0px';
+      @assert ctx.letterSpacing === '0px';
+    }
+    @nonfinite test_word_spacing(<0 NaN Infinity -Infinity>);
+
+- name: 2d.text.drawing.style.invalid.spacing
+  desc: Testing letter spacing and word spacing with invalid units
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+
+    function test_word_spacing(value) {
+      ctx.wordSpacing = value;
+      ctx.letterSpacing = value;
+      @assert ctx.wordSpacing === '0px';
+      @assert ctx.letterSpacing === '0px';
+    }
+    @nonfinite test_word_spacing(< '0s' '1min' '1deg' '1pp'>);
+
+- name: 2d.text.drawing.style.letterSpacing.measure
+  desc: Testing letter spacing and word spacing
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+    var width_normal = ctx.measureText('Hello World').width;
+
+    function test_letter_spacing(value, difference_spacing, epsilon) {
+      ctx.letterSpacing = value;
+      @assert ctx.letterSpacing === value;
+      @assert ctx.wordSpacing === '0px';
+      width_with_letter_spacing = ctx.measureText('Hello World').width;
+      assert_approx_equals(width_with_letter_spacing, width_normal + difference_spacing, epsilon, "letter spacing doesn't work.");
+    }
+
+    // The first value is the letter Spacing to be set, the second value the
+    // change in length of string 'Hello World', note that there are 11 letters
+    // in 'hello world', so the length difference is always letterSpacing * 11.
+    // and the third value is the acceptable differencee for the length change,
+    // note that unit such as 1cm/1mm doesn't map to an exact pixel value.
+    test_cases = [['3px', 33, 0],
+                  ['5px', 55, 0],
+                  ['-2px', -22, 0],
+                  ['1em', 110, 0],
+                  ['1in', 1056, 0],
+                  ['-0.1cm', -41.65, 0.2],
+                  ['-0.6mm', -24,95, 0.2]]
+
+    for (const test_case of test_cases) {
+      test_letter_spacing(test_case[0], test_case[1], test_case[2]);
+    }
+
+- name: 2d.text.drawing.style.wordSpacing.measure
+  desc: Testing if word spacing is working properly
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+    var width_normal = ctx.measureText('Hello World, again').width;
+
+    function test_word_spacing(value, difference_spacing, epsilon) {
+      ctx.wordSpacing = value;
+      @assert ctx.letterSpacing === '0px';
+      @assert ctx.wordSpacing === value;
+      width_with_word_spacing = ctx.measureText('Hello World, again').width;
+      assert_approx_equals(width_with_word_spacing, width_normal + difference_spacing, epsilon, "word spacing doesn't work.");
+    }
+
+    // The first value is the word Spacing to be set, the second value the
+    // change in length of string 'Hello World', note that there are 2 words
+    // in 'Hello World, again', so the length difference is always wordSpacing * 2.
+    // and the third value is the acceptable differencee for the length change,
+    // note that unit such as 1cm/1mm doesn't map to an exact pixel value.
+    test_cases = [['3px', 6, 0],
+                  ['5px', 10, 0],
+                  ['-2px', -4, 0],
+                  ['1em', 20, 0],
+                  ['1in', 192, 0],
+                  ['-0.1cm', -7.57, 0.2],
+                  ['-0.6mm', -4.54, 0.2]]
+
+    for (const test_case of test_cases) {
+      test_word_spacing(test_case[0], test_case[1], test_case[2]);
+    }
+
+- name: 2d.text.drawing.style.letterSpacing.change.font
+  desc: Set letter spacing and word spacing to font dependent value and verify it works after font change.
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+    // Get the width for 'Hello World' at default size, 10px.
+    var width_normal = ctx.measureText('Hello World').width;
+
+    ctx.letterSpacing = '1em';
+    @assert ctx.letterSpacing === '1em';
+    // 1em = 10px. Add 10px after each letter in "Hello World",
+    // makes it 110px longer.
+    var width_with_spacing = ctx.measureText('Hello World').width;
+    @assert width_with_spacing === width_normal + 110;
+
+    // Changing font to 20px. Without resetting the spacing, 1em letterSpacing
+    // is now 20px, so it's suppose to be 220px longer without any letterSpacing set.
+    ctx.font = '20px serif';
+    width_with_spacing = ctx.measureText('Hello World').width;
+    // Now calculate the reference spacing for "Hello World" with no spacing.
+    ctx.letterSpacing = '0em';
+    width_normal = ctx.measureText('Hello World').width;
+    @assert width_with_spacing === width_normal + 220;
+
+- name: 2d.text.drawing.style.wordSpacing.change.font
+  desc: Set word spacing and word spacing to font dependent value and verify it works after font change.
+  testing:
+  - 2d.text.drawing.style.spacing
+  code: |
+    @assert ctx.letterSpacing === '0px';
+    @assert ctx.wordSpacing === '0px';
+    // Get the width for 'Hello World, again' at default size, 10px.
+    var width_normal = ctx.measureText('Hello World, again').width;
+
+    ctx.wordSpacing = '1em';
+    @assert ctx.wordSpacing === '1em';
+    // 1em = 10px. Add 10px after each word in "Hello World, again",
+    // makes it 20px longer.
+    var width_with_spacing = ctx.measureText('Hello World, again').width;
+    @assert width_with_spacing === width_normal + 20;
+
+    // Changing font to 20px. Without resetting the spacing, 1em wordSpacing
+    // is now 20px, so it's suppose to be 40px longer without any wordSpacing set.
+    ctx.font = '20px serif';
+    width_with_spacing = ctx.measureText('Hello World, again').width;
+    // Now calculate the reference spacing for "Hello World, again" with no spacing.
+    ctx.wordSpacing = '0em';
+    width_normal = ctx.measureText('Hello World, again').width;
+    @assert width_with_spacing === width_normal + 40;
+
+- name: 2d.text.drawing.style.fontKerning
+  desc: Testing basic functionalities of fontKerning for canvas
+  testing:
+  - 2d.text.drawing.style.fontKerning
+  code: |
+    @assert ctx.fontKerning === "auto";
+    ctx.fontKerning = "normal";
+    @assert ctx.fontKerning === "normal";
+    width_normal = ctx.measureText("TAWATAVA").width;
+    ctx.fontKerning = "none";
+    @assert ctx.fontKerning === "none";
+    width_none = ctx.measureText("TAWATAVA").width;
+    @assert width_normal < width_none;
+
+- name: 2d.text.drawing.style.fontKerning.with.uppercase
+  desc: Testing basic functionalities of fontKerning for canvas
+  testing:
+  - 2d.text.drawing.style.fontKerning
+  code: |
+    @assert ctx.fontKerning === "auto";
+    ctx.fontKerning = "Normal";
+    @assert ctx.fontKerning === "normal";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "normal";
+    @assert ctx.fontKerning === "normal";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "noRmal";
+    @assert ctx.fontKerning === "normal";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "NoRMal";
+    @assert ctx.fontKerning === "normal";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "NORMAL";
+    @assert ctx.fontKerning === "normal";
+
+    ctx.fontKerning = "None";
+    @assert ctx.fontKerning === "none";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "none";
+    @assert ctx.fontKerning === "none";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "nOne";
+    @assert ctx.fontKerning === "none";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "nonE";
+    @assert ctx.fontKerning === "none";
+    ctx.fontKerning = "Auto";
+    ctx.fontKerning = "NONE";
+    @assert ctx.fontKerning === "none";
+
+- name: 2d.text.drawing.style.fontVariant.settings
+  desc: Testing basic functionalities of fontKerning for canvas
+  testing:
+  - 2d.text.drawing.style.fontVariantCaps
+  code: |
+    // Setting fontVariantCaps with lower cases
+    @assert ctx.fontVariantCaps === "normal";
+
+    ctx.fontVariantCaps = "normal";
+    @assert ctx.fontVariantCaps === "normal";
+
+    ctx.fontVariantCaps = "small-caps";
+    @assert ctx.fontVariantCaps === "small-caps";
+
+    ctx.fontVariantCaps = "all-small-caps";
+    @assert ctx.fontVariantCaps === "all-small-caps";
+
+    ctx.fontVariantCaps = "petite-caps";
+    @assert ctx.fontVariantCaps === "petite-caps";
+
+    ctx.fontVariantCaps = "all-petite-caps";
+    @assert ctx.fontVariantCaps === "all-petite-caps";
+
+    ctx.fontVariantCaps = "unicase";
+    @assert ctx.fontVariantCaps === "unicase";
+
+    ctx.fontVariantCaps = "titling-caps";
+    @assert ctx.fontVariantCaps === "titling-caps";
+
+    // Setting fontVariantCaps with lower cases and upper cases word.
+    ctx.fontVariantCaps = "nORmal";
+    @assert ctx.fontVariantCaps === "normal";
+
+    ctx.fontVariantCaps = "smaLL-caps";
+    @assert ctx.fontVariantCaps === "small-caps";
+
+    ctx.fontVariantCaps = "all-small-CAPS";
+    @assert ctx.fontVariantCaps === "all-small-caps";
+
+    ctx.fontVariantCaps = "pEtitE-caps";
+    @assert ctx.fontVariantCaps === "petite-caps";
+
+    ctx.fontVariantCaps = "All-Petite-Caps";
+    @assert ctx.fontVariantCaps === "all-petite-caps";
+
+    ctx.fontVariantCaps = "uNIcase";
+    @assert ctx.fontVariantCaps === "unicase";
+
+    ctx.fontVariantCaps = "titling-CAPS";
+    @assert ctx.fontVariantCaps === "titling-caps";
+
+    // Setting fontVariantCaps with non-existing font variant.
+    ctx.fontVariantCaps = "abcd";
+    @assert ctx.fontVariantCaps === "titling-caps";
+
+- name: 2d.text.drawing.style.textRendering.settings
+  desc: Testing basic functionalities of textRendering in Canvas
+  testing:
+  - 2d.text.drawing.style.textRendering
+  code: |
+    // Setting textRendering with lower cases
+    @assert ctx.textRendering === "auto";
+
+    ctx.textRendering = "auto";
+    @assert ctx.textRendering === "auto";
+
+    ctx.textRendering = "optimizespeed";
+    @assert ctx.textRendering === "optimizeSpeed";
+
+    ctx.textRendering = "optimizelegibility";
+    @assert ctx.textRendering === "optimizeLegibility";
+
+    ctx.textRendering = "geometricprecision";
+    @assert ctx.textRendering === "geometricPrecision";
+
+    // Setting textRendering with lower cases and upper cases word.
+    ctx.textRendering = "aUto";
+    @assert ctx.textRendering === "auto";
+
+    ctx.textRendering = "OPtimizeSpeed";
+    @assert ctx.textRendering === "optimizeSpeed";
+
+    ctx.textRendering = "OPtimizELEgibility";
+    @assert ctx.textRendering === "optimizeLegibility";
+
+    ctx.textRendering = "GeometricPrecision";
+    @assert ctx.textRendering === "geometricPrecision";
+
+    // Setting textRendering with non-existing font variant.
+    ctx.textRendering = "abcd";
+    @assert ctx.textRendering === "geometricPrecision";
+
+# TODO: shadows, alpha, composite, clip

--- a/test/wpt/fill-and-stroke-styles.yaml
+++ b/test/wpt/fill-and-stroke-styles.yaml
@@ -1,0 +1,2244 @@
+- name: 2d.fillStyle.parse.current.basic
+  desc: currentColor is computed from the canvas element
+  testing:
+  - 2d.colors.parse
+  - 2d.currentColor.onset
+  code: |
+    canvas.setAttribute('style', 'color: #0f0');
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = 'currentColor';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.fillStyle.parse.current.changed
+  desc: currentColor is computed when the attribute is set, not when it is painted
+  testing:
+  - 2d.colors.parse
+  - 2d.currentColor.onset
+  code: |
+    canvas.setAttribute('style', 'color: #0f0');
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = 'currentColor';
+    canvas.setAttribute('style', 'color: #f00');
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.fillStyle.parse.current.removed
+  desc: currentColor is solid black when the canvas element is not in a document
+  testing:
+  - 2d.colors.parse
+  - 2d.currentColor.outofdoc
+  code: |
+    // Try not to let it undetectably incorrectly pick up opaque-black
+    // from other parts of the document:
+    document.body.parentNode.setAttribute('style', 'color: #f00');
+    document.body.setAttribute('style', 'color: #f00');
+    canvas.setAttribute('style', 'color: #f00');
+
+    var canvas2 = document.createElement('canvas');
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#f00';
+    ctx2.fillStyle = 'currentColor';
+    ctx2.fillRect(0, 0, 100, 50);
+    ctx.drawImage(canvas2, 0, 0);
+
+    document.body.parentNode.removeAttribute('style');
+    document.body.removeAttribute('style');
+
+    @assert pixel 50,25 == 0,0,0,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0, 0, 0)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.fillStyle.invalidstring
+  testing:
+  - 2d.colors.invalidstring
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillStyle = 'invalid';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.fillStyle.invalidtype
+  testing:
+  - 2d.colors.invalidtype
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillStyle = null;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.fillStyle.get.solid
+  testing:
+  - 2d.colors.getcolor
+  - 2d.serializecolor.solid
+  code: |
+    ctx.fillStyle = '#fa0';
+    @assert ctx.fillStyle === '#ffaa00';
+
+- name: 2d.fillStyle.get.semitransparent
+  testing:
+  - 2d.colors.getcolor
+  - 2d.serializecolor.transparent
+  code: |
+    ctx.fillStyle = 'rgba(255,255,255,0.45)';
+    @assert ctx.fillStyle =~ /^rgba\(255, 255, 255, 0\.4\d+\)$/;
+
+- name: 2d.fillStyle.get.halftransparent
+  testing:
+  - 2d.colors.getcolor
+  - 2d.serializecolor.transparent
+  code: |
+    ctx.fillStyle = 'rgba(255,255,255,0.5)';
+    @assert ctx.fillStyle === 'rgba(255, 255, 255, 0.5)';
+
+- name: 2d.fillStyle.get.transparent
+  testing:
+  - 2d.colors.getcolor
+  - 2d.serializecolor.transparent
+  code: |
+    ctx.fillStyle = 'rgba(0,0,0,0)';
+    @assert ctx.fillStyle === 'rgba(0, 0, 0, 0)';
+
+- name: 2d.fillStyle.default
+  testing:
+  - 2d.colors.default
+  code: |
+    @assert ctx.fillStyle === '#000000';
+
+- name: 2d.fillStyle.toStringFunctionCallback
+  desc: Passing a function in to ctx.fillStyle or ctx.strokeStyle with a toString callback works as specified
+  testing:
+    2d.colors.toStringFunctionCallback
+  code: |
+    ctx.fillStyle = { toString: function() { return "#008000"; } };
+    @assert ctx.fillStyle === "#008000";
+    ctx.fillStyle = {};
+    @assert ctx.fillStyle === "#008000";
+    ctx.fillStyle = 800000;
+    @assert ctx.fillStyle === "#008000";
+    @assert throws TypeError ctx.fillStyle = { toString: function() { throw new TypeError; } };
+    ctx.strokeStyle = { toString: function() { return "#008000"; } };
+    @assert ctx.strokeStyle === "#008000";
+    ctx.strokeStyle = {};
+    @assert ctx.strokeStyle === "#008000";
+    ctx.strokeStyle = 800000;
+    @assert ctx.strokeStyle === "#008000";
+    @assert throws TypeError ctx.strokeStyle = { toString: function() { throw new TypeError; } };
+
+- name: 2d.strokeStyle.default
+  testing:
+  - 2d.colors.default
+  code: |
+    @assert ctx.strokeStyle === '#000000';
+
+
+- name: 2d.gradient.object.type
+  desc: window.CanvasGradient exists and has the right properties
+  testing:
+  - 2d.canvasGradient.type
+  notes: &bindings Defined in "Web IDL" (draft)
+  code: |
+    @assert window.CanvasGradient !== undefined;
+    @assert window.CanvasGradient.prototype.addColorStop !== undefined;
+
+- name: 2d.gradient.object.return
+  desc: createLinearGradient() and createRadialGradient() returns objects implementing
+    CanvasGradient
+  testing:
+  - 2d.gradient.linear.return
+  - 2d.gradient.radial.return
+  code: |
+    window.CanvasGradient.prototype.thisImplementsCanvasGradient = true;
+
+    var g1 = ctx.createLinearGradient(0, 0, 100, 0);
+    @assert g1.addColorStop !== undefined;
+    @assert g1.thisImplementsCanvasGradient === true;
+
+    var g2 = ctx.createRadialGradient(0, 0, 10, 0, 0, 20);
+    @assert g2.addColorStop !== undefined;
+    @assert g2.thisImplementsCanvasGradient === true;
+
+- name: 2d.gradient.interpolate.solid
+  testing:
+  - 2d.gradient.interpolate.linear
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.interpolate.color
+  testing:
+  - 2d.gradient.interpolate.linear
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    g.addColorStop(0, '#ff0');
+    g.addColorStop(1, '#00f');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 25,25 ==~ 191,191,63,255 +/- 3;
+    @assert pixel 50,25 ==~ 127,127,127,255 +/- 3;
+    @assert pixel 75,25 ==~ 63,63,191,255 +/- 3;
+  expected: |
+    size 100 50
+    g = cairo.LinearGradient(0, 0, 100, 0)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.gradient.interpolate.alpha
+  testing:
+  - 2d.gradient.interpolate.linear
+  code: |
+    ctx.fillStyle = '#ff0';
+    ctx.fillRect(0, 0, 100, 50);
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    g.addColorStop(0, 'rgba(0,0,255, 0)');
+    g.addColorStop(1, 'rgba(0,0,255, 1)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 25,25 ==~ 191,191,63,255 +/- 3;
+    @assert pixel 50,25 ==~ 127,127,127,255 +/- 3;
+    @assert pixel 75,25 ==~ 63,63,191,255 +/- 3;
+  expected: |
+    size 100 50
+    g = cairo.LinearGradient(0, 0, 100, 0)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.gradient.interpolate.coloralpha
+  testing:
+  - 2d.gradient.interpolate.alpha
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    g.addColorStop(0, 'rgba(255,255,0, 0)');
+    g.addColorStop(1, 'rgba(0,0,255, 1)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 25,25 ==~ 190,190,65,65 +/- 3;
+    @assert pixel 50,25 ==~ 126,126,128,128 +/- 3;
+    @assert pixel 75,25 ==~ 62,62,192,192 +/- 3;
+  expected: |
+    size 100 50
+    g = cairo.LinearGradient(0, 0, 100, 0)
+    g.add_color_stop_rgba(0, 1,1,0, 0)
+    g.add_color_stop_rgba(1, 0,0,1, 1)
+    cr.set_source(g)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.gradient.interpolate.outside
+  testing:
+  - 2d.gradient.outside.first
+  - 2d.gradient.outside.last
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(25, 0, 75, 0);
+    g.addColorStop(0.4, '#0f0');
+    g.addColorStop(0.6, '#0f0');
+
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 20,25 ==~ 0,255,0,255;
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 80,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.interpolate.zerosize.fill
+  testing:
+  - 2d.gradient.linear.zerosize
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(50, 25, 50, 25); // zero-length line (undefined direction)
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.rect(0, 0, 100, 50);
+    ctx.fill();
+    @assert pixel 40,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.interpolate.zerosize.stroke
+  testing:
+  - 2d.gradient.linear.zerosize
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(50, 25, 50, 25); // zero-length line (undefined direction)
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.strokeStyle = g;
+    ctx.rect(20, 20, 60, 10);
+    ctx.stroke();
+    @assert pixel 19,19 == 0,255,0,255;
+    @assert pixel 20,19 == 0,255,0,255;
+    @assert pixel 21,19 == 0,255,0,255;
+    @assert pixel 19,20 == 0,255,0,255;
+    @assert pixel 20,20 == 0,255,0,255;
+    @assert pixel 21,20 == 0,255,0,255;
+    @assert pixel 19,21 == 0,255,0,255;
+    @assert pixel 20,21 == 0,255,0,255;
+    @assert pixel 21,21 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.interpolate.zerosize.fillRect
+  testing:
+  - 2d.gradient.linear.zerosize
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(50, 25, 50, 25); // zero-length line (undefined direction)
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 40,20 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.gradient.interpolate.zerosize.strokeRect
+  testing:
+  - 2d.gradient.linear.zerosize
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(50, 25, 50, 25); // zero-length line (undefined direction)
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.strokeStyle = g;
+    ctx.strokeRect(20, 20, 60, 10);
+    @assert pixel 19,19 == 0,255,0,255;
+    @assert pixel 20,19 == 0,255,0,255;
+    @assert pixel 21,19 == 0,255,0,255;
+    @assert pixel 19,20 == 0,255,0,255;
+    @assert pixel 20,20 == 0,255,0,255;
+    @assert pixel 21,20 == 0,255,0,255;
+    @assert pixel 19,21 == 0,255,0,255;
+    @assert pixel 20,21 == 0,255,0,255;
+    @assert pixel 21,21 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.interpolate.zerosize.fillText
+  testing:
+  - 2d.gradient.linear.zerosize
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(50, 25, 50, 25); // zero-length line (undefined direction)
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.font = '100px sans-serif';
+    ctx.fillText("AA", 0, 50);
+    _assertGreen(ctx, 100, 50);
+  expected: green
+
+- name: 2d.gradient.interpolate.zerosize.strokeText
+  testing:
+  - 2d.gradient.linear.zerosize
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(50, 25, 50, 25); // zero-length line (undefined direction)
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.strokeStyle = g;
+    ctx.font = '100px sans-serif';
+    ctx.strokeText("AA", 0, 50);
+    _assertGreen(ctx, 100, 50);
+  expected: green
+
+
+- name: 2d.gradient.interpolate.vertical
+  testing:
+  - 2d.gradient.interpolate.linear
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 0, 50);
+    g.addColorStop(0, '#ff0');
+    g.addColorStop(1, '#00f');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,12 ==~ 191,191,63,255 +/- 10;
+    @assert pixel 50,25 ==~ 127,127,127,255 +/- 5;
+    @assert pixel 50,37 ==~ 63,63,191,255 +/- 10;
+  expected: |
+    size 100 50
+    g = cairo.LinearGradient(0, 0, 0, 50)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.gradient.interpolate.multiple
+  testing:
+  - 2d.gradient.interpolate.linear
+  code: |
+    canvas.width = 200;
+    var g = ctx.createLinearGradient(0, 0, 200, 0);
+    g.addColorStop(0, '#ff0');
+    g.addColorStop(0.5, '#0ff');
+    g.addColorStop(1, '#f0f');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 200, 50);
+    @assert pixel 50,25 ==~ 127,255,127,255 +/- 3;
+    @assert pixel 100,25 ==~ 0,255,255,255 +/- 3;
+    @assert pixel 150,25 ==~ 127,127,255,255 +/- 3;
+  expected: |
+    size 200 50
+    g = cairo.LinearGradient(0, 0, 200, 0)
+    g.add_color_stop_rgb(0.0, 1,1,0)
+    g.add_color_stop_rgb(0.5, 0,1,1)
+    g.add_color_stop_rgb(1.0, 1,0,1)
+    cr.set_source(g)
+    cr.rectangle(0, 0, 200, 50)
+    cr.fill()
+
+- name: 2d.gradient.interpolate.overlap
+  testing:
+  - 2d.gradient.interpolate.overlap
+  code: |
+    canvas.width = 200;
+    var g = ctx.createLinearGradient(0, 0, 200, 0);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(0, '#ff0');
+    g.addColorStop(0.25, '#00f');
+    g.addColorStop(0.25, '#0f0');
+    g.addColorStop(0.25, '#0f0');
+    g.addColorStop(0.25, '#0f0');
+    g.addColorStop(0.25, '#ff0');
+    g.addColorStop(0.5, '#00f');
+    g.addColorStop(0.5, '#0f0');
+    g.addColorStop(0.75, '#00f');
+    g.addColorStop(0.75, '#f00');
+    g.addColorStop(0.75, '#ff0');
+    g.addColorStop(0.5, '#0f0');
+    g.addColorStop(0.5, '#0f0');
+    g.addColorStop(0.5, '#ff0');
+    g.addColorStop(1, '#00f');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 200, 50);
+    @assert pixel 49,25 ==~ 0,0,255,255 +/- 16;
+    @assert pixel 51,25 ==~ 255,255,0,255 +/- 16;
+    @assert pixel 99,25 ==~ 0,0,255,255 +/- 16;
+    @assert pixel 101,25 ==~ 255,255,0,255 +/- 16;
+    @assert pixel 149,25 ==~ 0,0,255,255 +/- 16;
+    @assert pixel 151,25 ==~ 255,255,0,255 +/- 16;
+  expected: |
+    size 200 50
+    g = cairo.LinearGradient(0, 0, 50, 0)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(0, 0, 50, 50)
+    cr.fill()
+
+    g = cairo.LinearGradient(50, 0, 100, 0)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(50, 0, 50, 50)
+    cr.fill()
+
+    g = cairo.LinearGradient(100, 0, 150, 0)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(100, 0, 50, 50)
+    cr.fill()
+
+    g = cairo.LinearGradient(150, 0, 200, 0)
+    g.add_color_stop_rgb(0, 1,1,0)
+    g.add_color_stop_rgb(1, 0,0,1)
+    cr.set_source(g)
+    cr.rectangle(150, 0, 50, 50)
+    cr.fill()
+
+- name: 2d.gradient.interpolate.overlap2
+  testing:
+  - 2d.gradient.interpolate.overlap
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    var ps = [ 0, 1/10, 1/4, 1/3, 1/2, 3/4, 1 ];
+    for (var p = 0; p < ps.length; ++p)
+    {
+            g.addColorStop(ps[p], '#0f0');
+            for (var i = 0; i < 15; ++i)
+                    g.addColorStop(ps[p], '#f00');
+            g.addColorStop(ps[p], '#0f0');
+    }
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 30,25 == 0,255,0,255;
+    @assert pixel 40,25 == 0,255,0,255;
+    @assert pixel 60,25 == 0,255,0,255;
+    @assert pixel 80,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.empty
+  testing:
+  - 2d.gradient.empty
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    var g = ctx.createLinearGradient(0, 0, 0, 50);
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.object.update
+  testing:
+  - 2d.gradient.update
+  code: |
+    var g = ctx.createLinearGradient(-100, 0, 200, 0);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    g.addColorStop(0.1, '#0f0');
+    g.addColorStop(0.9, '#0f0');
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.object.compare
+  testing:
+  - 2d.gradient.object
+  code: |
+    var g1 = ctx.createLinearGradient(0, 0, 100, 0);
+    var g2 = ctx.createLinearGradient(0, 0, 100, 0);
+    @assert g1 !== g2;
+    ctx.fillStyle = g1;
+    @assert ctx.fillStyle === g1;
+
+- name: 2d.gradient.object.crosscanvas
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    var g = document.createElement('canvas').getContext('2d').createLinearGradient(0, 0, 100, 0);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.object.current
+  testing:
+  - 2d.currentColor.gradient
+  code: |
+    canvas.setAttribute('style', 'color: #f00');
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    g.addColorStop(0, 'currentColor');
+    g.addColorStop(1, 'currentColor');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 ==~ 0,0,0,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0, 0, 0)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.gradient.object.invalidoffset
+  testing:
+  - 2d.gradient.invalidoffset
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    @assert throws INDEX_SIZE_ERR g.addColorStop(-1, '#000');
+    @assert throws INDEX_SIZE_ERR g.addColorStop(2, '#000');
+    @assert throws TypeError g.addColorStop(Infinity, '#000');
+    @assert throws TypeError g.addColorStop(-Infinity, '#000');
+    @assert throws TypeError g.addColorStop(NaN, '#000');
+
+- name: 2d.gradient.object.invalidcolor
+  testing:
+  - 2d.gradient.invalidcolor
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 100, 0);
+    @assert throws SYNTAX_ERR g.addColorStop(0, "");
+    @assert throws SYNTAX_ERR g.addColorStop(0, 'rgb(NaN%, NaN%, NaN%)');
+    @assert throws SYNTAX_ERR g.addColorStop(0, 'null');
+    @assert throws SYNTAX_ERR g.addColorStop(0, 'undefined');
+    @assert throws SYNTAX_ERR g.addColorStop(0, null);
+    @assert throws SYNTAX_ERR g.addColorStop(0, undefined);
+
+    var g = ctx.createRadialGradient(0, 0, 0, 100, 0, 0);
+    @assert throws SYNTAX_ERR g.addColorStop(0, "");
+    @assert throws SYNTAX_ERR g.addColorStop(0, 'rgb(NaN%, NaN%, NaN%)');
+    @assert throws SYNTAX_ERR g.addColorStop(0, 'null');
+    @assert throws SYNTAX_ERR g.addColorStop(0, 'undefined');
+    @assert throws SYNTAX_ERR g.addColorStop(0, null);
+    @assert throws SYNTAX_ERR g.addColorStop(0, undefined);
+
+
+- name: 2d.gradient.linear.nonfinite
+  desc: createLinearGradient() throws TypeError if arguments are not finite
+  notes: *bindings
+  testing:
+  - 2d.gradient.linear.nonfinite
+  code: |
+    @nonfinite @assert throws TypeError ctx.createLinearGradient(<0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>);
+
+- name: 2d.gradient.linear.transform.1
+  desc: Linear gradient coordinates are relative to the coordinate space at the time
+    of filling
+  testing:
+  - 2d.gradient.linear.transform
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 200, 0);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(0.25, '#0f0');
+    g.addColorStop(0.75, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.translate(-50, 0);
+    ctx.fillRect(50, 0, 100, 50);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.linear.transform.2
+  desc: Linear gradient coordinates are relative to the coordinate space at the time
+    of filling
+  testing:
+  - 2d.gradient.linear.transform
+  code: |
+    ctx.translate(100, 0);
+    var g = ctx.createLinearGradient(0, 0, 200, 0);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(0.25, '#0f0');
+    g.addColorStop(0.75, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.translate(-150, 0);
+    ctx.fillRect(50, 0, 100, 50);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.linear.transform.3
+  desc: Linear gradient transforms do not experience broken caching effects
+  testing:
+  - 2d.gradient.linear.transform
+  code: |
+    var g = ctx.createLinearGradient(0, 0, 200, 0);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(0.25, '#0f0');
+    g.addColorStop(0.75, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.translate(-50, 0);
+    ctx.fillRect(50, 0, 100, 50);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.negative
+  desc: createRadialGradient() throws INDEX_SIZE_ERR if either radius is negative
+  testing:
+  - 2d.gradient.radial.negative
+  code: |
+    @assert throws INDEX_SIZE_ERR ctx.createRadialGradient(0, 0, -0.1, 0, 0, 1);
+    @assert throws INDEX_SIZE_ERR ctx.createRadialGradient(0, 0, 1, 0, 0, -0.1);
+    @assert throws INDEX_SIZE_ERR ctx.createRadialGradient(0, 0, -0.1, 0, 0, -0.1);
+
+- name: 2d.gradient.radial.nonfinite
+  desc: createRadialGradient() throws TypeError if arguments are not finite
+  notes: *bindings
+  testing:
+  - 2d.gradient.radial.nonfinite
+  code: |
+    @nonfinite @assert throws TypeError ctx.createRadialGradient(<0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>);
+
+- name: 2d.gradient.radial.inside1
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(50, 25, 100, 50, 25, 200);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.inside2
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(50, 25, 200, 50, 25, 100);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.inside3
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(50, 25, 200, 50, 25, 100);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(0.993, '#f00');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.outside1
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(200, 25, 10, 200, 25, 20);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.outside2
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(200, 25, 20, 200, 25, 10);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.outside3
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(200, 25, 20, 200, 25, 10);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(0.001, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.touch1
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(150, 25, 50, 200, 25, 100);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,1 == 0,255,0,255; @moz-todo
+    @assert pixel 98,1 == 0,255,0,255; @moz-todo
+    @assert pixel 1,25 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+    @assert pixel 98,25 == 0,255,0,255; @moz-todo
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 50,48 == 0,255,0,255; @moz-todo
+    @assert pixel 98,48 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.gradient.radial.touch2
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(-80, 25, 70, 0, 25, 150);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(0.01, '#0f0');
+    g.addColorStop(0.99, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.touch3
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(120, -15, 25, 140, -30, 50);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,1 == 0,255,0,255; @moz-todo
+    @assert pixel 98,1 == 0,255,0,255; @moz-todo
+    @assert pixel 1,25 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+    @assert pixel 98,25 == 0,255,0,255; @moz-todo
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 50,48 == 0,255,0,255; @moz-todo
+    @assert pixel 98,48 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.gradient.radial.equal
+  testing:
+  - 2d.gradient.radial.equal
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(50, 25, 20, 50, 25, 20);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,1 == 0,255,0,255; @moz-todo
+    @assert pixel 98,1 == 0,255,0,255; @moz-todo
+    @assert pixel 1,25 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+    @assert pixel 98,25 == 0,255,0,255; @moz-todo
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 50,48 == 0,255,0,255; @moz-todo
+    @assert pixel 98,48 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.gradient.radial.cone.behind
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(120, 25, 10, 211, 25, 100);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,1 == 0,255,0,255; @moz-todo
+    @assert pixel 98,1 == 0,255,0,255; @moz-todo
+    @assert pixel 1,25 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+    @assert pixel 98,25 == 0,255,0,255; @moz-todo
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 50,48 == 0,255,0,255; @moz-todo
+    @assert pixel 98,48 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.gradient.radial.cone.front
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(311, 25, 10, 210, 25, 100);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.cone.bottom
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(210, 25, 100, 230, 25, 101);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.cone.top
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(230, 25, 100, 100, 25, 101);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.cone.beside
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(0, 100, 40, 100, 100, 50);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,1 == 0,255,0,255; @moz-todo
+    @assert pixel 98,1 == 0,255,0,255; @moz-todo
+    @assert pixel 1,25 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+    @assert pixel 98,25 == 0,255,0,255; @moz-todo
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 50,48 == 0,255,0,255; @moz-todo
+    @assert pixel 98,48 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.gradient.radial.cone.cylinder
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(210, 25, 100, 230, 25, 100);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.cone.shape1
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    var tol = 1; // tolerance to avoid antialiasing artifacts
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(30+tol, 40);
+    ctx.lineTo(110, -20+tol);
+    ctx.lineTo(110, 100-tol);
+    ctx.fill();
+
+    var g = ctx.createRadialGradient(30+10*5/2, 40, 10*3/2, 30+10*15/4, 40, 10*9/4);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(1, '#0f0');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.cone.shape2
+  testing:
+  - 2d.gradient.radial.rendering
+  code: |
+    var tol = 1; // tolerance to avoid antialiasing artifacts
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var g = ctx.createRadialGradient(30+10*5/2, 40, 10*3/2, 30+10*15/4, 40, 10*9/4);
+    g.addColorStop(0, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(30-tol, 40);
+    ctx.lineTo(110, -20-tol);
+    ctx.lineTo(110, 100+tol);
+    ctx.fill();
+
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,1 == 0,255,0,255; @moz-todo
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.transform.1
+  desc: Radial gradient coordinates are relative to the coordinate space at the time
+    of filling
+  testing:
+  - 2d.gradient.radial.transform
+  code: |
+    var g = ctx.createRadialGradient(0, 0, 0, 0, 0, 11.2);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(0.5, '#0f0');
+    g.addColorStop(0.51, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.translate(50, 25);
+    ctx.scale(10, 10);
+    ctx.fillRect(-5, -2.5, 10, 5);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.transform.2
+  desc: Radial gradient coordinates are relative to the coordinate space at the time
+    of filling
+  testing:
+  - 2d.gradient.radial.transform
+  code: |
+    ctx.translate(100, 0);
+    var g = ctx.createRadialGradient(0, 0, 0, 0, 0, 11.2);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(0.5, '#0f0');
+    g.addColorStop(0.51, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.translate(-50, 25);
+    ctx.scale(10, 10);
+    ctx.fillRect(-5, -2.5, 10, 5);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.radial.transform.3
+  desc: Radial gradient transforms do not experience broken caching effects
+  testing:
+  - 2d.gradient.radial.transform
+  code: |
+    var g = ctx.createRadialGradient(0, 0, 0, 0, 0, 11.2);
+    g.addColorStop(0, '#0f0');
+    g.addColorStop(0.5, '#0f0');
+    g.addColorStop(0.51, '#f00');
+    g.addColorStop(1, '#f00');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.translate(50, 25);
+    ctx.scale(10, 10);
+    ctx.fillRect(-5, -2.5, 10, 5);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.conic.positive.rotation
+  desc: Conic gradient with positive rotation
+  code: |
+    const g = ctx.createConicGradient(3*Math.PI/2, 50, 25);
+    // It's red in the upper right region and green on the lower left region
+    g.addColorStop(0, "#f00");
+    g.addColorStop(0.25, "#0f0");
+    g.addColorStop(0.50, "#0f0");
+    g.addColorStop(0.75, "#f00");
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 25,15 == 255,0,0,255;
+    @assert pixel 75,40 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.conic.negative.rotation
+  desc: Conic gradient with negative rotation
+  code: |
+    const g = ctx.createConicGradient(-Math.PI/2, 50, 25);
+    // It's red in the upper right region and green on the lower left region
+    g.addColorStop(0, "#f00");
+    g.addColorStop(0.25, "#0f0");
+    g.addColorStop(0.50, "#0f0");
+    g.addColorStop(0.75, "#f00");
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 25,15 == 255,0,0,255;
+    @assert pixel 75,40 == 0,255,0,255;
+  expected: green
+
+- name: 2d.gradient.conic.invalid.inputs
+  desc: Conic gradient function with invalid inputs
+  code: |
+    @nonfinite @assert throws TypeError ctx.createConicGradient(<0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>);
+
+    const g = ctx.createConicGradient(0, 0, 25);
+    @nonfinite @assert throws TypeError g.addColorStop(<Infinity -Infinity NaN>, <'#f00'>);
+    @nonfinite @assert throws SYNTAX_ERR g.addColorStop(<0>, <Infinity -Infinity NaN>);
+
+- name: 2d.pattern.basic.type
+  testing:
+  - 2d.pattern.return
+  images:
+  - green.png
+  code: |
+    @assert window.CanvasPattern !== undefined;
+
+    window.CanvasPattern.prototype.thisImplementsCanvasPattern = true;
+
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    @assert pattern.thisImplementsCanvasPattern;
+
+- name: 2d.pattern.basic.image
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.basic.canvas
+  testing:
+  - 2d.pattern.painting
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#0f0';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.basic.zerocanvas
+  testing:
+  - 2d.pattern.zerocanvas
+  code: |
+    canvas.width = 0;
+    canvas.height = 10;
+    @assert canvas.width === 0;
+    @assert canvas.height === 10;
+    @assert throws INVALID_STATE_ERR ctx.createPattern(canvas, 'repeat');
+
+    canvas.width = 10;
+    canvas.height = 0;
+    @assert canvas.width === 10;
+    @assert canvas.height === 0;
+    @assert throws INVALID_STATE_ERR ctx.createPattern(canvas, 'repeat');
+
+    canvas.width = 0;
+    canvas.height = 0;
+    @assert canvas.width === 0;
+    @assert canvas.height === 0;
+    @assert throws INVALID_STATE_ERR ctx.createPattern(canvas, 'repeat');
+
+- name: 2d.pattern.basic.nocontext
+  testing:
+  - 2d.pattern.painting
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.transform.identity
+  testing:
+  - 2d.pattern.transform
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+    pattern.setTransform(new DOMMatrix());
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.transform.infinity
+  testing:
+  - 2d.pattern.transform
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+    pattern.setTransform({a: Infinity});
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.transform.invalid
+  testing:
+  - 2d.pattern.transform
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+    @assert throws TypeError pattern.setTransform({a: 1, m11: 2});
+
+- name: 2d.pattern.image.undefined
+  testing:
+  - 2d.pattern.IDL
+  notes: *bindings
+  code: |
+    @assert throws TypeError ctx.createPattern(undefined, 'repeat');
+
+- name: 2d.pattern.image.null
+  testing:
+  - 2d.pattern.IDL
+  notes: *bindings
+  code: |
+    @assert throws TypeError ctx.createPattern(null, 'repeat');
+
+- name: 2d.pattern.image.string
+  testing:
+  - 2d.pattern.IDL
+  notes: *bindings
+  code: |
+    @assert throws TypeError ctx.createPattern('../images/red.png', 'repeat');
+
+- name: 2d.pattern.image.incomplete.nosrc
+  testing:
+  - 2d.pattern.incomplete.image
+  code: |
+    var img = new Image();
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.incomplete.immediate
+  testing:
+  - 2d.pattern.incomplete.image
+  images:
+  - red.png
+  code: |
+    var img = new Image();
+    img.src = '../images/red.png';
+    // This triggers the "update the image data" algorithm.
+    // The image will not go to the "completely available" state
+    // until a fetch task in the networking task source is processed,
+    // so the image must not be fully decodable yet:
+    @assert ctx.createPattern(img, 'repeat') === null; @moz-todo
+
+- name: 2d.pattern.image.incomplete.reload
+  testing:
+  - 2d.pattern.incomplete.image
+  images:
+  - yellow.png
+  - red.png
+  code: |
+    var img = document.getElementById('yellow.png');
+    img.src = '../images/red.png';
+    // This triggers the "update the image data" algorithm,
+    // and resets the image to the "unavailable" state.
+    // The image will not go to the "completely available" state
+    // until a fetch task in the networking task source is processed,
+    // so the image must not be fully decodable yet:
+    @assert ctx.createPattern(img, 'repeat') === null; @moz-todo
+
+- name: 2d.pattern.image.incomplete.emptysrc
+  testing:
+  - 2d.pattern.incomplete.image
+  images:
+  - red.png
+  mozilla: {throws: !!null ''}
+  code: |
+    var img = document.getElementById('red.png');
+    img.src = "";
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.incomplete.removedsrc
+  testing:
+  - 2d.pattern.incomplete.image
+  images:
+  - red.png
+  mozilla: {throws: !!null ''}
+  code: |
+    var img = document.getElementById('red.png');
+    img.removeAttribute('src');
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.broken
+  testing:
+  - 2d.pattern.broken.image
+  images:
+  - broken.png
+  code: |
+    var img = document.getElementById('broken.png');
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.nonexistent
+  testing:
+  - 2d.pattern.nonexistent.image
+  images:
+  - no-such-image-really.png
+  code: |
+    var img = document.getElementById('no-such-image-really.png');
+    @assert throws INVALID_STATE_ERR ctx.createPattern(img, 'repeat');
+
+- name: 2d.pattern.svgimage.nonexistent
+  testing:
+  - 2d.pattern.nonexistent.svgimage
+  svgimages:
+  - no-such-image-really.png
+  code: |
+    var img = document.getElementById('no-such-image-really.png');
+    @assert throws INVALID_STATE_ERR ctx.createPattern(img, 'repeat');
+
+- name: 2d.pattern.image.nonexistent-but-loading
+  testing:
+  - 2d.pattern.nonexistent-but-loading.image
+  code: |
+    var img = document.createElement("img");
+    img.src = "/images/no-such-image-really.png";
+    @assert ctx.createPattern(img, 'repeat') === null;
+    var img = document.createElementNS("http://www.w3.org/2000/svg", "image");
+    img.src = "/images/no-such-image-really.png";
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.nosrc
+  testing:
+  - 2d.pattern.nosrc.image
+  code: |
+    var img = document.createElement("img");
+    @assert ctx.createPattern(img, 'repeat') === null;
+    var img = document.createElementNS("http://www.w3.org/2000/svg", "image");
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.zerowidth
+  testing:
+  - 2d.pattern.zerowidth.image
+  images:
+  - red-zerowidth.svg
+  code: |
+    var img = document.getElementById('red-zerowidth.svg');
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.image.zeroheight
+  testing:
+  - 2d.pattern.zeroheight.image
+  images:
+  - red-zeroheight.svg
+  code: |
+    var img = document.getElementById('red-zeroheight.svg');
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.svgimage.zerowidth
+  testing:
+  - 2d.pattern.zerowidth.svgimage
+  svgimages:
+  - red-zerowidth.svg
+  code: |
+    var img = document.getElementById('red-zerowidth.svg');
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.svgimage.zeroheight
+  testing:
+  - 2d.pattern.zeroheight.svgimage
+  svgimages:
+  - red-zeroheight.svg
+  code: |
+    var img = document.getElementById('red-zeroheight.svg');
+    @assert ctx.createPattern(img, 'repeat') === null;
+
+- name: 2d.pattern.repeat.empty
+  testing:
+  - 2d.pattern.missing
+  images:
+  - green-1x1.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    var img = document.getElementById('green-1x1.png');
+    var pattern = ctx.createPattern(img, "");
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 200, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.repeat.null
+  testing:
+  - 2d.pattern.unrecognised
+  code: |
+    @assert ctx.createPattern(canvas, null) != null;
+
+- name: 2d.pattern.repeat.undefined
+  testing:
+  - 2d.pattern.unrecognised
+  code: |
+    @assert throws SYNTAX_ERR ctx.createPattern(canvas, undefined);
+
+- name: 2d.pattern.repeat.unrecognised
+  testing:
+  - 2d.pattern.unrecognised
+  code: |
+    @assert throws SYNTAX_ERR ctx.createPattern(canvas, "invalid");
+
+- name: 2d.pattern.repeat.unrecognisednull
+  testing:
+  - 2d.pattern.unrecognised
+  code: |
+    @assert throws SYNTAX_ERR ctx.createPattern(canvas, "null");
+
+- name: 2d.pattern.repeat.case
+  testing:
+  - 2d.pattern.exact
+  code: |
+    @assert throws SYNTAX_ERR ctx.createPattern(canvas, "Repeat");
+
+- name: 2d.pattern.repeat.nullsuffix
+  testing:
+  - 2d.pattern.exact
+  code: |
+    @assert throws SYNTAX_ERR ctx.createPattern(canvas, "repeat\0");
+
+- name: 2d.pattern.modify.image1
+  testing:
+  - 2d.pattern.modify
+  images:
+  - green.png
+  code: |
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    deferTest();
+    img.onload = t.step_func_done(function ()
+    {
+        ctx.fillStyle = pattern;
+        ctx.fillRect(0, 0, 100, 50);
+
+        @assert pixel 1,1 == 0,255,0,255;
+        @assert pixel 98,1 == 0,255,0,255;
+        @assert pixel 1,48 == 0,255,0,255;
+        @assert pixel 98,48 == 0,255,0,255;
+    });
+    img.src = '/images/red.png';
+  expected: green
+
+- name: 2d.pattern.modify.image2
+  testing:
+  - 2d.pattern.modify
+  images:
+  - green.png
+  code: |
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#00f';
+    ctx.fillRect(0, 0, 100, 50);
+    deferTest();
+    img.onload = t.step_func_done(function ()
+    {
+        ctx.fillStyle = pattern;
+        ctx.fillRect(0, 0, 100, 50);
+
+        @assert pixel 1,1 == 0,255,0,255;
+        @assert pixel 98,1 == 0,255,0,255;
+        @assert pixel 1,48 == 0,255,0,255;
+        @assert pixel 98,48 == 0,255,0,255;
+    });
+    img.src = '/images/red.png';
+  expected: green
+
+- name: 2d.pattern.modify.canvas1
+  testing:
+  - 2d.pattern.modify
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#0f0';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+
+    ctx2.fillStyle = '#f00';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.modify.canvas2
+  testing:
+  - 2d.pattern.modify
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#0f0';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx2.fillStyle = '#f00';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.crosscanvas
+  images:
+  - green.png
+  code: |
+    var img = document.getElementById('green.png');
+
+    var pattern = document.createElement('canvas').getContext('2d').createPattern(img, 'no-repeat');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.norepeat.basic
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.norepeat.outside
+  testing:
+  - 2d.pattern.painting
+  images:
+  - red.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('red.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, -50, 100, 50);
+    ctx.fillRect(-100, 0, 100, 50);
+    ctx.fillRect(0, 50, 100, 50);
+    ctx.fillRect(100, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.norepeat.coord1
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(50, 0, 50, 50);
+
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.translate(50, 0);
+    ctx.fillRect(-50, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.norepeat.coord2
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green.png
+  code: |
+    var img = document.getElementById('green.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 50, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(50, 0, 50, 50);
+
+    ctx.fillStyle = pattern;
+    ctx.translate(50, 0);
+    ctx.fillRect(-50, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.norepeat.coord3
+  testing:
+  - 2d.pattern.painting
+  images:
+  - red.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('red.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.translate(50, 25);
+    ctx.fillRect(-50, -25, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 25);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeat.basic
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green-16x16.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('green-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeat.outside
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green-16x16.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('green-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.fillStyle = pattern;
+    ctx.translate(50, 25);
+    ctx.fillRect(-50, -25, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeat.coord1
+  testing:
+  - 2d.pattern.painting
+  images:
+  - rgrg-256x256.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('rgrg-256x256.png');
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.fillStyle = pattern;
+    ctx.translate(-128, -78);
+    ctx.fillRect(128, 78, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeat.coord2
+  testing:
+  - 2d.pattern.painting
+  images:
+  - ggrr-256x256.png
+  code: |
+    var img = document.getElementById('ggrr-256x256.png');
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeat.coord3
+  testing:
+  - 2d.pattern.painting
+  images:
+  - rgrg-256x256.png
+  code: |
+    var img = document.getElementById('rgrg-256x256.png');
+    var pattern = ctx.createPattern(img, 'repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(-128, -78);
+    ctx.fillRect(128, 78, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeatx.basic
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green-16x16.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 16);
+
+    var img = document.getElementById('green-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat-x');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeatx.outside
+  testing:
+  - 2d.pattern.painting
+  images:
+  - red-16x16.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('red-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat-x');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 16);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeatx.coord1
+  testing:
+  - 2d.pattern.painting
+  images:
+  - red-16x16.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('red-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat-x');
+    ctx.fillStyle = pattern;
+    ctx.translate(0, 16);
+    ctx.fillRect(0, -16, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 16);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeaty.basic
+  testing:
+  - 2d.pattern.painting
+  images:
+  - green-16x16.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 16, 50);
+
+    var img = document.getElementById('green-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat-y');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeaty.outside
+  testing:
+  - 2d.pattern.painting
+  images:
+  - red-16x16.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('red-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat-y');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 16, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.repeaty.coord1
+  testing:
+  - 2d.pattern.painting
+  images:
+  - red-16x16.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('red-16x16.png');
+    var pattern = ctx.createPattern(img, 'repeat-y');
+    ctx.fillStyle = pattern;
+    ctx.translate(48, 0);
+    ctx.fillRect(-48, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 16, 50);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.orientation.image
+  desc: Image patterns do not get flipped when painted
+  testing:
+  - 2d.pattern.painting
+  images:
+  - rrgg-256x256.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var img = document.getElementById('rrgg-256x256.png');
+    var pattern = ctx.createPattern(img, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.save();
+    ctx.translate(0, -103);
+    ctx.fillRect(0, 103, 100, 50);
+    ctx.restore();
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 25);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.pattern.paint.orientation.canvas
+  desc: Canvas patterns do not get flipped when painted
+  testing:
+  - 2d.pattern.painting
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#f00';
+    ctx2.fillRect(0, 0, 100, 25);
+    ctx2.fillStyle = '#0f0';
+    ctx2.fillRect(0, 25, 100, 25);
+
+    var pattern = ctx.createPattern(canvas2, 'no-repeat');
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 25);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.pattern.animated.gif
+  desc: createPattern() of an animated GIF draws the first frame
+  testing:
+  - 2d.pattern.animated.image
+  images:
+  - anim-gr.gif
+  code: |
+    deferTest();
+    step_timeout(function () {
+        var pattern = ctx.createPattern(document.getElementById('anim-gr.gif'), 'repeat');
+        ctx.fillStyle = pattern;
+        ctx.fillRect(0, 0, 50, 50);
+        step_timeout(t.step_func_done(function () {
+            ctx.fillRect(50, 0, 50, 50);
+            @assert pixel 25,25 ==~ 0,255,0,255;
+            @assert pixel 75,25 ==~ 0,255,0,255;
+        }), 250);
+    }, 250);
+  expected: green
+
+- name: 2d.fillStyle.CSSRGB
+  desc: CSSRGB works as color input
+  testing:
+  - 2d.colors.CSSRGB
+  code: |
+    ctx.fillStyle = new CSSRGB(1, 0, 1);
+    @assert ctx.fillStyle === '#ff00ff';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 255,0,255,255;
+
+    const color = new CSSRGB(0, CSS.percent(50), 0);
+    ctx.fillStyle = color;
+    @assert ctx.fillStyle === '#008000';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,128,0,255;
+    color.g = 0;
+    ctx.fillStyle = color;
+    @assert ctx.fillStyle === '#000000';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,0,0,255;
+
+    color.alpha = 0;
+    ctx.fillStyle = color;
+    @assert ctx.fillStyle === 'rgba(0, 0, 0, 0)';
+    ctx.reset();
+    color.alpha = 0.5;
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,0,0,128;
+
+    ctx.fillStyle = new CSSHSL(CSS.deg(0), 1, 1).toRGB();
+    @assert ctx.fillStyle === '#ffffff';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 255,255,255,255;
+
+    color.alpha = 1;
+    color.g = 1;
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 100, 50);
+  expected: green
+
+- name: 2d.fillStyle.CSSHSL
+  desc: CSSHSL works as color input
+  testing:
+  - 2d.colors.CSSHSL
+  code: |
+    ctx.fillStyle = new CSSHSL(CSS.deg(180), 0.5, 0.5);
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 ==~ 64,191,191,255 +/- 3;
+
+    const color = new CSSHSL(CSS.deg(180), 1, 1);
+    ctx.fillStyle = color;
+    @assert ctx.fillStyle === '#ffffff';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 255,255,255,255;
+    color.l = 0.5;
+    ctx.fillStyle = color;
+    @assert ctx.fillStyle === '#00ffff';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,255,255;
+
+    ctx.fillStyle = new CSSRGB(1, 0, 1).toHSL();
+    @assert ctx.fillStyle === '#ff00ff';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 255,0,255,255;
+
+    color.h = CSS.deg(120);
+    color.s = 1;
+    color.l = 0.5;
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 100, 50);
+  expected: green

--- a/test/wpt/generate.js
+++ b/test/wpt/generate.js
@@ -1,0 +1,260 @@
+// This file is a port of gentestutils.py from
+// https://github.com/web-platform-tests/wpt/tree/master/html/canvas/tools
+
+const yaml = require("js-yaml");
+const fs = require("fs");
+
+const yamlFiles = fs.readdirSync(__dirname).filter(f => f.endsWith(".yaml"));
+// Files that should be skipped:
+const SKIP_FILES = new Set("meta.yaml");
+// Tests that should be skipped (e.g. because they cause hangs or V8 crashes):
+const SKIP_TESTS = new Set([
+	"2d.path.arc.nonfinite", // https://github.com/Automattic/node-canvas/issues/2055
+	"2d.imageData.create2.negative",
+	"2d.imageData.create2.zero",
+	"2d.imageData.create2.nonfinite",
+	"2d.imageData.create1.zero",
+	"2d.imageData.create2.double",
+	"2d.imageData.get.source.outside",
+	"2d.imageData.get.source.negative",
+	"2d.imageData.get.double",
+	"2d.imageData.get.large.crash", // expected
+]);
+
+function expandNonfinite(method, argstr, tail) {
+	// argstr is "<valid-1 invalid1-1 invalid2-1 ...>, ..." (where usually
+	// 'invalid' is Infinity/-Infinity/NaN)
+	const args = [];
+	for (const arg of argstr.split(', ')) {
+		const [, a] = arg.match(/<(.*)>/);
+		args.push(a.split(' '));
+	}
+	const calls = [];
+	// Start with the valid argument list
+	const call = [];
+	for (let i = 0; i < args.length; i++) {
+		call.push(args[i][0]);
+	}
+	// For each argument alone, try setting it to all its invalid values:
+	for (let i = 0; i < args.length; i++) {
+		for (let j = 1; j < args[i].length; j++) {
+			const c2 = [...call]
+			c2[i] = args[i][j];
+			calls.push(c2);
+		}
+	}
+	// For all combinations of >= 2 arguments, try setting them to their first
+	// invalid values. (Don't do all invalid values, because the number of
+	// combinations explodes.)
+	const f = (c, start, depth) => {
+		for (let i = start; i < args.length; i++) {
+			if (args[i].length > 1) {
+				const a = args[i][1]
+				const c2 = [...c]
+				c2[i] = a
+				if (depth > 0)
+					calls.push(c2)
+				f(c2, i+1, depth+1)
+			}
+		}
+	};
+	f(call, 0, 0);
+
+	return calls.map(c => `${method}(${c.join(", ")})${tail}`).join("\n\t\t");
+}
+
+function simpleEscapeJS(str) {
+	return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function escapeJS(str) {
+	str = simpleEscapeJS(str)
+	str = str.replace(/\[(\w+)\]/g, '[\\""+($1)+"\\"]') // kind of an ugly hack, for nicer failure-message output
+	return str
+}
+
+/** @type {string} test */
+function convert(test) {
+	let code = test.code;
+	if (!code) return "";
+	// Indent it
+	code = code.trim().replace(/^/gm, "\t\t");
+
+	code = code.replace(/@nonfinite ([^(]+)\(([^)]+)\)(.*)/g, (match, g1, g2, g3) => {
+		return expandNonfinite(g1, g2, g3);
+	});
+
+	code = code.replace(/@assert pixel (\d+,\d+) == (\d+,\d+,\d+,\d+);/g,
+						"_assertPixel(canvas, $1, $2);");
+
+	code = code.replace(/@assert pixel (\d+,\d+) ==~ (\d+,\d+,\d+,\d+);/g,
+						"_assertPixelApprox(canvas, $1, $2);");
+
+	code = code.replace(/@assert pixel (\d+,\d+) ==~ (\d+,\d+,\d+,\d+) \+\/- (\d+);/g,
+						"_assertPixelApprox(canvas, $1, $2, $3);");
+
+	code = code.replace(/@assert throws (\S+_ERR) (.*);/g,
+						'assert.throws(function() { $2; }, /$1/);');
+
+	code = code.replace(/@assert throws (\S+Error) (.*);/g,
+						'assert.throws(function() { $2; }, $1);');
+
+	code = code.replace(/@assert (.*) === (.*);/g, (match, g1, g2) => {
+		return `assert.strictEqual(${g1}, ${g2}, "${escapeJS(g1)}", "${escapeJS(g2)}")`;
+	});
+
+	code = code.replace(/@assert (.*) !== (.*);/g, (match, g1, g2) => {
+		return `assert.notStrictEqual(${g1}, ${g2}, "${escapeJS(g1)}", "${escapeJS(g2)}");`;
+	});
+
+	code = code.replace(/@assert (.*) =~ (.*);/g, (match, g1, g2) => {
+		return `assert.match(${g1}, ${g2});`;
+	});
+
+	code = code.replace(/@assert (.*);/g, (match, g1) => {
+		return `assert(${g1}, "${escapeJS(g1)}");`;
+	});
+
+	code = code.replace(/ @moz-todo/g, "");
+
+	code = code.replace(/@moz-UniversalBrowserRead;/g, "");
+
+	if (code.includes("@"))
+		throw new Error("@ found in code; generation failed");
+
+	const name = test.name.replace(/"/g, /\"/);
+
+	const skip = SKIP_TESTS.has(name) ? ".skip" : "";
+
+	return `
+	it${skip}("${name}", function () {${test.desc ? `\n\t\t// ${test.desc}` : ""}
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+${code}
+	});
+`
+}
+
+
+for (const filename of yamlFiles) {
+	if (SKIP_FILES.has(filename))
+		continue;
+
+	let tests;
+	try {
+		const content = fs.readFileSync(`${__dirname}/${filename}`, "utf8");
+		tests = yaml.load(content, {
+			filename,
+			// schema: yaml.DEFAULT_SCHEMA
+		});
+	} catch (ex) {
+		console.error(ex.toString());
+		continue;
+	}
+
+	const out = fs.createWriteStream(`${__dirname}/generated/${filename.replace(".yaml", ".js")}`);
+
+	out.write(`// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(\`createElement(\${type}) not supported\`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a \${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			\`expected \${actual} to equal \${expected} +/- \${epsilon}. \${msg}\`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: ${filename.replace(".yaml", "")}", function () {
+`);
+
+	for (const test of tests) {
+		out.write(convert(test));
+	}
+
+	out.write(`});
+`)
+
+	out.end();
+}

--- a/test/wpt/generated/drawing-text-to-the-canvas.js
+++ b/test/wpt/generated/drawing-text-to-the-canvas.js
@@ -1,0 +1,1122 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: drawing-text-to-the-canvas", function () {
+
+	it("2d.text.draw.fill.basic", function () {
+		// fillText draws filled text
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('PASS', 5, 35);
+	});
+
+	it("2d.text.draw.fill.unaffected", function () {
+		// fillText does not start a new path or subpath
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('FAIL', 5, 35);
+		
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 5,45, 0,255,0,255);
+	});
+
+	it("2d.text.draw.fill.rtl", function () {
+		// fillText respects Right-To-Left Override characters
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('\u202eFAIL \xa0 \xa0 SSAP', 5, 35);
+	});
+
+	it("2d.text.draw.fill.maxWidth.large", function () {
+		// fillText handles maxWidth correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('PASS', 5, 35, 200);
+	});
+
+	it("2d.text.draw.fill.maxWidth.small", function () {
+		// fillText handles maxWidth correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('fail fail fail fail fail', -100, 35, 90);
+		_assertGreen(ctx, 100, 50);
+	});
+
+	it("2d.text.draw.fill.maxWidth.zero", function () {
+		// fillText handles maxWidth correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('fail fail fail fail fail', 5, 35, 0);
+		_assertGreen(ctx, 100, 50);
+	});
+
+	it("2d.text.draw.fill.maxWidth.negative", function () {
+		// fillText handles maxWidth correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('fail fail fail fail fail', 5, 35, -1);
+		_assertGreen(ctx, 100, 50);
+	});
+
+	it("2d.text.draw.fill.maxWidth.NaN", function () {
+		// fillText handles maxWidth correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.font = '35px Arial, sans-serif';
+		ctx.fillText('fail fail fail fail fail', 5, 35, NaN);
+		_assertGreen(ctx, 100, 50);
+	});
+
+	it("2d.text.draw.stroke.basic", function () {
+		// strokeText draws stroked text
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.fillStyle = '#f00';
+		ctx.lineWidth = 1;
+		ctx.font = '35px Arial, sans-serif';
+		ctx.strokeText('PASS', 5, 35);
+	});
+
+	it("2d.text.draw.stroke.unaffected", function () {
+		// strokeText does not start a new path or subpath
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		
+		ctx.font = '35px Arial, sans-serif';
+		ctx.strokeStyle = '#f00';
+		ctx.strokeText('FAIL', 5, 35);
+		
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 5,45, 0,255,0,255);
+	});
+
+	it("2d.text.draw.kern.consistent", function () {
+		// Stroked and filled text should have exactly the same kerning so it overlaps
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 3;
+		ctx.font = '20px Arial, sans-serif';
+		ctx.fillText('VAVAVAVAVAVAVA', -50, 25);
+		ctx.fillText('ToToToToToToTo', -50, 45);
+		ctx.strokeText('VAVAVAVAVAVAVA', -50, 25);
+		ctx.strokeText('ToToToToToToTo', -50, 45);
+	});
+
+	it("2d.text.draw.fill.maxWidth.fontface", function () {
+		// fillText works on @font-face fonts
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#f00';
+		    ctx.fillText('EEEE', -50, 37.5, 40);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.fill.maxWidth.bound", function () {
+		// fillText handles maxWidth based on line size, not bounding box size
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('DD', 0, 37.5, 100);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.fontface", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '67px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('AA', 0, 50);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.fontface.repeat", function () {
+		// Draw with the font immediately, then wait a bit until and draw again. (This crashes some version of WebKit.)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.font = '67px CanvasTest';
+		ctx.fillStyle = '#0f0';
+		ctx.fillText('AA', 0, 50);
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillText('AA', 0, 50);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.fontface.notinpage", function () {
+		// @font-face fonts should work even if they are not used in the page
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '67px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('AA', 0, 50);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.left", function () {
+		// textAlign left is the left of the first em square (not the bounding box)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'left';
+		    ctx.fillText('DD', 0, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.right", function () {
+		// textAlign right is the right of the last em square (not the bounding box)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'right';
+		    ctx.fillText('DD', 100, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.start.ltr", function () {
+		// textAlign start with ltr is the left edge
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'start';
+		    ctx.fillText('DD', 0, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.start.rtl", function () {
+		// textAlign start with rtl is the right edge
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'start';
+		    ctx.fillText('DD', 100, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.end.ltr", function () {
+		// textAlign end with ltr is the right edge
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'end';
+		    ctx.fillText('DD', 100, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.end.rtl", function () {
+		// textAlign end with rtl is the left edge
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'end';
+		    ctx.fillText('DD', 0, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.align.center", function () {
+		// textAlign center is the center of the em squares (not the bounding box)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'center';
+		    ctx.fillText('DD', 50, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.space.basic", function () {
+		// U+0020 is rendered the correct size (1em wide)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('E EE', -100, 37.5);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.space.collapse.nonspace", function () {
+		// Non-space characters are not converted to U+0020 and collapsed
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('E\x0b EE', -150, 37.5);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.measure.width.basic", function () {
+		// The width of character is same as font used
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        assert.strictEqual(ctx.measureText('A').width, 50, "ctx.measureText('A').width", "50")
+		        assert.strictEqual(ctx.measureText('AA').width, 100, "ctx.measureText('AA').width", "100")
+		        assert.strictEqual(ctx.measureText('ABCD').width, 200, "ctx.measureText('ABCD').width", "200")
+		
+		        ctx.font = '100px CanvasTest';
+		        assert.strictEqual(ctx.measureText('A').width, 100, "ctx.measureText('A').width", "100")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.width.empty", function () {
+		// The empty string has zero width
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        assert.strictEqual(ctx.measureText("").width, 0, "ctx.measureText(\"\").width", "0")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.advances", function () {
+		// Testing width advances
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        ctx.direction = 'ltr';
+		        ctx.align = 'left'
+		        // Some platforms may return '-0'.
+		        assert.strictEqual(Math.abs(ctx.measureText('Hello').advances[0]), 0, "Math.abs(ctx.measureText('Hello').advances[\""+(0)+"\"])", "0")
+		        // Different platforms may render text slightly different.
+		        assert(ctx.measureText('Hello').advances[1] >= 36, "ctx.measureText('Hello').advances[\""+(1)+"\"] >= 36");
+		        assert(ctx.measureText('Hello').advances[2] >= 58, "ctx.measureText('Hello').advances[\""+(2)+"\"] >= 58");
+		        assert(ctx.measureText('Hello').advances[3] >= 70, "ctx.measureText('Hello').advances[\""+(3)+"\"] >= 70");
+		        assert(ctx.measureText('Hello').advances[4] >= 80, "ctx.measureText('Hello').advances[\""+(4)+"\"] >= 80");
+		
+		        var tm = ctx.measureText('Hello');
+		        assert.strictEqual(ctx.measureText('Hello').advances[0], tm.advances[0], "ctx.measureText('Hello').advances[\""+(0)+"\"]", "tm.advances[\""+(0)+"\"]")
+		        assert.strictEqual(ctx.measureText('Hello').advances[1], tm.advances[1], "ctx.measureText('Hello').advances[\""+(1)+"\"]", "tm.advances[\""+(1)+"\"]")
+		        assert.strictEqual(ctx.measureText('Hello').advances[2], tm.advances[2], "ctx.measureText('Hello').advances[\""+(2)+"\"]", "tm.advances[\""+(2)+"\"]")
+		        assert.strictEqual(ctx.measureText('Hello').advances[3], tm.advances[3], "ctx.measureText('Hello').advances[\""+(3)+"\"]", "tm.advances[\""+(3)+"\"]")
+		        assert.strictEqual(ctx.measureText('Hello').advances[4], tm.advances[4], "ctx.measureText('Hello').advances[\""+(4)+"\"]", "tm.advances[\""+(4)+"\"]")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.actualBoundingBox", function () {
+		// Testing actualBoundingBox
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        ctx.direction = 'ltr';
+		        ctx.align = 'left'
+		        ctx.baseline = 'alphabetic'
+		        // Different platforms may render text slightly different.
+		        // Values that are nominally expected to be zero might actually vary by a pixel or so
+		        // if the UA accounts for antialiasing at glyph edges, so we allow a slight deviation.
+		        assert(Math.abs(ctx.measureText('A').actualBoundingBoxLeft) <= 1, "Math.abs(ctx.measureText('A').actualBoundingBoxLeft) <= 1");
+		        assert(ctx.measureText('A').actualBoundingBoxRight >= 50, "ctx.measureText('A').actualBoundingBoxRight >= 50");
+		        assert(ctx.measureText('A').actualBoundingBoxAscent >= 35, "ctx.measureText('A').actualBoundingBoxAscent >= 35");
+		        assert(Math.abs(ctx.measureText('A').actualBoundingBoxDescent) <= 1, "Math.abs(ctx.measureText('A').actualBoundingBoxDescent) <= 1");
+		
+		        assert(ctx.measureText('D').actualBoundingBoxLeft >= 48, "ctx.measureText('D').actualBoundingBoxLeft >= 48");
+		        assert(ctx.measureText('D').actualBoundingBoxLeft <= 52, "ctx.measureText('D').actualBoundingBoxLeft <= 52");
+		        assert(ctx.measureText('D').actualBoundingBoxRight >= 75, "ctx.measureText('D').actualBoundingBoxRight >= 75");
+		        assert(ctx.measureText('D').actualBoundingBoxRight <= 80, "ctx.measureText('D').actualBoundingBoxRight <= 80");
+		        assert(ctx.measureText('D').actualBoundingBoxAscent >= 35, "ctx.measureText('D').actualBoundingBoxAscent >= 35");
+		        assert(ctx.measureText('D').actualBoundingBoxAscent <= 40, "ctx.measureText('D').actualBoundingBoxAscent <= 40");
+		        assert(ctx.measureText('D').actualBoundingBoxDescent >= 12, "ctx.measureText('D').actualBoundingBoxDescent >= 12");
+		        assert(ctx.measureText('D').actualBoundingBoxDescent <= 15, "ctx.measureText('D').actualBoundingBoxDescent <= 15");
+		
+		        assert(Math.abs(ctx.measureText('ABCD').actualBoundingBoxLeft) <= 1, "Math.abs(ctx.measureText('ABCD').actualBoundingBoxLeft) <= 1");
+		        assert(ctx.measureText('ABCD').actualBoundingBoxRight >= 200, "ctx.measureText('ABCD').actualBoundingBoxRight >= 200");
+		        assert(ctx.measureText('ABCD').actualBoundingBoxAscent >= 85, "ctx.measureText('ABCD').actualBoundingBoxAscent >= 85");
+		        assert(ctx.measureText('ABCD').actualBoundingBoxDescent >= 37, "ctx.measureText('ABCD').actualBoundingBoxDescent >= 37");
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.fontBoundingBox", function () {
+		// Testing fontBoundingBox
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        ctx.direction = 'ltr';
+		        ctx.align = 'left'
+		        assert.strictEqual(ctx.measureText('A').fontBoundingBoxAscent, 85, "ctx.measureText('A').fontBoundingBoxAscent", "85")
+		        assert.strictEqual(ctx.measureText('A').fontBoundingBoxDescent, 39, "ctx.measureText('A').fontBoundingBoxDescent", "39")
+		
+		        assert.strictEqual(ctx.measureText('ABCD').fontBoundingBoxAscent, 85, "ctx.measureText('ABCD').fontBoundingBoxAscent", "85")
+		        assert.strictEqual(ctx.measureText('ABCD').fontBoundingBoxDescent, 39, "ctx.measureText('ABCD').fontBoundingBoxDescent", "39")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.fontBoundingBox.ahem", function () {
+		// Testing fontBoundingBox for font ahem
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("Ahem", "/fonts/Ahem.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px Ahem';
+		        ctx.direction = 'ltr';
+		        ctx.align = 'left'
+		        assert.strictEqual(ctx.measureText('A').fontBoundingBoxAscent, 40, "ctx.measureText('A').fontBoundingBoxAscent", "40")
+		        assert.strictEqual(ctx.measureText('A').fontBoundingBoxDescent, 10, "ctx.measureText('A').fontBoundingBoxDescent", "10")
+		
+		        assert.strictEqual(ctx.measureText('ABCD').fontBoundingBoxAscent, 40, "ctx.measureText('ABCD').fontBoundingBoxAscent", "40")
+		        assert.strictEqual(ctx.measureText('ABCD').fontBoundingBoxDescent, 10, "ctx.measureText('ABCD').fontBoundingBoxDescent", "10")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.emHeights", function () {
+		// Testing emHeights
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		     step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        ctx.direction = 'ltr';
+		        ctx.align = 'left'
+		        assert.strictEqual(ctx.measureText('A').emHeightAscent, 37.5, "ctx.measureText('A').emHeightAscent", "37.5")
+		        assert.strictEqual(ctx.measureText('A').emHeightDescent, 12.5, "ctx.measureText('A').emHeightDescent", "12.5")
+		        assert.strictEqual(ctx.measureText('A').emHeightDescent + ctx.measureText('A').emHeightAscent, 50, "ctx.measureText('A').emHeightDescent + ctx.measureText('A').emHeightAscent", "50")
+		
+		        assert.strictEqual(ctx.measureText('ABCD').emHeightAscent, 37.5, "ctx.measureText('ABCD').emHeightAscent", "37.5")
+		        assert.strictEqual(ctx.measureText('ABCD').emHeightDescent, 12.5, "ctx.measureText('ABCD').emHeightDescent", "12.5")
+		        assert.strictEqual(ctx.measureText('ABCD').emHeightDescent + ctx.measureText('ABCD').emHeightAscent, 50, "ctx.measureText('ABCD').emHeightDescent + ctx.measureText('ABCD').emHeightAscent", "50")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.baselines", function () {
+		// Testing baselines
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		     step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        ctx.direction = 'ltr';
+		        ctx.align = 'left'
+		        assert.strictEqual(Math.abs(ctx.measureText('A').getBaselines().alphabetic), 0, "Math.abs(ctx.measureText('A').getBaselines().alphabetic)", "0")
+		        assert.strictEqual(ctx.measureText('A').getBaselines().ideographic, -39, "ctx.measureText('A').getBaselines().ideographic", "-39")
+		        assert.strictEqual(ctx.measureText('A').getBaselines().hanging, 68, "ctx.measureText('A').getBaselines().hanging", "68")
+		
+		        assert.strictEqual(Math.abs(ctx.measureText('ABCD').getBaselines().alphabetic), 0, "Math.abs(ctx.measureText('ABCD').getBaselines().alphabetic)", "0")
+		        assert.strictEqual(ctx.measureText('ABCD').getBaselines().ideographic, -39, "ctx.measureText('ABCD').getBaselines().ideographic", "-39")
+		        assert.strictEqual(ctx.measureText('ABCD').getBaselines().hanging, 68, "ctx.measureText('ABCD').getBaselines().hanging", "68")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.drawing.style.spacing", function () {
+		// Testing letter spacing and word spacing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		
+		ctx.letterSpacing = '3px';
+		assert.strictEqual(ctx.letterSpacing, '3px', "ctx.letterSpacing", "'3px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		
+		ctx.wordSpacing = '5px';
+		assert.strictEqual(ctx.letterSpacing, '3px', "ctx.letterSpacing", "'3px'")
+		assert.strictEqual(ctx.wordSpacing, '5px', "ctx.wordSpacing", "'5px'")
+		
+		ctx.letterSpacing = '-1px';
+		ctx.wordSpacing = '-1px';
+		assert.strictEqual(ctx.letterSpacing, '-1px', "ctx.letterSpacing", "'-1px'")
+		assert.strictEqual(ctx.wordSpacing, '-1px', "ctx.wordSpacing", "'-1px'")
+		
+		ctx.letterSpacing = '1PX';
+		ctx.wordSpacing = '1EM';
+		assert.strictEqual(ctx.letterSpacing, '1px', "ctx.letterSpacing", "'1px'")
+		assert.strictEqual(ctx.wordSpacing, '1em', "ctx.wordSpacing", "'1em'")
+	});
+
+	it("2d.text.drawing.style.nonfinite.spacing", function () {
+		// Testing letter spacing and word spacing with nonfinite inputs
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		
+		function test_word_spacing(value) {
+		  ctx.wordSpacing = value;
+		  ctx.letterSpacing = value;
+		  assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		  assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		}
+		test_word_spacing(NaN);
+		test_word_spacing(Infinity);
+		test_word_spacing(-Infinity);
+	});
+
+	it("2d.text.drawing.style.invalid.spacing", function () {
+		// Testing letter spacing and word spacing with invalid units
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		
+		function test_word_spacing(value) {
+		  ctx.wordSpacing = value;
+		  ctx.letterSpacing = value;
+		  assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		  assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		}
+		test_word_spacing('0s');
+		test_word_spacing('1min');
+		test_word_spacing('1deg');
+		test_word_spacing('1pp');
+	});
+
+	it("2d.text.drawing.style.letterSpacing.measure", function () {
+		// Testing letter spacing and word spacing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		var width_normal = ctx.measureText('Hello World').width;
+		
+		function test_letter_spacing(value, difference_spacing, epsilon) {
+		  ctx.letterSpacing = value;
+		  assert.strictEqual(ctx.letterSpacing, value, "ctx.letterSpacing", "value")
+		  assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		  width_with_letter_spacing = ctx.measureText('Hello World').width;
+		  assert_approx_equals(width_with_letter_spacing, width_normal + difference_spacing, epsilon, "letter spacing doesn't work.");
+		}
+		
+		// The first value is the letter Spacing to be set, the second value the
+		// change in length of string 'Hello World', note that there are 11 letters
+		// in 'hello world', so the length difference is always letterSpacing * 11.
+		// and the third value is the acceptable differencee for the length change,
+		// note that unit such as 1cm/1mm doesn't map to an exact pixel value.
+		test_cases = [['3px', 33, 0],
+		              ['5px', 55, 0],
+		              ['-2px', -22, 0],
+		              ['1em', 110, 0],
+		              ['1in', 1056, 0],
+		              ['-0.1cm', -41.65, 0.2],
+		              ['-0.6mm', -24,95, 0.2]]
+		
+		for (const test_case of test_cases) {
+		  test_letter_spacing(test_case[0], test_case[1], test_case[2]);
+		}
+	});
+
+	it("2d.text.drawing.style.wordSpacing.measure", function () {
+		// Testing if word spacing is working properly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		var width_normal = ctx.measureText('Hello World, again').width;
+		
+		function test_word_spacing(value, difference_spacing, epsilon) {
+		  ctx.wordSpacing = value;
+		  assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		  assert.strictEqual(ctx.wordSpacing, value, "ctx.wordSpacing", "value")
+		  width_with_word_spacing = ctx.measureText('Hello World, again').width;
+		  assert_approx_equals(width_with_word_spacing, width_normal + difference_spacing, epsilon, "word spacing doesn't work.");
+		}
+		
+		// The first value is the word Spacing to be set, the second value the
+		// change in length of string 'Hello World', note that there are 2 words
+		// in 'Hello World, again', so the length difference is always wordSpacing * 2.
+		// and the third value is the acceptable differencee for the length change,
+		// note that unit such as 1cm/1mm doesn't map to an exact pixel value.
+		test_cases = [['3px', 6, 0],
+		              ['5px', 10, 0],
+		              ['-2px', -4, 0],
+		              ['1em', 20, 0],
+		              ['1in', 192, 0],
+		              ['-0.1cm', -7.57, 0.2],
+		              ['-0.6mm', -4.54, 0.2]]
+		
+		for (const test_case of test_cases) {
+		  test_word_spacing(test_case[0], test_case[1], test_case[2]);
+		}
+	});
+
+	it("2d.text.drawing.style.letterSpacing.change.font", function () {
+		// Set letter spacing and word spacing to font dependent value and verify it works after font change.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		// Get the width for 'Hello World' at default size, 10px.
+		var width_normal = ctx.measureText('Hello World').width;
+		
+		ctx.letterSpacing = '1em';
+		assert.strictEqual(ctx.letterSpacing, '1em', "ctx.letterSpacing", "'1em'")
+		// 1em = 10px. Add 10px after each letter in "Hello World",
+		// makes it 110px longer.
+		var width_with_spacing = ctx.measureText('Hello World').width;
+		assert.strictEqual(width_with_spacing, width_normal + 110, "width_with_spacing", "width_normal + 110")
+		
+		// Changing font to 20px. Without resetting the spacing, 1em letterSpacing
+		// is now 20px, so it's suppose to be 220px longer without any letterSpacing set.
+		ctx.font = '20px serif';
+		width_with_spacing = ctx.measureText('Hello World').width;
+		// Now calculate the reference spacing for "Hello World" with no spacing.
+		ctx.letterSpacing = '0em';
+		width_normal = ctx.measureText('Hello World').width;
+		assert.strictEqual(width_with_spacing, width_normal + 220, "width_with_spacing", "width_normal + 220")
+	});
+
+	it("2d.text.drawing.style.wordSpacing.change.font", function () {
+		// Set word spacing and word spacing to font dependent value and verify it works after font change.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'")
+		assert.strictEqual(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'")
+		// Get the width for 'Hello World, again' at default size, 10px.
+		var width_normal = ctx.measureText('Hello World, again').width;
+		
+		ctx.wordSpacing = '1em';
+		assert.strictEqual(ctx.wordSpacing, '1em', "ctx.wordSpacing", "'1em'")
+		// 1em = 10px. Add 10px after each word in "Hello World, again",
+		// makes it 20px longer.
+		var width_with_spacing = ctx.measureText('Hello World, again').width;
+		assert.strictEqual(width_with_spacing, width_normal + 20, "width_with_spacing", "width_normal + 20")
+		
+		// Changing font to 20px. Without resetting the spacing, 1em wordSpacing
+		// is now 20px, so it's suppose to be 40px longer without any wordSpacing set.
+		ctx.font = '20px serif';
+		width_with_spacing = ctx.measureText('Hello World, again').width;
+		// Now calculate the reference spacing for "Hello World, again" with no spacing.
+		ctx.wordSpacing = '0em';
+		width_normal = ctx.measureText('Hello World, again').width;
+		assert.strictEqual(width_with_spacing, width_normal + 40, "width_with_spacing", "width_normal + 40")
+	});
+
+	it("2d.text.drawing.style.fontKerning", function () {
+		// Testing basic functionalities of fontKerning for canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.fontKerning, "auto", "ctx.fontKerning", "\"auto\"")
+		ctx.fontKerning = "normal";
+		assert.strictEqual(ctx.fontKerning, "normal", "ctx.fontKerning", "\"normal\"")
+		width_normal = ctx.measureText("TAWATAVA").width;
+		ctx.fontKerning = "none";
+		assert.strictEqual(ctx.fontKerning, "none", "ctx.fontKerning", "\"none\"")
+		width_none = ctx.measureText("TAWATAVA").width;
+		assert(width_normal < width_none, "width_normal < width_none");
+	});
+
+	it("2d.text.drawing.style.fontKerning.with.uppercase", function () {
+		// Testing basic functionalities of fontKerning for canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.fontKerning, "auto", "ctx.fontKerning", "\"auto\"")
+		ctx.fontKerning = "Normal";
+		assert.strictEqual(ctx.fontKerning, "normal", "ctx.fontKerning", "\"normal\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "normal";
+		assert.strictEqual(ctx.fontKerning, "normal", "ctx.fontKerning", "\"normal\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "noRmal";
+		assert.strictEqual(ctx.fontKerning, "normal", "ctx.fontKerning", "\"normal\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "NoRMal";
+		assert.strictEqual(ctx.fontKerning, "normal", "ctx.fontKerning", "\"normal\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "NORMAL";
+		assert.strictEqual(ctx.fontKerning, "normal", "ctx.fontKerning", "\"normal\"")
+		
+		ctx.fontKerning = "None";
+		assert.strictEqual(ctx.fontKerning, "none", "ctx.fontKerning", "\"none\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "none";
+		assert.strictEqual(ctx.fontKerning, "none", "ctx.fontKerning", "\"none\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "nOne";
+		assert.strictEqual(ctx.fontKerning, "none", "ctx.fontKerning", "\"none\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "nonE";
+		assert.strictEqual(ctx.fontKerning, "none", "ctx.fontKerning", "\"none\"")
+		ctx.fontKerning = "Auto";
+		ctx.fontKerning = "NONE";
+		assert.strictEqual(ctx.fontKerning, "none", "ctx.fontKerning", "\"none\"")
+	});
+
+	it("2d.text.drawing.style.fontVariant.settings", function () {
+		// Testing basic functionalities of fontKerning for canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		// Setting fontVariantCaps with lower cases
+		assert.strictEqual(ctx.fontVariantCaps, "normal", "ctx.fontVariantCaps", "\"normal\"")
+		
+		ctx.fontVariantCaps = "normal";
+		assert.strictEqual(ctx.fontVariantCaps, "normal", "ctx.fontVariantCaps", "\"normal\"")
+		
+		ctx.fontVariantCaps = "small-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "small-caps", "ctx.fontVariantCaps", "\"small-caps\"")
+		
+		ctx.fontVariantCaps = "all-small-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "all-small-caps", "ctx.fontVariantCaps", "\"all-small-caps\"")
+		
+		ctx.fontVariantCaps = "petite-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "petite-caps", "ctx.fontVariantCaps", "\"petite-caps\"")
+		
+		ctx.fontVariantCaps = "all-petite-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "all-petite-caps", "ctx.fontVariantCaps", "\"all-petite-caps\"")
+		
+		ctx.fontVariantCaps = "unicase";
+		assert.strictEqual(ctx.fontVariantCaps, "unicase", "ctx.fontVariantCaps", "\"unicase\"")
+		
+		ctx.fontVariantCaps = "titling-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "titling-caps", "ctx.fontVariantCaps", "\"titling-caps\"")
+		
+		// Setting fontVariantCaps with lower cases and upper cases word.
+		ctx.fontVariantCaps = "nORmal";
+		assert.strictEqual(ctx.fontVariantCaps, "normal", "ctx.fontVariantCaps", "\"normal\"")
+		
+		ctx.fontVariantCaps = "smaLL-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "small-caps", "ctx.fontVariantCaps", "\"small-caps\"")
+		
+		ctx.fontVariantCaps = "all-small-CAPS";
+		assert.strictEqual(ctx.fontVariantCaps, "all-small-caps", "ctx.fontVariantCaps", "\"all-small-caps\"")
+		
+		ctx.fontVariantCaps = "pEtitE-caps";
+		assert.strictEqual(ctx.fontVariantCaps, "petite-caps", "ctx.fontVariantCaps", "\"petite-caps\"")
+		
+		ctx.fontVariantCaps = "All-Petite-Caps";
+		assert.strictEqual(ctx.fontVariantCaps, "all-petite-caps", "ctx.fontVariantCaps", "\"all-petite-caps\"")
+		
+		ctx.fontVariantCaps = "uNIcase";
+		assert.strictEqual(ctx.fontVariantCaps, "unicase", "ctx.fontVariantCaps", "\"unicase\"")
+		
+		ctx.fontVariantCaps = "titling-CAPS";
+		assert.strictEqual(ctx.fontVariantCaps, "titling-caps", "ctx.fontVariantCaps", "\"titling-caps\"")
+		
+		// Setting fontVariantCaps with non-existing font variant.
+		ctx.fontVariantCaps = "abcd";
+		assert.strictEqual(ctx.fontVariantCaps, "titling-caps", "ctx.fontVariantCaps", "\"titling-caps\"")
+	});
+
+	it("2d.text.drawing.style.textRendering.settings", function () {
+		// Testing basic functionalities of textRendering in Canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		// Setting textRendering with lower cases
+		assert.strictEqual(ctx.textRendering, "auto", "ctx.textRendering", "\"auto\"")
+		
+		ctx.textRendering = "auto";
+		assert.strictEqual(ctx.textRendering, "auto", "ctx.textRendering", "\"auto\"")
+		
+		ctx.textRendering = "optimizespeed";
+		assert.strictEqual(ctx.textRendering, "optimizeSpeed", "ctx.textRendering", "\"optimizeSpeed\"")
+		
+		ctx.textRendering = "optimizelegibility";
+		assert.strictEqual(ctx.textRendering, "optimizeLegibility", "ctx.textRendering", "\"optimizeLegibility\"")
+		
+		ctx.textRendering = "geometricprecision";
+		assert.strictEqual(ctx.textRendering, "geometricPrecision", "ctx.textRendering", "\"geometricPrecision\"")
+		
+		// Setting textRendering with lower cases and upper cases word.
+		ctx.textRendering = "aUto";
+		assert.strictEqual(ctx.textRendering, "auto", "ctx.textRendering", "\"auto\"")
+		
+		ctx.textRendering = "OPtimizeSpeed";
+		assert.strictEqual(ctx.textRendering, "optimizeSpeed", "ctx.textRendering", "\"optimizeSpeed\"")
+		
+		ctx.textRendering = "OPtimizELEgibility";
+		assert.strictEqual(ctx.textRendering, "optimizeLegibility", "ctx.textRendering", "\"optimizeLegibility\"")
+		
+		ctx.textRendering = "GeometricPrecision";
+		assert.strictEqual(ctx.textRendering, "geometricPrecision", "ctx.textRendering", "\"geometricPrecision\"")
+		
+		// Setting textRendering with non-existing font variant.
+		ctx.textRendering = "abcd";
+		assert.strictEqual(ctx.textRendering, "geometricPrecision", "ctx.textRendering", "\"geometricPrecision\"")
+	});
+});

--- a/test/wpt/generated/line-styles.js
+++ b/test/wpt/generated/line-styles.js
@@ -1,0 +1,1136 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: line-styles", function () {
+
+	it("2d.line.defaults", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.lineWidth, 1, "ctx.lineWidth", "1")
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		assert.strictEqual(ctx.lineJoin, 'miter', "ctx.lineJoin", "'miter'")
+		assert.strictEqual(ctx.miterLimit, 10, "ctx.miterLimit", "10")
+	});
+
+	it("2d.line.width.basic", function () {
+		// lineWidth determines the width of line strokes
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 20;
+		// Draw a green line over a red box, to check the line is not too small
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.fillRect(15, 15, 20, 20);
+		ctx.beginPath();
+		ctx.moveTo(25, 15);
+		ctx.lineTo(25, 35);
+		ctx.stroke();
+		
+		// Draw a green box over a red line, to check the line is not too large
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(75, 15);
+		ctx.lineTo(75, 35);
+		ctx.stroke();
+		ctx.fillRect(65, 15, 20, 20);
+		
+		_assertPixel(canvas, 14,25, 0,255,0,255);
+		_assertPixel(canvas, 15,25, 0,255,0,255);
+		_assertPixel(canvas, 16,25, 0,255,0,255);
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 34,25, 0,255,0,255);
+		_assertPixel(canvas, 35,25, 0,255,0,255);
+		_assertPixel(canvas, 36,25, 0,255,0,255);
+		
+		_assertPixel(canvas, 64,25, 0,255,0,255);
+		_assertPixel(canvas, 65,25, 0,255,0,255);
+		_assertPixel(canvas, 66,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+		_assertPixel(canvas, 84,25, 0,255,0,255);
+		_assertPixel(canvas, 85,25, 0,255,0,255);
+		_assertPixel(canvas, 86,25, 0,255,0,255);
+	});
+
+	it("2d.line.width.transformed", function () {
+		// Line stroke widths are affected by scale transformations
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 4;
+		// Draw a green line over a red box, to check the line is not too small
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.fillRect(15, 15, 20, 20);
+		ctx.save();
+		 ctx.scale(5, 1);
+		 ctx.beginPath();
+		 ctx.moveTo(5, 15);
+		 ctx.lineTo(5, 35);
+		 ctx.stroke();
+		ctx.restore();
+		
+		// Draw a green box over a red line, to check the line is not too large
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.save();
+		 ctx.scale(-5, 1);
+		 ctx.beginPath();
+		 ctx.moveTo(-15, 15);
+		 ctx.lineTo(-15, 35);
+		 ctx.stroke();
+		ctx.restore();
+		ctx.fillRect(65, 15, 20, 20);
+		
+		_assertPixel(canvas, 14,25, 0,255,0,255);
+		_assertPixel(canvas, 15,25, 0,255,0,255);
+		_assertPixel(canvas, 16,25, 0,255,0,255);
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 34,25, 0,255,0,255);
+		_assertPixel(canvas, 35,25, 0,255,0,255);
+		_assertPixel(canvas, 36,25, 0,255,0,255);
+		
+		_assertPixel(canvas, 64,25, 0,255,0,255);
+		_assertPixel(canvas, 65,25, 0,255,0,255);
+		_assertPixel(canvas, 66,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+		_assertPixel(canvas, 84,25, 0,255,0,255);
+		_assertPixel(canvas, 85,25, 0,255,0,255);
+		_assertPixel(canvas, 86,25, 0,255,0,255);
+	});
+
+	it("2d.line.width.scaledefault", function () {
+		// Default lineWidth strokes are affected by scale transformations
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.scale(50, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.moveTo(0, 0.5);
+		ctx.lineTo(2, 0.5);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+		_assertPixel(canvas, 50,5, 0,255,0,255);
+		_assertPixel(canvas, 50,45, 0,255,0,255);
+	});
+
+	it("2d.line.width.valid", function () {
+		// Setting lineWidth to valid values works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineWidth = 1.5;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = "1e1";
+		assert.strictEqual(ctx.lineWidth, 10, "ctx.lineWidth", "10")
+		
+		ctx.lineWidth = 1/1024;
+		assert.strictEqual(ctx.lineWidth, 1/1024, "ctx.lineWidth", "1/1024")
+		
+		ctx.lineWidth = 1000;
+		assert.strictEqual(ctx.lineWidth, 1000, "ctx.lineWidth", "1000")
+	});
+
+	it("2d.line.width.invalid", function () {
+		// Setting lineWidth to invalid values is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineWidth = 1.5;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = 0;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = -1;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = Infinity;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = -Infinity;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = NaN;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = 'string';
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = true;
+		assert.strictEqual(ctx.lineWidth, 1, "ctx.lineWidth", "1")
+		
+		ctx.lineWidth = 1.5;
+		ctx.lineWidth = false;
+		assert.strictEqual(ctx.lineWidth, 1.5, "ctx.lineWidth", "1.5")
+	});
+
+	it("2d.line.cap.butt", function () {
+		// lineCap 'butt' is rendered correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineCap = 'butt';
+		ctx.lineWidth = 20;
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.fillRect(15, 15, 20, 20);
+		ctx.beginPath();
+		ctx.moveTo(25, 15);
+		ctx.lineTo(25, 35);
+		ctx.stroke();
+		
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(75, 15);
+		ctx.lineTo(75, 35);
+		ctx.stroke();
+		ctx.fillRect(65, 15, 20, 20);
+		
+		_assertPixel(canvas, 25,14, 0,255,0,255);
+		_assertPixel(canvas, 25,15, 0,255,0,255);
+		_assertPixel(canvas, 25,16, 0,255,0,255);
+		_assertPixel(canvas, 25,34, 0,255,0,255);
+		_assertPixel(canvas, 25,35, 0,255,0,255);
+		_assertPixel(canvas, 25,36, 0,255,0,255);
+		
+		_assertPixel(canvas, 75,14, 0,255,0,255);
+		_assertPixel(canvas, 75,15, 0,255,0,255);
+		_assertPixel(canvas, 75,16, 0,255,0,255);
+		_assertPixel(canvas, 75,34, 0,255,0,255);
+		_assertPixel(canvas, 75,35, 0,255,0,255);
+		_assertPixel(canvas, 75,36, 0,255,0,255);
+	});
+
+	it("2d.line.cap.round", function () {
+		// lineCap 'round' is rendered correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		var tol = 1; // tolerance to avoid antialiasing artifacts
+		
+		ctx.lineCap = 'round';
+		ctx.lineWidth = 20;
+		
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		
+		ctx.beginPath();
+		ctx.moveTo(35-tol, 15);
+		ctx.arc(25, 15, 10-tol, 0, Math.PI, true);
+		ctx.arc(25, 35, 10-tol, Math.PI, 0, true);
+		ctx.fill();
+		
+		ctx.beginPath();
+		ctx.moveTo(25, 15);
+		ctx.lineTo(25, 35);
+		ctx.stroke();
+		
+		
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		
+		ctx.beginPath();
+		ctx.moveTo(75, 15);
+		ctx.lineTo(75, 35);
+		ctx.stroke();
+		
+		ctx.beginPath();
+		ctx.moveTo(85+tol, 15);
+		ctx.arc(75, 15, 10+tol, 0, Math.PI, true);
+		ctx.arc(75, 35, 10+tol, Math.PI, 0, true);
+		ctx.fill();
+		
+		_assertPixel(canvas, 17,6, 0,255,0,255);
+		_assertPixel(canvas, 25,6, 0,255,0,255);
+		_assertPixel(canvas, 32,6, 0,255,0,255);
+		_assertPixel(canvas, 17,43, 0,255,0,255);
+		_assertPixel(canvas, 25,43, 0,255,0,255);
+		_assertPixel(canvas, 32,43, 0,255,0,255);
+		
+		_assertPixel(canvas, 67,6, 0,255,0,255);
+		_assertPixel(canvas, 75,6, 0,255,0,255);
+		_assertPixel(canvas, 82,6, 0,255,0,255);
+		_assertPixel(canvas, 67,43, 0,255,0,255);
+		_assertPixel(canvas, 75,43, 0,255,0,255);
+		_assertPixel(canvas, 82,43, 0,255,0,255);
+	});
+
+	it("2d.line.cap.square", function () {
+		// lineCap 'square' is rendered correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineCap = 'square';
+		ctx.lineWidth = 20;
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.fillRect(15, 5, 20, 40);
+		ctx.beginPath();
+		ctx.moveTo(25, 15);
+		ctx.lineTo(25, 35);
+		ctx.stroke();
+		
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(75, 15);
+		ctx.lineTo(75, 35);
+		ctx.stroke();
+		ctx.fillRect(65, 5, 20, 40);
+		
+		_assertPixel(canvas, 25,4, 0,255,0,255);
+		_assertPixel(canvas, 25,5, 0,255,0,255);
+		_assertPixel(canvas, 25,6, 0,255,0,255);
+		_assertPixel(canvas, 25,44, 0,255,0,255);
+		_assertPixel(canvas, 25,45, 0,255,0,255);
+		_assertPixel(canvas, 25,46, 0,255,0,255);
+		
+		_assertPixel(canvas, 75,4, 0,255,0,255);
+		_assertPixel(canvas, 75,5, 0,255,0,255);
+		_assertPixel(canvas, 75,6, 0,255,0,255);
+		_assertPixel(canvas, 75,44, 0,255,0,255);
+		_assertPixel(canvas, 75,45, 0,255,0,255);
+		_assertPixel(canvas, 75,46, 0,255,0,255);
+	});
+
+	it("2d.line.cap.open", function () {
+		// Line caps are drawn at the corners of an unclosed rectangle
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineCap = 'square';
+		ctx.lineWidth = 400;
+		
+		ctx.beginPath();
+		ctx.moveTo(200, 200);
+		ctx.lineTo(200, 1000);
+		ctx.lineTo(1000, 1000);
+		ctx.lineTo(1000, 200);
+		ctx.lineTo(200, 200);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.cap.closed", function () {
+		// Line caps are not drawn at the corners of an unclosed rectangle
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineCap = 'square';
+		ctx.lineWidth = 400;
+		
+		ctx.beginPath();
+		ctx.moveTo(200, 200);
+		ctx.lineTo(200, 1000);
+		ctx.lineTo(1000, 1000);
+		ctx.lineTo(1000, 200);
+		ctx.closePath();
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.cap.valid", function () {
+		// Setting lineCap to valid values works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineCap = 'butt'
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'round';
+		assert.strictEqual(ctx.lineCap, 'round', "ctx.lineCap", "'round'")
+		
+		ctx.lineCap = 'square';
+		assert.strictEqual(ctx.lineCap, 'square', "ctx.lineCap", "'square'")
+	});
+
+	it("2d.line.cap.invalid", function () {
+		// Setting lineCap to invalid values is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineCap = 'butt'
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'butt';
+		ctx.lineCap = 'invalid';
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'butt';
+		ctx.lineCap = 'ROUND';
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'butt';
+		ctx.lineCap = 'round\0';
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'butt';
+		ctx.lineCap = 'round ';
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'butt';
+		ctx.lineCap = "";
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+		
+		ctx.lineCap = 'butt';
+		ctx.lineCap = 'bevel';
+		assert.strictEqual(ctx.lineCap, 'butt', "ctx.lineCap", "'butt'")
+	});
+
+	it("2d.line.join.bevel", function () {
+		// lineJoin 'bevel' is rendered correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		var tol = 1; // tolerance to avoid antialiasing artifacts
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineWidth = 20;
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		
+		ctx.fillRect(10, 10, 20, 20);
+		ctx.fillRect(20, 20, 20, 20);
+		ctx.beginPath();
+		ctx.moveTo(30, 20);
+		ctx.lineTo(40-tol, 20);
+		ctx.lineTo(30, 10+tol);
+		ctx.fill();
+		
+		ctx.beginPath();
+		ctx.moveTo(10, 20);
+		ctx.lineTo(30, 20);
+		ctx.lineTo(30, 40);
+		ctx.stroke();
+		
+		
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		
+		ctx.beginPath();
+		ctx.moveTo(60, 20);
+		ctx.lineTo(80, 20);
+		ctx.lineTo(80, 40);
+		ctx.stroke();
+		
+		ctx.fillRect(60, 10, 20, 20);
+		ctx.fillRect(70, 20, 20, 20);
+		ctx.beginPath();
+		ctx.moveTo(80, 20);
+		ctx.lineTo(90+tol, 20);
+		ctx.lineTo(80, 10-tol);
+		ctx.fill();
+		
+		_assertPixel(canvas, 34,16, 0,255,0,255);
+		_assertPixel(canvas, 34,15, 0,255,0,255);
+		_assertPixel(canvas, 35,15, 0,255,0,255);
+		_assertPixel(canvas, 36,15, 0,255,0,255);
+		_assertPixel(canvas, 36,14, 0,255,0,255);
+		
+		_assertPixel(canvas, 84,16, 0,255,0,255);
+		_assertPixel(canvas, 84,15, 0,255,0,255);
+		_assertPixel(canvas, 85,15, 0,255,0,255);
+		_assertPixel(canvas, 86,15, 0,255,0,255);
+		_assertPixel(canvas, 86,14, 0,255,0,255);
+	});
+
+	it("2d.line.join.round", function () {
+		// lineJoin 'round' is rendered correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		var tol = 1; // tolerance to avoid antialiasing artifacts
+		
+		ctx.lineJoin = 'round';
+		ctx.lineWidth = 20;
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		
+		ctx.fillRect(10, 10, 20, 20);
+		ctx.fillRect(20, 20, 20, 20);
+		ctx.beginPath();
+		ctx.moveTo(30, 20);
+		ctx.arc(30, 20, 10-tol, 0, 2*Math.PI, true);
+		ctx.fill();
+		
+		ctx.beginPath();
+		ctx.moveTo(10, 20);
+		ctx.lineTo(30, 20);
+		ctx.lineTo(30, 40);
+		ctx.stroke();
+		
+		
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		
+		ctx.beginPath();
+		ctx.moveTo(60, 20);
+		ctx.lineTo(80, 20);
+		ctx.lineTo(80, 40);
+		ctx.stroke();
+		
+		ctx.fillRect(60, 10, 20, 20);
+		ctx.fillRect(70, 20, 20, 20);
+		ctx.beginPath();
+		ctx.moveTo(80, 20);
+		ctx.arc(80, 20, 10+tol, 0, 2*Math.PI, true);
+		ctx.fill();
+		
+		_assertPixel(canvas, 36,14, 0,255,0,255);
+		_assertPixel(canvas, 36,13, 0,255,0,255);
+		_assertPixel(canvas, 37,13, 0,255,0,255);
+		_assertPixel(canvas, 38,13, 0,255,0,255);
+		_assertPixel(canvas, 38,12, 0,255,0,255);
+		
+		_assertPixel(canvas, 86,14, 0,255,0,255);
+		_assertPixel(canvas, 86,13, 0,255,0,255);
+		_assertPixel(canvas, 87,13, 0,255,0,255);
+		_assertPixel(canvas, 88,13, 0,255,0,255);
+		_assertPixel(canvas, 88,12, 0,255,0,255);
+	});
+
+	it("2d.line.join.miter", function () {
+		// lineJoin 'miter' is rendered correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineJoin = 'miter';
+		ctx.lineWidth = 20;
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		
+		ctx.fillRect(10, 10, 30, 20);
+		ctx.fillRect(20, 10, 20, 30);
+		
+		ctx.beginPath();
+		ctx.moveTo(10, 20);
+		ctx.lineTo(30, 20);
+		ctx.lineTo(30, 40);
+		ctx.stroke();
+		
+		
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		
+		ctx.beginPath();
+		ctx.moveTo(60, 20);
+		ctx.lineTo(80, 20);
+		ctx.lineTo(80, 40);
+		ctx.stroke();
+		
+		ctx.fillRect(60, 10, 30, 20);
+		ctx.fillRect(70, 10, 20, 30);
+		
+		_assertPixel(canvas, 38,12, 0,255,0,255);
+		_assertPixel(canvas, 39,11, 0,255,0,255);
+		_assertPixel(canvas, 40,10, 0,255,0,255);
+		_assertPixel(canvas, 41,9, 0,255,0,255);
+		_assertPixel(canvas, 42,8, 0,255,0,255);
+		
+		_assertPixel(canvas, 88,12, 0,255,0,255);
+		_assertPixel(canvas, 89,11, 0,255,0,255);
+		_assertPixel(canvas, 90,10, 0,255,0,255);
+		_assertPixel(canvas, 91,9, 0,255,0,255);
+		_assertPixel(canvas, 92,8, 0,255,0,255);
+	});
+
+	it("2d.line.join.open", function () {
+		// Line joins are not drawn at the corner of an unclosed rectangle
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.strokeStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineJoin = 'miter';
+		ctx.lineWidth = 200;
+		
+		ctx.beginPath();
+		ctx.moveTo(100, 50);
+		ctx.lineTo(100, 1000);
+		ctx.lineTo(1000, 1000);
+		ctx.lineTo(1000, 50);
+		ctx.lineTo(100, 50);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.join.closed", function () {
+		// Line joins are drawn at the corner of a closed rectangle
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.strokeStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineJoin = 'miter';
+		ctx.lineWidth = 200;
+		
+		ctx.beginPath();
+		ctx.moveTo(100, 50);
+		ctx.lineTo(100, 1000);
+		ctx.lineTo(1000, 1000);
+		ctx.lineTo(1000, 50);
+		ctx.closePath();
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.join.parallel", function () {
+		// Line joins are drawn at 180-degree joins
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 300;
+		ctx.lineJoin = 'round';
+		ctx.beginPath();
+		ctx.moveTo(-100, 25);
+		ctx.lineTo(0, 25);
+		ctx.lineTo(-100, 25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.join.valid", function () {
+		// Setting lineJoin to valid values works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineJoin = 'bevel'
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'round';
+		assert.strictEqual(ctx.lineJoin, 'round', "ctx.lineJoin", "'round'")
+		
+		ctx.lineJoin = 'miter';
+		assert.strictEqual(ctx.lineJoin, 'miter', "ctx.lineJoin", "'miter'")
+	});
+
+	it("2d.line.join.invalid", function () {
+		// Setting lineJoin to invalid values is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineJoin = 'bevel'
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineJoin = 'invalid';
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineJoin = 'ROUND';
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineJoin = 'round\0';
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineJoin = 'round ';
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineJoin = "";
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+		
+		ctx.lineJoin = 'bevel';
+		ctx.lineJoin = 'butt';
+		assert.strictEqual(ctx.lineJoin, 'bevel', "ctx.lineJoin", "'bevel'")
+	});
+
+	it("2d.line.miter.exceeded", function () {
+		// Miter joins are not drawn when the miter limit is exceeded
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 400;
+		ctx.lineJoin = 'miter';
+		
+		ctx.strokeStyle = '#f00';
+		ctx.miterLimit = 1.414;
+		ctx.beginPath();
+		ctx.moveTo(200, 1000);
+		ctx.lineTo(200, 200);
+		ctx.lineTo(1000, 201); // slightly non-right-angle to avoid being a special case
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.miter.acute", function () {
+		// Miter joins are drawn correctly with acute angles
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'miter';
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.miterLimit = 2.614;
+		ctx.beginPath();
+		ctx.moveTo(100, 1000);
+		ctx.lineTo(100, 100);
+		ctx.lineTo(1000, 1000);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.miterLimit = 2.613;
+		ctx.beginPath();
+		ctx.moveTo(100, 1000);
+		ctx.lineTo(100, 100);
+		ctx.lineTo(1000, 1000);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.miter.obtuse", function () {
+		// Miter joins are drawn correctly with obtuse angles
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 1600;
+		ctx.lineJoin = 'miter';
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.miterLimit = 1.083;
+		ctx.beginPath();
+		ctx.moveTo(800, 10000);
+		ctx.lineTo(800, 300);
+		ctx.lineTo(10000, -8900);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.miterLimit = 1.082;
+		ctx.beginPath();
+		ctx.moveTo(800, 10000);
+		ctx.lineTo(800, 300);
+		ctx.lineTo(10000, -8900);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.miter.rightangle", function () {
+		// Miter joins are not drawn when the miter limit is exceeded, on exact right angles
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 400;
+		ctx.lineJoin = 'miter';
+		
+		ctx.strokeStyle = '#f00';
+		ctx.miterLimit = 1.414;
+		ctx.beginPath();
+		ctx.moveTo(200, 1000);
+		ctx.lineTo(200, 200);
+		ctx.lineTo(1000, 200);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.miter.lineedge", function () {
+		// Miter joins are not drawn when the miter limit is exceeded at the corners of a zero-height rectangle
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'miter';
+		
+		ctx.strokeStyle = '#f00';
+		ctx.miterLimit = 1.414;
+		ctx.beginPath();
+		ctx.strokeRect(100, 25, 200, 0);
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.miter.within", function () {
+		// Miter joins are drawn when the miter limit is not quite exceeded
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 400;
+		ctx.lineJoin = 'miter';
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.miterLimit = 1.416;
+		ctx.beginPath();
+		ctx.moveTo(200, 1000);
+		ctx.lineTo(200, 200);
+		ctx.lineTo(1000, 201);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.miter.valid", function () {
+		// Setting miterLimit to valid values works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.miterLimit = 1.5;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = "1e1";
+		assert.strictEqual(ctx.miterLimit, 10, "ctx.miterLimit", "10")
+		
+		ctx.miterLimit = 1/1024;
+		assert.strictEqual(ctx.miterLimit, 1/1024, "ctx.miterLimit", "1/1024")
+		
+		ctx.miterLimit = 1000;
+		assert.strictEqual(ctx.miterLimit, 1000, "ctx.miterLimit", "1000")
+	});
+
+	it("2d.line.miter.invalid", function () {
+		// Setting miterLimit to invalid values is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.miterLimit = 1.5;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = 0;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = -1;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = Infinity;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = -Infinity;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = NaN;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = 'string';
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = true;
+		assert.strictEqual(ctx.miterLimit, 1, "ctx.miterLimit", "1")
+		
+		ctx.miterLimit = 1.5;
+		ctx.miterLimit = false;
+		assert.strictEqual(ctx.miterLimit, 1.5, "ctx.miterLimit", "1.5")
+	});
+
+	it("2d.line.cross", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'bevel';
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(110, 50);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(100, 60);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.line.union", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 24);
+		ctx.lineTo(100, 25);
+		ctx.lineTo(0, 26);
+		ctx.closePath();
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 25,1, 0,255,0,255);
+		_assertPixel(canvas, 48,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 25,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+	});
+
+	it("2d.line.invalid.strokestyle", function () {
+		// Verify correct behavior of canvas on an invalid strokeStyle()
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.strokeStyle = 'rgb(0, 255, 0)';
+		ctx.strokeStyle = 'nonsense';
+		ctx.lineWidth = 200;
+		ctx.moveTo(0,100);
+		ctx.lineTo(200,100);
+		ctx.stroke();
+		var imageData = ctx.getImageData(0, 0, 200, 200);
+		var imgdata = imageData.data;
+		assert(imgdata[4] == 0, "imgdata[\""+(4)+"\"] == 0");
+		assert(imgdata[5] == 255, "imgdata[\""+(5)+"\"] == 255");
+		assert(imgdata[6] == 0, "imgdata[\""+(6)+"\"] == 0");
+	});
+});

--- a/test/wpt/generated/meta.js
+++ b/test/wpt/generated/meta.js
@@ -1,0 +1,92 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: meta", function () {
+});

--- a/test/wpt/generated/path-objects.js
+++ b/test/wpt/generated/path-objects.js
@@ -1,0 +1,4352 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: path-objects", function () {
+
+	it("2d.path.initial", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.closePath();
+		ctx.fillStyle = '#f00';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.beginPath", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.rect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.fillStyle = '#f00';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.moveTo.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.rect(0, 0, 10, 50);
+		ctx.moveTo(100, 0);
+		ctx.lineTo(10, 0);
+		ctx.lineTo(10, 50);
+		ctx.lineTo(100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 90,25, 0,255,0,255);
+	});
+
+	it("2d.path.moveTo.newsubpath", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.moveTo(0, 0);
+		ctx.moveTo(100, 0);
+		ctx.moveTo(100, 50);
+		ctx.moveTo(0, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.moveTo.multiple", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.moveTo(0, 25);
+		ctx.moveTo(100, 25);
+		ctx.moveTo(0, 25);
+		ctx.lineTo(100, 25);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.moveTo.nonfinite", function () {
+		// moveTo() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.moveTo(Infinity, 50);
+		ctx.moveTo(-Infinity, 50);
+		ctx.moveTo(NaN, 50);
+		ctx.moveTo(0, Infinity);
+		ctx.moveTo(0, -Infinity);
+		ctx.moveTo(0, NaN);
+		ctx.moveTo(Infinity, Infinity);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.closePath.empty", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.closePath();
+		ctx.fillStyle = '#f00';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.closePath.newline", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.moveTo(-100, 25);
+		ctx.lineTo(-100, -100);
+		ctx.lineTo(200, -100);
+		ctx.lineTo(200, 25);
+		ctx.closePath();
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.closePath.nextpoint", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.moveTo(-100, 25);
+		ctx.lineTo(-100, -1000);
+		ctx.closePath();
+		ctx.lineTo(1000, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.lineTo.ensuresubpath.1", function () {
+		// If there is no subpath, the point is added and nothing is drawn
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.lineTo(100, 50);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.lineTo.ensuresubpath.2", function () {
+		// If there is no subpath, the point is added and used for subsequent drawing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.lineTo(0, 25);
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.lineTo.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.lineTo.nextpoint", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.moveTo(-100, -100);
+		ctx.lineTo(0, 25);
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.lineTo.nonfinite", function () {
+		// lineTo() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.lineTo(Infinity, 50);
+		ctx.lineTo(-Infinity, 50);
+		ctx.lineTo(NaN, 50);
+		ctx.lineTo(0, Infinity);
+		ctx.lineTo(0, -Infinity);
+		ctx.lineTo(0, NaN);
+		ctx.lineTo(Infinity, Infinity);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.lineTo.nonfinite.details", function () {
+		// lineTo() with Infinity/NaN for first arg still converts the second arg
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		for (var arg1 of [Infinity, -Infinity, NaN]) {
+		  var converted = false;
+		  ctx.lineTo(arg1, { valueOf: function() { converted = true; return 0; } });
+		  assert(converted, "converted");
+		}
+	});
+
+	it("2d.path.quadraticCurveTo.ensuresubpath.1", function () {
+		// If there is no subpath, the first control point is added (and nothing is drawn up to it)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.quadraticCurveTo(100, 50, 200, 50);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 95,45, 0,255,0,255);
+	});
+
+	it("2d.path.quadraticCurveTo.ensuresubpath.2", function () {
+		// If there is no subpath, the first control point is added
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.quadraticCurveTo(0, 25, 100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 5,45, 0,255,0,255);
+	});
+
+	it("2d.path.quadraticCurveTo.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.quadraticCurveTo(100, 25, 100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.quadraticCurveTo.shape", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 55;
+		ctx.beginPath();
+		ctx.moveTo(-1000, 1050);
+		ctx.quadraticCurveTo(0, -1000, 1200, 1050);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.quadraticCurveTo.scaled", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.scale(1000, 1000);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 0.055;
+		ctx.beginPath();
+		ctx.moveTo(-1, 1.05);
+		ctx.quadraticCurveTo(0, -1, 1.2, 1.05);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.quadraticCurveTo.nonfinite", function () {
+		// quadraticCurveTo() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.quadraticCurveTo(Infinity, 50, 0, 50);
+		ctx.quadraticCurveTo(-Infinity, 50, 0, 50);
+		ctx.quadraticCurveTo(NaN, 50, 0, 50);
+		ctx.quadraticCurveTo(0, Infinity, 0, 50);
+		ctx.quadraticCurveTo(0, -Infinity, 0, 50);
+		ctx.quadraticCurveTo(0, NaN, 0, 50);
+		ctx.quadraticCurveTo(0, 50, Infinity, 50);
+		ctx.quadraticCurveTo(0, 50, -Infinity, 50);
+		ctx.quadraticCurveTo(0, 50, NaN, 50);
+		ctx.quadraticCurveTo(0, 50, 0, Infinity);
+		ctx.quadraticCurveTo(0, 50, 0, -Infinity);
+		ctx.quadraticCurveTo(0, 50, 0, NaN);
+		ctx.quadraticCurveTo(Infinity, Infinity, 0, 50);
+		ctx.quadraticCurveTo(Infinity, Infinity, Infinity, 50);
+		ctx.quadraticCurveTo(Infinity, Infinity, Infinity, Infinity);
+		ctx.quadraticCurveTo(Infinity, Infinity, 0, Infinity);
+		ctx.quadraticCurveTo(Infinity, 50, Infinity, 50);
+		ctx.quadraticCurveTo(Infinity, 50, Infinity, Infinity);
+		ctx.quadraticCurveTo(Infinity, 50, 0, Infinity);
+		ctx.quadraticCurveTo(0, Infinity, Infinity, 50);
+		ctx.quadraticCurveTo(0, Infinity, Infinity, Infinity);
+		ctx.quadraticCurveTo(0, Infinity, 0, Infinity);
+		ctx.quadraticCurveTo(0, 50, Infinity, Infinity);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.bezierCurveTo.ensuresubpath.1", function () {
+		// If there is no subpath, the first control point is added (and nothing is drawn up to it)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.bezierCurveTo(100, 50, 200, 50, 200, 50);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 95,45, 0,255,0,255);
+	});
+
+	it("2d.path.bezierCurveTo.ensuresubpath.2", function () {
+		// If there is no subpath, the first control point is added
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.bezierCurveTo(0, 25, 100, 25, 100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 5,45, 0,255,0,255);
+	});
+
+	it("2d.path.bezierCurveTo.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.bezierCurveTo(100, 25, 100, 25, 100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.bezierCurveTo.shape", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 55;
+		ctx.beginPath();
+		ctx.moveTo(-2000, 3100);
+		ctx.bezierCurveTo(-2000, -1000, 2100, -1000, 2100, 3100);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.bezierCurveTo.scaled", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.scale(1000, 1000);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 0.055;
+		ctx.beginPath();
+		ctx.moveTo(-2, 3.1);
+		ctx.bezierCurveTo(-2, -1, 2.1, -1, 2.1, 3.1);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.bezierCurveTo.nonfinite", function () {
+		// bezierCurveTo() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.bezierCurveTo(Infinity, 50, 0, 50, 0, 50);
+		ctx.bezierCurveTo(-Infinity, 50, 0, 50, 0, 50);
+		ctx.bezierCurveTo(NaN, 50, 0, 50, 0, 50);
+		ctx.bezierCurveTo(0, Infinity, 0, 50, 0, 50);
+		ctx.bezierCurveTo(0, -Infinity, 0, 50, 0, 50);
+		ctx.bezierCurveTo(0, NaN, 0, 50, 0, 50);
+		ctx.bezierCurveTo(0, 50, Infinity, 50, 0, 50);
+		ctx.bezierCurveTo(0, 50, -Infinity, 50, 0, 50);
+		ctx.bezierCurveTo(0, 50, NaN, 50, 0, 50);
+		ctx.bezierCurveTo(0, 50, 0, Infinity, 0, 50);
+		ctx.bezierCurveTo(0, 50, 0, -Infinity, 0, 50);
+		ctx.bezierCurveTo(0, 50, 0, NaN, 0, 50);
+		ctx.bezierCurveTo(0, 50, 0, 50, Infinity, 50);
+		ctx.bezierCurveTo(0, 50, 0, 50, -Infinity, 50);
+		ctx.bezierCurveTo(0, 50, 0, 50, NaN, 50);
+		ctx.bezierCurveTo(0, 50, 0, 50, 0, Infinity);
+		ctx.bezierCurveTo(0, 50, 0, 50, 0, -Infinity);
+		ctx.bezierCurveTo(0, 50, 0, 50, 0, NaN);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, 50, 0, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, 50, 0, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, Infinity, 0, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, 50, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, Infinity, 50, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, Infinity, 0, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, 50, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, Infinity, 0, 50, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, 50, 0, 50);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, Infinity, 0, 50);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, 50, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, Infinity, 50, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, 0, Infinity, 0, 50);
+		ctx.bezierCurveTo(Infinity, 50, 0, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, 50, 0, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, 0, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, 0, 50, Infinity, 50);
+		ctx.bezierCurveTo(Infinity, 50, 0, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(Infinity, 50, 0, 50, 0, Infinity);
+		ctx.bezierCurveTo(0, Infinity, Infinity, 50, 0, 50);
+		ctx.bezierCurveTo(0, Infinity, Infinity, Infinity, 0, 50);
+		ctx.bezierCurveTo(0, Infinity, Infinity, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(0, Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(0, Infinity, Infinity, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(0, Infinity, Infinity, 50, Infinity, 50);
+		ctx.bezierCurveTo(0, Infinity, Infinity, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(0, Infinity, Infinity, 50, 0, Infinity);
+		ctx.bezierCurveTo(0, Infinity, 0, Infinity, 0, 50);
+		ctx.bezierCurveTo(0, Infinity, 0, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(0, Infinity, 0, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(0, Infinity, 0, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(0, Infinity, 0, 50, Infinity, 50);
+		ctx.bezierCurveTo(0, Infinity, 0, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(0, Infinity, 0, 50, 0, Infinity);
+		ctx.bezierCurveTo(0, 50, Infinity, Infinity, 0, 50);
+		ctx.bezierCurveTo(0, 50, Infinity, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(0, 50, Infinity, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(0, 50, Infinity, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(0, 50, Infinity, 50, Infinity, 50);
+		ctx.bezierCurveTo(0, 50, Infinity, 50, Infinity, Infinity);
+		ctx.bezierCurveTo(0, 50, Infinity, 50, 0, Infinity);
+		ctx.bezierCurveTo(0, 50, 0, Infinity, Infinity, 50);
+		ctx.bezierCurveTo(0, 50, 0, Infinity, Infinity, Infinity);
+		ctx.bezierCurveTo(0, 50, 0, Infinity, 0, Infinity);
+		ctx.bezierCurveTo(0, 50, 0, 50, Infinity, Infinity);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.ensuresubpath.1", function () {
+		// If there is no subpath, the first control point is added (and nothing is drawn up to it)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.arcTo(100, 50, 200, 50, 0.1);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.ensuresubpath.2", function () {
+		// If there is no subpath, the first control point is added
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.arcTo(0, 25, 50, 250, 0.1); // adds (x1,y1), draws nothing
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.coincide.1", function () {
+		// arcTo() has no effect if P0 = P1
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(0, 25, 50, 1000, 1);
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.arcTo(50, 25, 100, 25, 1);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,1, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 50,48, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.coincide.2", function () {
+		// arcTo() draws a straight line to P1 if P1 = P2
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(100, 25, 100, 25, 1);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.collinear.1", function () {
+		// arcTo() with all points on a line, and P1 between P0/P2, draws a straight line to P1
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(100, 25, 200, 25, 1);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(-100, 25);
+		ctx.arcTo(0, 25, 100, 25, 1);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.collinear.2", function () {
+		// arcTo() with all points on a line, and P2 between P0/P1, draws a straight line to P1
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(100, 25, 10, 25, 1);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 25);
+		ctx.arcTo(200, 25, 110, 25, 1);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.collinear.3", function () {
+		// arcTo() with all points on a line, and P0 between P1/P2, draws a straight line to P1
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(100, 25, -100, 25, 1);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 25);
+		ctx.arcTo(200, 25, 0, 25, 1);
+		ctx.stroke();
+		
+		ctx.beginPath();
+		ctx.moveTo(-100, 25);
+		ctx.arcTo(0, 25, -200, 25, 1);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.shape.curve1", function () {
+		// arcTo() curves in the right kind of shape
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var tol = 1.5; // tolerance to avoid antialiasing artifacts
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 10;
+		ctx.beginPath();
+		ctx.moveTo(10, 25);
+		ctx.arcTo(75, 25, 75, 60, 20);
+		ctx.stroke();
+		
+		ctx.fillStyle = '#0f0';
+		ctx.beginPath();
+		ctx.rect(10, 20, 45, 10);
+		ctx.moveTo(80, 45);
+		ctx.arc(55, 45, 25+tol, 0, -Math.PI/2, true);
+		ctx.arc(55, 45, 15-tol, -Math.PI/2, 0, false);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 55,19, 0,255,0,255);
+		_assertPixel(canvas, 55,20, 0,255,0,255);
+		_assertPixel(canvas, 55,21, 0,255,0,255);
+		_assertPixel(canvas, 64,22, 0,255,0,255);
+		_assertPixel(canvas, 65,21, 0,255,0,255);
+		_assertPixel(canvas, 72,28, 0,255,0,255);
+		_assertPixel(canvas, 73,27, 0,255,0,255);
+		_assertPixel(canvas, 78,36, 0,255,0,255);
+		_assertPixel(canvas, 79,35, 0,255,0,255);
+		_assertPixel(canvas, 80,44, 0,255,0,255);
+		_assertPixel(canvas, 80,45, 0,255,0,255);
+		_assertPixel(canvas, 80,46, 0,255,0,255);
+		_assertPixel(canvas, 65,45, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.shape.curve2", function () {
+		// arcTo() curves in the right kind of shape
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var tol = 1.5; // tolerance to avoid antialiasing artifacts
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.rect(10, 20, 45, 10);
+		ctx.moveTo(80, 45);
+		ctx.arc(55, 45, 25-tol, 0, -Math.PI/2, true);
+		ctx.arc(55, 45, 15+tol, -Math.PI/2, 0, false);
+		ctx.fill();
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 10;
+		ctx.beginPath();
+		ctx.moveTo(10, 25);
+		ctx.arcTo(75, 25, 75, 60, 20);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 55,19, 0,255,0,255);
+		_assertPixel(canvas, 55,20, 0,255,0,255);
+		_assertPixel(canvas, 55,21, 0,255,0,255);
+		_assertPixel(canvas, 64,22, 0,255,0,255);
+		_assertPixel(canvas, 65,21, 0,255,0,255);
+		_assertPixel(canvas, 72,28, 0,255,0,255);
+		_assertPixel(canvas, 73,27, 0,255,0,255);
+		_assertPixel(canvas, 78,36, 0,255,0,255);
+		_assertPixel(canvas, 79,35, 0,255,0,255);
+		_assertPixel(canvas, 80,44, 0,255,0,255);
+		_assertPixel(canvas, 80,45, 0,255,0,255);
+		_assertPixel(canvas, 80,46, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.shape.start", function () {
+		// arcTo() draws a straight line from P0 to P1
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(200, 25, 200, 50, 10);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.shape.end", function () {
+		// arcTo() does not draw anything from P1 to P2
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.beginPath();
+		ctx.moveTo(-100, -100);
+		ctx.arcTo(-100, 25, 200, 25, 10);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.negative", function () {
+		// arcTo() with negative radius throws an exception
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.arcTo(0, 0, 0, 0, -1); }, /INDEX_SIZE_ERR/);
+		var path = new Path2D();
+		assert.throws(function() { path.arcTo(10, 10, 20, 20, -5); }, /INDEX_SIZE_ERR/);
+	});
+
+	it("2d.path.arcTo.zero.1", function () {
+		// arcTo() with zero radius draws a straight line from P0 to P1
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(100, 25, 100, 100, 0);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(0, -25);
+		ctx.arcTo(50, -25, 50, 50, 0);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.zero.2", function () {
+		// arcTo() with zero radius draws a straight line from P0 to P1, even when all points are collinear
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arcTo(100, 25, -100, 25, 0);
+		ctx.stroke();
+		
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 25);
+		ctx.arcTo(200, 25, 50, 25, 0);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.transformation", function () {
+		// arcTo joins up to the last subpath point correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 50);
+		ctx.translate(100, 0);
+		ctx.arcTo(50, 50, 50, 0, 50);
+		ctx.lineTo(-100, 0);
+		ctx.fill();
+		
+		_assertPixel(canvas, 0,0, 0,255,0,255);
+		_assertPixel(canvas, 50,0, 0,255,0,255);
+		_assertPixel(canvas, 99,0, 0,255,0,255);
+		_assertPixel(canvas, 0,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 99,25, 0,255,0,255);
+		_assertPixel(canvas, 0,49, 0,255,0,255);
+		_assertPixel(canvas, 50,49, 0,255,0,255);
+		_assertPixel(canvas, 99,49, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.scale", function () {
+		// arcTo scales the curve, not just the control points
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 50);
+		ctx.translate(100, 0);
+		ctx.scale(0.1, 1);
+		ctx.arcTo(50, 50, 50, 0, 50);
+		ctx.lineTo(-1000, 0);
+		ctx.fill();
+		
+		_assertPixel(canvas, 0,0, 0,255,0,255);
+		_assertPixel(canvas, 50,0, 0,255,0,255);
+		_assertPixel(canvas, 99,0, 0,255,0,255);
+		_assertPixel(canvas, 0,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 99,25, 0,255,0,255);
+		_assertPixel(canvas, 0,49, 0,255,0,255);
+		_assertPixel(canvas, 50,49, 0,255,0,255);
+		_assertPixel(canvas, 99,49, 0,255,0,255);
+	});
+
+	it("2d.path.arcTo.nonfinite", function () {
+		// arcTo() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.arcTo(Infinity, 50, 0, 50, 0);
+		ctx.arcTo(-Infinity, 50, 0, 50, 0);
+		ctx.arcTo(NaN, 50, 0, 50, 0);
+		ctx.arcTo(0, Infinity, 0, 50, 0);
+		ctx.arcTo(0, -Infinity, 0, 50, 0);
+		ctx.arcTo(0, NaN, 0, 50, 0);
+		ctx.arcTo(0, 50, Infinity, 50, 0);
+		ctx.arcTo(0, 50, -Infinity, 50, 0);
+		ctx.arcTo(0, 50, NaN, 50, 0);
+		ctx.arcTo(0, 50, 0, Infinity, 0);
+		ctx.arcTo(0, 50, 0, -Infinity, 0);
+		ctx.arcTo(0, 50, 0, NaN, 0);
+		ctx.arcTo(0, 50, 0, 50, Infinity);
+		ctx.arcTo(0, 50, 0, 50, -Infinity);
+		ctx.arcTo(0, 50, 0, 50, NaN);
+		ctx.arcTo(Infinity, Infinity, 0, 50, 0);
+		ctx.arcTo(Infinity, Infinity, Infinity, 50, 0);
+		ctx.arcTo(Infinity, Infinity, Infinity, Infinity, 0);
+		ctx.arcTo(Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.arcTo(Infinity, Infinity, Infinity, 50, Infinity);
+		ctx.arcTo(Infinity, Infinity, 0, Infinity, 0);
+		ctx.arcTo(Infinity, Infinity, 0, Infinity, Infinity);
+		ctx.arcTo(Infinity, Infinity, 0, 50, Infinity);
+		ctx.arcTo(Infinity, 50, Infinity, 50, 0);
+		ctx.arcTo(Infinity, 50, Infinity, Infinity, 0);
+		ctx.arcTo(Infinity, 50, Infinity, Infinity, Infinity);
+		ctx.arcTo(Infinity, 50, Infinity, 50, Infinity);
+		ctx.arcTo(Infinity, 50, 0, Infinity, 0);
+		ctx.arcTo(Infinity, 50, 0, Infinity, Infinity);
+		ctx.arcTo(Infinity, 50, 0, 50, Infinity);
+		ctx.arcTo(0, Infinity, Infinity, 50, 0);
+		ctx.arcTo(0, Infinity, Infinity, Infinity, 0);
+		ctx.arcTo(0, Infinity, Infinity, Infinity, Infinity);
+		ctx.arcTo(0, Infinity, Infinity, 50, Infinity);
+		ctx.arcTo(0, Infinity, 0, Infinity, 0);
+		ctx.arcTo(0, Infinity, 0, Infinity, Infinity);
+		ctx.arcTo(0, Infinity, 0, 50, Infinity);
+		ctx.arcTo(0, 50, Infinity, Infinity, 0);
+		ctx.arcTo(0, 50, Infinity, Infinity, Infinity);
+		ctx.arcTo(0, 50, Infinity, 50, Infinity);
+		ctx.arcTo(0, 50, 0, Infinity, Infinity);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.arc.empty", function () {
+		// arc() with an empty path does not draw a straight line to the start point
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.arc(200, 25, 5, 0, 2*Math.PI, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.nonempty", function () {
+		// arc() with a non-empty path does draw a straight line to the start point
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arc(200, 25, 5, 0, 2*Math.PI, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.end", function () {
+		// arc() adds the end point of the arc to the subpath
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(-100, 0);
+		ctx.arc(-100, 0, 25, -Math.PI/2, Math.PI/2, true);
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.default", function () {
+		// arc() with missing last argument defaults to clockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 0);
+		ctx.arc(100, 0, 150, -Math.PI, Math.PI/2);
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.angle.1", function () {
+		// arc() draws pi/2 .. -pi anticlockwise correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 0);
+		ctx.arc(100, 0, 150, Math.PI/2, -Math.PI, true);
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.angle.2", function () {
+		// arc() draws -3pi/2 .. -pi anticlockwise correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 0);
+		ctx.arc(100, 0, 150, -3*Math.PI/2, -Math.PI, true);
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.angle.3", function () {
+		// arc() wraps angles mod 2pi when anticlockwise and end > start+2pi
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 0);
+		ctx.arc(100, 0, 150, (512+1/2)*Math.PI, (1024-1)*Math.PI, true);
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.angle.4", function () {
+		// arc() draws a full circle when clockwise and end > start+2pi
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.arc(50, 25, 60, (512+1/2)*Math.PI, (1024-1)*Math.PI, false);
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.angle.5", function () {
+		// arc() wraps angles mod 2pi when clockwise and start > end+2pi
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(100, 0);
+		ctx.arc(100, 0, 150, (1024-1)*Math.PI, (512+1/2)*Math.PI, false);
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.angle.6", function () {
+		// arc() draws a full circle when anticlockwise and start > end+2pi
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.arc(50, 25, 60, (1024-1)*Math.PI, (512+1/2)*Math.PI, true);
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.zero.1", function () {
+		// arc() draws nothing when startAngle = endAngle and anticlockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.arc(50, 25, 50, 0, 0, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,20, 0,255,0,255);
+	});
+
+	it("2d.path.arc.zero.2", function () {
+		// arc() draws nothing when startAngle = endAngle and clockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.arc(50, 25, 50, 0, 0, false);
+		ctx.stroke();
+		_assertPixel(canvas, 50,20, 0,255,0,255);
+	});
+
+	it("2d.path.arc.twopie.1", function () {
+		// arc() draws nothing when end = start + 2pi-e and anticlockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.arc(50, 25, 50, 0, 2*Math.PI - 1e-4, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,20, 0,255,0,255);
+	});
+
+	it("2d.path.arc.twopie.2", function () {
+		// arc() draws a full circle when end = start + 2pi-e and clockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.arc(50, 25, 50, 0, 2*Math.PI - 1e-4, false);
+		ctx.stroke();
+		_assertPixel(canvas, 50,20, 0,255,0,255);
+	});
+
+	it("2d.path.arc.twopie.3", function () {
+		// arc() draws a full circle when end = start + 2pi+e and anticlockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.arc(50, 25, 50, 0, 2*Math.PI + 1e-4, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,20, 0,255,0,255);
+	});
+
+	it("2d.path.arc.twopie.4", function () {
+		// arc() draws nothing when end = start + 2pi+e and clockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.arc(50, 25, 50, 0, 2*Math.PI + 1e-4, false);
+		ctx.stroke();
+		_assertPixel(canvas, 50,20, 0,255,0,255);
+	});
+
+	it("2d.path.arc.shape.1", function () {
+		// arc() from 0 to pi does not draw anything in the wrong half
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.arc(50, 50, 50, 0, Math.PI, false);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 20,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.shape.2", function () {
+		// arc() from 0 to pi draws stuff in the right half
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 100;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.arc(50, 50, 50, 0, Math.PI, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 20,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.shape.3", function () {
+		// arc() from 0 to -pi/2 does not draw anything in the wrong quadrant
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 100;
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.arc(0, 50, 50, 0, -Math.PI/2, false);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.shape.4", function () {
+		// arc() from 0 to -pi/2 draws stuff in the right quadrant
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 150;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.arc(-50, 50, 100, 0, -Math.PI/2, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.shape.5", function () {
+		// arc() from 0 to 5pi does not draw crazy things
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 200;
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.arc(300, 0, 100, 0, 5*Math.PI, false);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.selfintersect.1", function () {
+		// arc() with lineWidth > 2*radius is drawn sensibly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 200;
+		ctx.strokeStyle = '#f00';
+		ctx.beginPath();
+		ctx.arc(100, 50, 25, 0, -Math.PI/2, true);
+		ctx.stroke();
+		ctx.beginPath();
+		ctx.arc(0, 0, 25, 0, -Math.PI/2, true);
+		ctx.stroke();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.selfintersect.2", function () {
+		// arc() with lineWidth > 2*radius is drawn sensibly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 180;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.arc(-50, 50, 25, 0, -Math.PI/2, true);
+		ctx.stroke();
+		ctx.beginPath();
+		ctx.arc(100, 0, 25, 0, -Math.PI/2, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,10, 0,255,0,255);
+		_assertPixel(canvas, 97,1, 0,255,0,255);
+		_assertPixel(canvas, 97,2, 0,255,0,255);
+		_assertPixel(canvas, 97,3, 0,255,0,255);
+		_assertPixel(canvas, 2,48, 0,255,0,255);
+	});
+
+	it("2d.path.arc.negative", function () {
+		// arc() with negative radius throws INDEX_SIZE_ERR
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.arc(0, 0, -1, 0, 0, true); }, /INDEX_SIZE_ERR/);
+		var path = new Path2D();
+		assert.throws(function() { path.arc(10, 10, -5, 0, 1, false); }, /INDEX_SIZE_ERR/);
+	});
+
+	it("2d.path.arc.zeroradius", function () {
+		// arc() with zero radius draws a line to the start point
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00'
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.lineWidth = 50;
+		ctx.strokeStyle = '#0f0';
+		ctx.beginPath();
+		ctx.moveTo(0, 25);
+		ctx.arc(200, 25, 0, 0, Math.PI, true);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.arc.scale.1", function () {
+		// Non-uniformly scaled arcs are the right shape
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.scale(2, 0.5);
+		ctx.fillStyle = '#0f0';
+		ctx.beginPath();
+		ctx.arc(25, 50, 56, 0, 2*Math.PI, false);
+		ctx.fill();
+		ctx.fillStyle = '#f00';
+		ctx.beginPath();
+		ctx.moveTo(-25, 50);
+		ctx.arc(-25, 50, 24, 0, 2*Math.PI, false);
+		ctx.moveTo(75, 50);
+		ctx.arc(75, 50, 24, 0, 2*Math.PI, false);
+		ctx.moveTo(25, -25);
+		ctx.arc(25, -25, 24, 0, 2*Math.PI, false);
+		ctx.moveTo(25, 125);
+		ctx.arc(25, 125, 24, 0, 2*Math.PI, false);
+		ctx.fill();
+		
+		_assertPixel(canvas, 0,0, 0,255,0,255);
+		_assertPixel(canvas, 50,0, 0,255,0,255);
+		_assertPixel(canvas, 99,0, 0,255,0,255);
+		_assertPixel(canvas, 0,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 99,25, 0,255,0,255);
+		_assertPixel(canvas, 0,49, 0,255,0,255);
+		_assertPixel(canvas, 50,49, 0,255,0,255);
+		_assertPixel(canvas, 99,49, 0,255,0,255);
+	});
+
+	it("2d.path.arc.scale.2", function () {
+		// Highly scaled arcs are the right shape
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.scale(100, 100);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 1.2;
+		ctx.beginPath();
+		ctx.arc(0, 0, 0.6, 0, Math.PI/2, false);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 50,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,25, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 50,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it.skip("2d.path.arc.nonfinite", function () {
+		// arc() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.arc(Infinity, 0, 50, 0, 2*Math.PI, true);
+		ctx.arc(-Infinity, 0, 50, 0, 2*Math.PI, true);
+		ctx.arc(NaN, 0, 50, 0, 2*Math.PI, true);
+		ctx.arc(0, Infinity, 50, 0, 2*Math.PI, true);
+		ctx.arc(0, -Infinity, 50, 0, 2*Math.PI, true);
+		ctx.arc(0, NaN, 50, 0, 2*Math.PI, true);
+		ctx.arc(0, 0, Infinity, 0, 2*Math.PI, true);
+		ctx.arc(0, 0, -Infinity, 0, 2*Math.PI, true);
+		ctx.arc(0, 0, NaN, 0, 2*Math.PI, true);
+		ctx.arc(0, 0, 50, Infinity, 2*Math.PI, true);
+		ctx.arc(0, 0, 50, -Infinity, 2*Math.PI, true);
+		ctx.arc(0, 0, 50, NaN, 2*Math.PI, true);
+		ctx.arc(0, 0, 50, 0, Infinity, true);
+		ctx.arc(0, 0, 50, 0, -Infinity, true);
+		ctx.arc(0, 0, 50, 0, NaN, true);
+		ctx.arc(Infinity, Infinity, 50, 0, 2*Math.PI, true);
+		ctx.arc(Infinity, Infinity, Infinity, 0, 2*Math.PI, true);
+		ctx.arc(Infinity, Infinity, Infinity, Infinity, 2*Math.PI, true);
+		ctx.arc(Infinity, Infinity, Infinity, Infinity, Infinity, true);
+		ctx.arc(Infinity, Infinity, Infinity, 0, Infinity, true);
+		ctx.arc(Infinity, Infinity, 50, Infinity, 2*Math.PI, true);
+		ctx.arc(Infinity, Infinity, 50, Infinity, Infinity, true);
+		ctx.arc(Infinity, Infinity, 50, 0, Infinity, true);
+		ctx.arc(Infinity, 0, Infinity, 0, 2*Math.PI, true);
+		ctx.arc(Infinity, 0, Infinity, Infinity, 2*Math.PI, true);
+		ctx.arc(Infinity, 0, Infinity, Infinity, Infinity, true);
+		ctx.arc(Infinity, 0, Infinity, 0, Infinity, true);
+		ctx.arc(Infinity, 0, 50, Infinity, 2*Math.PI, true);
+		ctx.arc(Infinity, 0, 50, Infinity, Infinity, true);
+		ctx.arc(Infinity, 0, 50, 0, Infinity, true);
+		ctx.arc(0, Infinity, Infinity, 0, 2*Math.PI, true);
+		ctx.arc(0, Infinity, Infinity, Infinity, 2*Math.PI, true);
+		ctx.arc(0, Infinity, Infinity, Infinity, Infinity, true);
+		ctx.arc(0, Infinity, Infinity, 0, Infinity, true);
+		ctx.arc(0, Infinity, 50, Infinity, 2*Math.PI, true);
+		ctx.arc(0, Infinity, 50, Infinity, Infinity, true);
+		ctx.arc(0, Infinity, 50, 0, Infinity, true);
+		ctx.arc(0, 0, Infinity, Infinity, 2*Math.PI, true);
+		ctx.arc(0, 0, Infinity, Infinity, Infinity, true);
+		ctx.arc(0, 0, Infinity, 0, Infinity, true);
+		ctx.arc(0, 0, 50, Infinity, Infinity, true);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.rect.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.rect(0, 0, 100, 50);
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.newsubpath", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.moveTo(-100, 25);
+		ctx.lineTo(-50, 25);
+		ctx.rect(200, 25, 1, 1);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.closed", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'miter';
+		ctx.rect(100, 50, 100, 100);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.end.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.rect(200, 100, 400, 1000);
+		ctx.lineTo(-2000, -1000);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.end.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 450;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'bevel';
+		ctx.rect(150, 150, 2000, 2000);
+		ctx.lineTo(160, 160);
+		ctx.stroke();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.rect.zero.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.rect(0, 50, 100, 0);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.zero.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.rect(50, -100, 0, 250);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.zero.3", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.rect(50, 25, 0, 0);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.zero.4", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.rect(100, 25, 0, 0);
+		ctx.lineTo(0, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.zero.5", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.moveTo(0, 0);
+		ctx.rect(100, 25, 0, 0);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.zero.6", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineJoin = 'miter';
+		ctx.miterLimit = 1.5;
+		ctx.lineWidth = 200;
+		ctx.beginPath();
+		ctx.rect(100, 25, 1000, 0);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.negative", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.fillStyle = '#0f0';
+		ctx.rect(0, 0, 50, 25);
+		ctx.rect(100, 0, -50, 25);
+		ctx.rect(0, 50, 50, -25);
+		ctx.rect(100, 50, -50, -25);
+		ctx.fill();
+		_assertPixel(canvas, 25,12, 0,255,0,255);
+		_assertPixel(canvas, 75,12, 0,255,0,255);
+		_assertPixel(canvas, 25,37, 0,255,0,255);
+		_assertPixel(canvas, 75,37, 0,255,0,255);
+	});
+
+	it("2d.path.rect.winding", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.fillStyle = '#f00';
+		ctx.rect(0, 0, 50, 50);
+		ctx.rect(100, 50, -50, -50);
+		ctx.rect(0, 25, 100, -25);
+		ctx.rect(100, 25, -100, 25);
+		ctx.fill();
+		_assertPixel(canvas, 25,12, 0,255,0,255);
+		_assertPixel(canvas, 75,12, 0,255,0,255);
+		_assertPixel(canvas, 25,37, 0,255,0,255);
+		_assertPixel(canvas, 75,37, 0,255,0,255);
+	});
+
+	it("2d.path.rect.selfintersect", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 90;
+		ctx.beginPath();
+		ctx.rect(45, 20, 10, 10);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.rect.nonfinite", function () {
+		// rect() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.rect(Infinity, 50, 1, 1);
+		ctx.rect(-Infinity, 50, 1, 1);
+		ctx.rect(NaN, 50, 1, 1);
+		ctx.rect(0, Infinity, 1, 1);
+		ctx.rect(0, -Infinity, 1, 1);
+		ctx.rect(0, NaN, 1, 1);
+		ctx.rect(0, 50, Infinity, 1);
+		ctx.rect(0, 50, -Infinity, 1);
+		ctx.rect(0, 50, NaN, 1);
+		ctx.rect(0, 50, 1, Infinity);
+		ctx.rect(0, 50, 1, -Infinity);
+		ctx.rect(0, 50, 1, NaN);
+		ctx.rect(Infinity, Infinity, 1, 1);
+		ctx.rect(Infinity, Infinity, Infinity, 1);
+		ctx.rect(Infinity, Infinity, Infinity, Infinity);
+		ctx.rect(Infinity, Infinity, 1, Infinity);
+		ctx.rect(Infinity, 50, Infinity, 1);
+		ctx.rect(Infinity, 50, Infinity, Infinity);
+		ctx.rect(Infinity, 50, 1, Infinity);
+		ctx.rect(0, Infinity, Infinity, 1);
+		ctx.rect(0, Infinity, Infinity, Infinity);
+		ctx.rect(0, Infinity, 1, Infinity);
+		ctx.rect(0, 50, Infinity, Infinity);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.newsubpath", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.moveTo(-100, 25);
+		ctx.lineTo(-50, 25);
+		ctx.roundRect(200, 25, 1, 1, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.closed", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'miter';
+		ctx.roundRect(100, 50, 100, 100, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.end.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.roundRect(200, 100, 400, 1000, [0]);
+		ctx.lineTo(-2000, -1000);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.end.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 450;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'bevel';
+		ctx.roundRect(150, 150, 2000, 2000, [0]);
+		ctx.lineTo(160, 160);
+		ctx.stroke();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.end.3", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.roundRect(101, 51, 2000, 2000, [500, 500, 500, 500]);
+		ctx.lineTo(-1, -1);
+		ctx.stroke();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.end.4", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 10;
+		ctx.roundRect(-1, -1, 2000, 2000, [1000, 1000, 1000, 1000]);
+		ctx.lineTo(-150, -150);
+		ctx.stroke();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.zero.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.roundRect(0, 50, 100, 0, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.zero.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.roundRect(50, -100, 0, 250, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.zero.3", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.beginPath();
+		ctx.roundRect(50, 25, 0, 0, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.zero.4", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 50;
+		ctx.roundRect(100, 25, 0, 0, [0]);
+		ctx.lineTo(0, 25);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.zero.5", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.moveTo(0, 0);
+		ctx.roundRect(100, 25, 0, 0, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.zero.6", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.lineJoin = 'miter';
+		ctx.miterLimit = 1.5;
+		ctx.lineWidth = 200;
+		ctx.beginPath();
+		ctx.roundRect(100, 25, 1000, 0, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.negative", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.fillStyle = '#0f0';
+		ctx.roundRect(0, 0, 50, 25, [10, 0, 0, 0]);
+		ctx.roundRect(100, 0, -50, 25, [10, 0, 0, 0]);
+		ctx.roundRect(0, 50, 50, -25, [10, 0, 0, 0]);
+		ctx.roundRect(100, 50, -50, -25, [10, 0, 0, 0]);
+		ctx.fill();
+		// All rects drawn
+		_assertPixel(canvas, 25,12, 0,255,0,255);
+		_assertPixel(canvas, 75,12, 0,255,0,255);
+		_assertPixel(canvas, 25,37, 0,255,0,255);
+		_assertPixel(canvas, 75,37, 0,255,0,255);
+		// Correct corners are rounded.
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.winding", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.beginPath();
+		ctx.fillStyle = '#f00';
+		ctx.roundRect(0, 0, 50, 50, [0]);
+		ctx.roundRect(100, 50, -50, -50, [0]);
+		ctx.roundRect(0, 25, 100, -25, [0]);
+		ctx.roundRect(100, 25, -100, 25, [0]);
+		ctx.fill();
+		_assertPixel(canvas, 25,12, 0,255,0,255);
+		_assertPixel(canvas, 75,12, 0,255,0,255);
+		_assertPixel(canvas, 25,37, 0,255,0,255);
+		_assertPixel(canvas, 75,37, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.selfintersect", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.roundRect(0, 0, 100, 50, [0]);
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 90;
+		ctx.beginPath();
+		ctx.roundRect(45, 20, 10, 10, [0]);
+		ctx.stroke();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.nonfinite", function () {
+		// roundRect() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.roundRect(Infinity, 50, 1, 1, [0]);
+		ctx.roundRect(-Infinity, 50, 1, 1, [0]);
+		ctx.roundRect(NaN, 50, 1, 1, [0]);
+		ctx.roundRect(0, Infinity, 1, 1, [0]);
+		ctx.roundRect(0, -Infinity, 1, 1, [0]);
+		ctx.roundRect(0, NaN, 1, 1, [0]);
+		ctx.roundRect(0, 50, Infinity, 1, [0]);
+		ctx.roundRect(0, 50, -Infinity, 1, [0]);
+		ctx.roundRect(0, 50, NaN, 1, [0]);
+		ctx.roundRect(0, 50, 1, Infinity, [0]);
+		ctx.roundRect(0, 50, 1, -Infinity, [0]);
+		ctx.roundRect(0, 50, 1, NaN, [0]);
+		ctx.roundRect(0, 50, 1, 1, [Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [-Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [NaN]);
+		ctx.roundRect(0, 50, 1, 1, [Infinity,0]);
+		ctx.roundRect(0, 50, 1, 1, [-Infinity,0]);
+		ctx.roundRect(0, 50, 1, 1, [NaN,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [0,-Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [0,NaN]);
+		ctx.roundRect(0, 50, 1, 1, [Infinity,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [-Infinity,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [NaN,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,Infinity,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,-Infinity,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,NaN,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,-Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,NaN]);
+		ctx.roundRect(0, 50, 1, 1, [Infinity,0,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [-Infinity,0,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [NaN,0,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,Infinity,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,-Infinity,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,NaN,0,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,Infinity,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,-Infinity,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,NaN,0]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,0,Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,0,-Infinity]);
+		ctx.roundRect(0, 50, 1, 1, [0,0,0,NaN]);
+		ctx.roundRect(Infinity, Infinity, 1, 1, [0]);
+		ctx.roundRect(Infinity, Infinity, Infinity, 1, [0]);
+		ctx.roundRect(Infinity, Infinity, Infinity, Infinity, [0]);
+		ctx.roundRect(Infinity, Infinity, Infinity, Infinity, [Infinity]);
+		ctx.roundRect(Infinity, Infinity, Infinity, 1, [Infinity]);
+		ctx.roundRect(Infinity, Infinity, 1, Infinity, [0]);
+		ctx.roundRect(Infinity, Infinity, 1, Infinity, [Infinity]);
+		ctx.roundRect(Infinity, Infinity, 1, 1, [Infinity]);
+		ctx.roundRect(Infinity, 50, Infinity, 1, [0]);
+		ctx.roundRect(Infinity, 50, Infinity, Infinity, [0]);
+		ctx.roundRect(Infinity, 50, Infinity, Infinity, [Infinity]);
+		ctx.roundRect(Infinity, 50, Infinity, 1, [Infinity]);
+		ctx.roundRect(Infinity, 50, 1, Infinity, [0]);
+		ctx.roundRect(Infinity, 50, 1, Infinity, [Infinity]);
+		ctx.roundRect(Infinity, 50, 1, 1, [Infinity]);
+		ctx.roundRect(0, Infinity, Infinity, 1, [0]);
+		ctx.roundRect(0, Infinity, Infinity, Infinity, [0]);
+		ctx.roundRect(0, Infinity, Infinity, Infinity, [Infinity]);
+		ctx.roundRect(0, Infinity, Infinity, 1, [Infinity]);
+		ctx.roundRect(0, Infinity, 1, Infinity, [0]);
+		ctx.roundRect(0, Infinity, 1, Infinity, [Infinity]);
+		ctx.roundRect(0, Infinity, 1, 1, [Infinity]);
+		ctx.roundRect(0, 50, Infinity, Infinity, [0]);
+		ctx.roundRect(0, 50, Infinity, Infinity, [Infinity]);
+		ctx.roundRect(0, 50, Infinity, 1, [Infinity]);
+		ctx.roundRect(0, 50, 1, Infinity, [Infinity]);
+		ctx.roundRect(0, 0, 100, 100, [new DOMPoint(10, Infinity)]);
+		ctx.roundRect(0, 0, 100, 100, [new DOMPoint(10, -Infinity)]);
+		ctx.roundRect(0, 0, 100, 100, [new DOMPoint(10, NaN)]);
+		ctx.roundRect(0, 0, 100, 100, [new DOMPoint(Infinity, 10)]);
+		ctx.roundRect(0, 0, 100, 100, [new DOMPoint(-Infinity, 10)]);
+		ctx.roundRect(0, 0, 100, 100, [new DOMPoint(NaN, 10)]);
+		ctx.roundRect(0, 0, 100, 100, [{x: 10, y: Infinity}]);
+		ctx.roundRect(0, 0, 100, 100, [{x: 10, y: -Infinity}]);
+		ctx.roundRect(0, 0, 100, 100, [{x: 10, y: NaN}]);
+		ctx.roundRect(0, 0, 100, 100, [{x: Infinity, y: 10}]);
+		ctx.roundRect(0, 0, 100, 100, [{x: -Infinity, y: 10}]);
+		ctx.roundRect(0, 0, 100, 100, [{x: NaN, y: 10}]);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 90,45, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.1.double", function () {
+		// Verify that when four radii are given to roundRect(), the first radius, specified as a double, applies to the top-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [20, 0, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.1.dompoint", function () {
+		// Verify that when four radii are given to roundRect(), the first radius, specified as a DOMPoint, applies to the top-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20), 0, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.1.dompointinit", function () {
+		// Verify that when four radii are given to roundRect(), the first radius, specified as a DOMPointInit, applies to the top-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}, 0, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.2.double", function () {
+		// Verify that when four radii are given to roundRect(), the second radius, specified as a double, applies to the top-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 20, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.2.dompoint", function () {
+		// Verify that when four radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, new DOMPoint(40, 20), 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.2.dompointinit", function () {
+		// Verify that when four radii are given to roundRect(), the second radius, specified as a DOMPointInit, applies to the top-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, {x: 40, y: 20}, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.3.double", function () {
+		// Verify that when four radii are given to roundRect(), the third radius, specified as a double, applies to the bottom-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, 20, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.3.dompoint", function () {
+		// Verify that when four radii are given to roundRect(), the third radius, specified as a DOMPoint, applies to the bottom-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, new DOMPoint(40, 20), 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.3.dompointinit", function () {
+		// Verify that when four radii are given to roundRect(), the third radius, specified as a DOMPointInit, applies to the bottom-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, {x: 40, y: 20}, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.4.double", function () {
+		// Verify that when four radii are given to roundRect(), the fourth radius, specified as a double, applies to the bottom-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, 0, 20]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.4.dompoint", function () {
+		// Verify that when four radii are given to roundRect(), the fourth radius, specified as a DOMPoint, applies to the bottom-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, 0, new DOMPoint(40, 20)]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.4.radii.4.dompointinit", function () {
+		// Verify that when four radii are given to roundRect(), the fourth radius, specified as a DOMPointInit, applies to the bottom-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, 0, {x: 40, y: 20}]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.1.double", function () {
+		// Verify that when three radii are given to roundRect(), the first radius, specified as a double, applies to the top-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [20, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.1.dompoint", function () {
+		// Verify that when three radii are given to roundRect(), the first radius, specified as a DOMPoint, applies to the top-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20), 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.1.dompointinit", function () {
+		// Verify that when three radii are given to roundRect(), the first radius, specified as a DOMPointInit, applies to the top-left corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}, 0, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.2.double", function () {
+		// Verify that when three radii are given to roundRect(), the second radius, specified as a double, applies to the top-right and bottom-left corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 20, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.2.dompoint", function () {
+		// Verify that when three radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right and bottom-left corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, new DOMPoint(40, 20), 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.2.dompointinit", function () {
+		// Verify that when three radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right and bottom-left corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, {x: 40, y: 20}, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.3.double", function () {
+		// Verify that when three radii are given to roundRect(), the third radius, specified as a double, applies to the bottom-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, 20]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.3.dompoint", function () {
+		// Verify that when three radii are given to roundRect(), the third radius, specified as a DOMPoint, applies to the bottom-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, new DOMPoint(40, 20)]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.3.radii.3.dompointinit", function () {
+		// Verify that when three radii are given to roundRect(), the third radius, specified as a DOMPointInit, applies to the bottom-right corner.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 0, {x: 40, y: 20}]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.2.radii.1.double", function () {
+		// Verify that when two radii are given to roundRect(), the first radius, specified as a double, applies to the top-left and bottom-right corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [20, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.2.radii.1.dompoint", function () {
+		// Verify that when two radii are given to roundRect(), the first radius, specified as a DOMPoint, applies to the top-left and bottom-right corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20), 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.2.radii.1.dompointinit", function () {
+		// Verify that when two radii are given to roundRect(), the first radius, specified as a DOMPointInit, applies to the top-left and bottom-right corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}, 0]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 98,1, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.2.radii.2.double", function () {
+		// Verify that when two radii are given to roundRect(), the second radius, specified as a double, applies to the top-right and bottom-left corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, 20]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.2.radii.2.dompoint", function () {
+		// Verify that when two radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right and bottom-left corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, new DOMPoint(40, 20)]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.2.radii.2.dompointinit", function () {
+		// Verify that when two radii are given to roundRect(), the second radius, specified as a DOMPointInit, applies to the top-right and bottom-left corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [0, {x: 40, y: 20}]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+		
+		// other corners
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.1.radius.double", function () {
+		// Verify that when one radius is given to roundRect(), specified as a double, it applies to all corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [20]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.1.radius.double.single.argument", function () {
+		// Verify that when one radius is given to roundRect() as a non-array argument, specified as a double, it applies to all corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, 20);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.1.radius.dompoint", function () {
+		// Verify that when one radius is given to roundRect(), specified as a DOMPoint, it applies to all corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20)]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.1.radius.dompoint.single argument", function () {
+		// Verify that when one radius is given to roundRect() as a non-array argument, specified as a DOMPoint, it applies to all corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, new DOMPoint(40, 20));
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.1.radius.dompointinit", function () {
+		// Verify that when one radius is given to roundRect(), specified as a DOMPointInit, applies to all corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.1.radius.dompointinit.single.argument", function () {
+		// Verify that when one radius is given to roundRect() as a non-array argument, specified as a DOMPointInit, applies to all corners.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, {x: 40, y: 20});
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		// top-left corner
+		_assertPixel(canvas, 20,1, 255,0,0,255);
+		_assertPixel(canvas, 41,1, 0,255,0,255);
+		_assertPixel(canvas, 1,10, 255,0,0,255);
+		_assertPixel(canvas, 1,21, 0,255,0,255);
+		
+		// top-right corner
+		_assertPixel(canvas, 79,1, 255,0,0,255);
+		_assertPixel(canvas, 58,1, 0,255,0,255);
+		_assertPixel(canvas, 98,10, 255,0,0,255);
+		_assertPixel(canvas, 98,21, 0,255,0,255);
+		
+		// bottom-right corner
+		_assertPixel(canvas, 79,48, 255,0,0,255);
+		_assertPixel(canvas, 58,48, 0,255,0,255);
+		_assertPixel(canvas, 98,39, 255,0,0,255);
+		_assertPixel(canvas, 98,28, 0,255,0,255);
+		
+		// bottom-left corner
+		_assertPixel(canvas, 20,48, 255,0,0,255);
+		_assertPixel(canvas, 41,48, 0,255,0,255);
+		_assertPixel(canvas, 1,39, 255,0,0,255);
+		_assertPixel(canvas, 1,28, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.radius.intersecting.1", function () {
+		// Check that roundRects with intersecting corner arcs are rendered correctly.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [40, 40, 40, 40]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 2,25, 0,255,0,255);
+		_assertPixel(canvas, 50,1, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 50,48, 0,255,0,255);
+		_assertPixel(canvas, 97,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.radius.intersecting.2", function () {
+		// Check that roundRects with intersecting corner arcs are rendered correctly.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(0, 0, 100, 50, [1000, 1000, 1000, 1000]);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 2,25, 0,255,0,255);
+		_assertPixel(canvas, 50,1, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 50,48, 0,255,0,255);
+		_assertPixel(canvas, 97,25, 0,255,0,255);
+		_assertPixel(canvas, 1,1, 255,0,0,255);
+		_assertPixel(canvas, 98,1, 255,0,0,255);
+		_assertPixel(canvas, 1,48, 255,0,0,255);
+		_assertPixel(canvas, 98,48, 255,0,0,255);
+	});
+
+	it("2d.path.roundrect.radius.none", function () {
+		// Check that roundRect throws an RangeError if radii is an empty array.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 100, 50, [])});
+	});
+
+	it("2d.path.roundrect.radius.noargument", function () {
+		// Check that roundRect draws a rectangle when no radii are provided.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.roundRect(10, 10, 80, 30);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		// upper left corner (10, 10)
+		_assertPixel(canvas, 10,9, 255,0,0,255);
+		_assertPixel(canvas, 9,10, 255,0,0,255);
+		_assertPixel(canvas, 10,10, 0,255,0,255);
+		
+		// upper right corner (89, 10)
+		_assertPixel(canvas, 90,10, 255,0,0,255);
+		_assertPixel(canvas, 89,9, 255,0,0,255);
+		_assertPixel(canvas, 89,10, 0,255,0,255);
+		
+		// lower right corner (89, 39)
+		_assertPixel(canvas, 89,40, 255,0,0,255);
+		_assertPixel(canvas, 90,39, 255,0,0,255);
+		_assertPixel(canvas, 89,39, 0,255,0,255);
+		
+		// lower left corner (10, 30)
+		_assertPixel(canvas, 9,39, 255,0,0,255);
+		_assertPixel(canvas, 10,40, 255,0,0,255);
+		_assertPixel(canvas, 10,39, 0,255,0,255);
+	});
+
+	it("2d.path.roundrect.radius.toomany", function () {
+		// Check that roundRect throws an IndeSizeError if radii has more than four items.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 100, 50, [0, 0, 0, 0, 0])});
+	});
+
+	it("2d.path.roundrect.radius.negative", function () {
+		// roundRect() with negative radius throws an exception
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [-1])});
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [1, -1])});
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [new DOMPoint(-1, 1), 1])});
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [new DOMPoint(1, -1)])});
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [{x: -1, y: 1}, 1])});
+		assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [{x: 1, y: -1}])});
+	});
+
+	it("2d.path.ellipse.basics", function () {
+		// Verify canvas throws error when drawing ellipse with negative radii.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.ellipse(10, 10, 10, 5, 0, 0, 1, false);
+		ctx.ellipse(10, 10, 10, 0, 0, 0, 1, false);
+		ctx.ellipse(10, 10, -0, 5, 0, 0, 1, false);
+		assert.throws(function() { ctx.ellipse(10, 10, -2, 5, 0, 0, 1, false); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.ellipse(10, 10, 0, -1.5, 0, 0, 1, false); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.ellipse(10, 10, -2, -5, 0, 0, 1, false); }, /INDEX_SIZE_ERR/);
+		ctx.ellipse(80, 0, 10, 4294967277, Math.PI / -84, -Math.PI / 2147483436, false);
+	});
+
+	it("2d.path.fill.overlap", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = 'rgba(0, 255, 0, 0.5)';
+		ctx.rect(0, 0, 100, 50);
+		ctx.closePath();
+		ctx.rect(10, 10, 80, 30);
+		ctx.fill();
+		
+		_assertPixelApprox(canvas, 50,25, 0,127,0,255, 1);
+	});
+
+	it("2d.path.fill.winding.add", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.moveTo(-10, -10);
+		ctx.lineTo(110, -10);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(-10, 60);
+		ctx.lineTo(-10, -10);
+		ctx.lineTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.fill.winding.subtract.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#f00';
+		ctx.moveTo(-10, -10);
+		ctx.lineTo(110, -10);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(-10, 60);
+		ctx.lineTo(-10, -10);
+		ctx.lineTo(0, 0);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(100, 0);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.fill.winding.subtract.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#f00';
+		ctx.moveTo(-10, -10);
+		ctx.lineTo(110, -10);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(-10, 60);
+		ctx.moveTo(0, 0);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(100, 0);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.fill.winding.subtract.3", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.moveTo(-10, -10);
+		ctx.lineTo(110, -10);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(-10, 60);
+		ctx.lineTo(-10, -10);
+		ctx.lineTo(-20, -20);
+		ctx.lineTo(120, -20);
+		ctx.lineTo(120, 70);
+		ctx.lineTo(-20, 70);
+		ctx.lineTo(-20, -20);
+		ctx.lineTo(0, 0);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(100, 0);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.fill.closed.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(0, 50);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.fill.closed.unaffected", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#00f';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.moveTo(0, 0);
+		ctx.lineTo(100, 0);
+		ctx.lineTo(100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fill();
+		ctx.lineTo(0, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		_assertPixel(canvas, 90,10, 0,255,0,255);
+		_assertPixel(canvas, 10,40, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.overlap", function () {
+		// Stroked subpaths are combined before being drawn
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = 'rgba(0, 255, 0, 0.5)';
+		ctx.lineWidth = 50;
+		ctx.moveTo(0, 20);
+		ctx.lineTo(100, 20);
+		ctx.moveTo(0, 30);
+		ctx.lineTo(100, 30);
+		ctx.stroke();
+		
+		_assertPixelApprox(canvas, 50,25, 0,127,0,255, 1);
+	});
+
+	it("2d.path.stroke.union", function () {
+		// Strokes in opposite directions are unioned, not subtracted
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#0f0';
+		ctx.lineWidth = 40;
+		ctx.moveTo(0, 10);
+		ctx.lineTo(100, 10);
+		ctx.moveTo(100, 40);
+		ctx.lineTo(0, 40);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.unaffected", function () {
+		// Stroking does not start a new path or subpath
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.lineWidth = 50;
+		ctx.moveTo(-100, 25);
+		ctx.lineTo(-100, -100);
+		ctx.lineTo(200, -100);
+		ctx.lineTo(200, 25);
+		ctx.strokeStyle = '#f00';
+		ctx.stroke();
+		
+		ctx.closePath();
+		ctx.strokeStyle = '#0f0';
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.scale1", function () {
+		// Stroke line widths are scaled by the current transformation matrix
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.rect(25, 12.5, 50, 25);
+		ctx.save();
+		ctx.scale(50, 25);
+		ctx.strokeStyle = '#0f0';
+		ctx.stroke();
+		ctx.restore();
+		
+		ctx.beginPath();
+		ctx.rect(-25, -12.5, 150, 75);
+		ctx.save();
+		ctx.scale(50, 25);
+		ctx.strokeStyle = '#f00';
+		ctx.stroke();
+		ctx.restore();
+		
+		_assertPixel(canvas, 0,0, 0,255,0,255);
+		_assertPixel(canvas, 50,0, 0,255,0,255);
+		_assertPixel(canvas, 99,0, 0,255,0,255);
+		_assertPixel(canvas, 0,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 99,25, 0,255,0,255);
+		_assertPixel(canvas, 0,49, 0,255,0,255);
+		_assertPixel(canvas, 50,49, 0,255,0,255);
+		_assertPixel(canvas, 99,49, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.scale2", function () {
+		// Stroke line widths are scaled by the current transformation matrix
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.rect(25, 12.5, 50, 25);
+		ctx.save();
+		ctx.rotate(Math.PI/2);
+		ctx.scale(25, 50);
+		ctx.strokeStyle = '#0f0';
+		ctx.stroke();
+		ctx.restore();
+		
+		ctx.beginPath();
+		ctx.rect(-25, -12.5, 150, 75);
+		ctx.save();
+		ctx.rotate(Math.PI/2);
+		ctx.scale(25, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.stroke();
+		ctx.restore();
+		
+		_assertPixel(canvas, 0,0, 0,255,0,255);
+		_assertPixel(canvas, 50,0, 0,255,0,255);
+		_assertPixel(canvas, 99,0, 0,255,0,255);
+		_assertPixel(canvas, 0,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 99,25, 0,255,0,255);
+		_assertPixel(canvas, 0,49, 0,255,0,255);
+		_assertPixel(canvas, 50,49, 0,255,0,255);
+		_assertPixel(canvas, 99,49, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.skew", function () {
+		// Strokes lines are skewed by the current transformation matrix
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.save();
+		ctx.beginPath();
+		ctx.moveTo(49, -50);
+		ctx.lineTo(201, -50);
+		ctx.rotate(Math.PI/4);
+		ctx.scale(1, 283);
+		ctx.strokeStyle = '#0f0';
+		ctx.stroke();
+		ctx.restore();
+		
+		ctx.save();
+		ctx.beginPath();
+		ctx.translate(-150, 0);
+		ctx.moveTo(49, -50);
+		ctx.lineTo(199, -50);
+		ctx.rotate(Math.PI/4);
+		ctx.scale(1, 142);
+		ctx.strokeStyle = '#f00';
+		ctx.stroke();
+		ctx.restore();
+		
+		ctx.save();
+		ctx.beginPath();
+		ctx.translate(-150, 0);
+		ctx.moveTo(49, -50);
+		ctx.lineTo(199, -50);
+		ctx.rotate(Math.PI/4);
+		ctx.scale(1, 142);
+		ctx.strokeStyle = '#f00';
+		ctx.stroke();
+		ctx.restore();
+		
+		_assertPixel(canvas, 0,0, 0,255,0,255);
+		_assertPixel(canvas, 50,0, 0,255,0,255);
+		_assertPixel(canvas, 99,0, 0,255,0,255);
+		_assertPixel(canvas, 0,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 99,25, 0,255,0,255);
+		_assertPixel(canvas, 0,49, 0,255,0,255);
+		_assertPixel(canvas, 50,49, 0,255,0,255);
+		_assertPixel(canvas, 99,49, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.empty", function () {
+		// Empty subpaths are not stroked
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'round';
+		
+		ctx.beginPath();
+		ctx.moveTo(40, 25);
+		ctx.moveTo(60, 25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.prune.line", function () {
+		// Zero-length line segments from lineTo are removed before stroking
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'round';
+		
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.lineTo(50, 25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.prune.closed", function () {
+		// Zero-length line segments from closed paths are removed before stroking
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'round';
+		
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.lineTo(50, 25);
+		ctx.closePath();
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.prune.curve", function () {
+		// Zero-length line segments from quadraticCurveTo and bezierCurveTo are removed before stroking
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'round';
+		
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.quadraticCurveTo(50, 25, 50, 25);
+		ctx.stroke();
+		
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.bezierCurveTo(50, 25, 50, 25, 50, 25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.prune.arc", function () {
+		// Zero-length line segments from arcTo and arc are removed before stroking
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'round';
+		
+		ctx.beginPath();
+		ctx.moveTo(50, 25);
+		ctx.arcTo(50, 25, 150, 25, 10);
+		ctx.stroke();
+		
+		ctx.beginPath();
+		ctx.moveTo(60, 25);
+		ctx.arc(50, 25, 10, 0, 0, false);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.prune.rect", function () {
+		// Zero-length line segments from rect and strokeRect are removed before stroking
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 100;
+		ctx.lineCap = 'round';
+		ctx.lineJoin = 'round';
+		
+		ctx.beginPath();
+		ctx.rect(50, 25, 0, 0);
+		ctx.stroke();
+		
+		ctx.strokeRect(50, 25, 0, 0);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.stroke.prune.corner", function () {
+		// Zero-length line segments are removed before stroking with miters
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 400;
+		ctx.lineJoin = 'miter';
+		ctx.miterLimit = 1.4;
+		
+		ctx.beginPath();
+		ctx.moveTo(-1000, 200);
+		ctx.lineTo(-100, 200);
+		ctx.lineTo(-100, 200);
+		ctx.lineTo(-100, 200);
+		ctx.lineTo(-100, 1000);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.transformation.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(-100, 0);
+		ctx.rect(100, 0, 100, 50);
+		ctx.translate(0, -100);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.transformation.multiple", function () {
+		// Transformations are applied while building paths, not when drawing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#f00';
+		ctx.translate(-100, 0);
+		ctx.rect(0, 0, 100, 50);
+		ctx.fill();
+		ctx.translate(100, 0);
+		ctx.fill();
+		
+		ctx.beginPath();
+		ctx.strokeStyle = '#f00';
+		ctx.lineWidth = 50;
+		ctx.translate(0, -50);
+		ctx.moveTo(0, 25);
+		ctx.lineTo(100, 25);
+		ctx.stroke();
+		ctx.translate(0, 50);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.transformation.changing", function () {
+		// Transformations are applied while building paths, not when drawing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.moveTo(0, 0);
+		ctx.translate(100, 0);
+		ctx.lineTo(0, 0);
+		ctx.translate(0, 50);
+		ctx.lineTo(0, 0);
+		ctx.translate(-100, 0);
+		ctx.lineTo(0, 0);
+		ctx.translate(1000, 1000);
+		ctx.rotate(Math.PI/2);
+		ctx.scale(0.1, 0.1);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.empty", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.clip();
+		
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.basic.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.rect(0, 0, 100, 50);
+		ctx.clip();
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.basic.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.rect(-100, 0, 100, 50);
+		ctx.clip();
+		
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.intersect", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.rect(0, 0, 50, 50);
+		ctx.clip();
+		ctx.beginPath();
+		ctx.rect(50, 0, 50, 50)
+		ctx.clip();
+		
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.winding.1", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.moveTo(-10, -10);
+		ctx.lineTo(110, -10);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(-10, 60);
+		ctx.lineTo(-10, -10);
+		ctx.lineTo(0, 0);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(100, 0);
+		ctx.clip();
+		
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.winding.2", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.beginPath();
+		ctx.moveTo(-10, -10);
+		ctx.lineTo(110, -10);
+		ctx.lineTo(110, 60);
+		ctx.lineTo(-10, 60);
+		ctx.lineTo(-10, -10);
+		ctx.clip();
+		
+		ctx.beginPath();
+		ctx.moveTo(0, 0);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(100, 0);
+		ctx.lineTo(0, 0);
+		ctx.clip();
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.clip.unaffected", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		
+		ctx.beginPath();
+		ctx.moveTo(0, 0);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(100, 50);
+		ctx.lineTo(100, 0);
+		ctx.clip();
+		
+		ctx.lineTo(0, 0);
+		ctx.fill();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.path.isPointInPath.basic.1", function () {
+		// isPointInPath() detects whether the point is inside the path
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(0, 0, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(10, 10), true, "ctx.isPointInPath(10, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(30, 10), false, "ctx.isPointInPath(30, 10)", "false")
+	});
+
+	it("2d.path.isPointInPath.basic.2", function () {
+		// isPointInPath() detects whether the point is inside the path
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(20, 0, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(10, 10), false, "ctx.isPointInPath(10, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 10), true, "ctx.isPointInPath(30, 10)", "true")
+	});
+
+	it("2d.path.isPointInPath.edge", function () {
+		// isPointInPath() counts points on the path as being inside
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(0, 0, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(0, 0), true, "ctx.isPointInPath(0, 0)", "true")
+		assert.strictEqual(ctx.isPointInPath(10, 0), true, "ctx.isPointInPath(10, 0)", "true")
+		assert.strictEqual(ctx.isPointInPath(20, 0), true, "ctx.isPointInPath(20, 0)", "true")
+		assert.strictEqual(ctx.isPointInPath(20, 10), true, "ctx.isPointInPath(20, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(20, 20), true, "ctx.isPointInPath(20, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(10, 20), true, "ctx.isPointInPath(10, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(0, 20), true, "ctx.isPointInPath(0, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(0, 10), true, "ctx.isPointInPath(0, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(10, -0.01), false, "ctx.isPointInPath(10, -0.01)", "false")
+		assert.strictEqual(ctx.isPointInPath(10, 20.01), false, "ctx.isPointInPath(10, 20.01)", "false")
+		assert.strictEqual(ctx.isPointInPath(-0.01, 10), false, "ctx.isPointInPath(-0.01, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(20.01, 10), false, "ctx.isPointInPath(20.01, 10)", "false")
+	});
+
+	it("2d.path.isPointInPath.empty", function () {
+		// isPointInPath() works when there is no path
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.isPointInPath(0, 0), false, "ctx.isPointInPath(0, 0)", "false")
+	});
+
+	it("2d.path.isPointInPath.subpath", function () {
+		// isPointInPath() uses the current path, not just the subpath
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(0, 0, 20, 20);
+		ctx.beginPath();
+		ctx.rect(20, 0, 20, 20);
+		ctx.closePath();
+		ctx.rect(40, 0, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(10, 10), false, "ctx.isPointInPath(10, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 10), true, "ctx.isPointInPath(30, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(50, 10), true, "ctx.isPointInPath(50, 10)", "true")
+	});
+
+	it("2d.path.isPointInPath.outside", function () {
+		// isPointInPath() works on paths outside the canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(0, -100, 20, 20);
+		ctx.rect(20, -10, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(10, -110), false, "ctx.isPointInPath(10, -110)", "false")
+		assert.strictEqual(ctx.isPointInPath(10, -90), true, "ctx.isPointInPath(10, -90)", "true")
+		assert.strictEqual(ctx.isPointInPath(10, -70), false, "ctx.isPointInPath(10, -70)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, -20), false, "ctx.isPointInPath(30, -20)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 0), true, "ctx.isPointInPath(30, 0)", "true")
+		assert.strictEqual(ctx.isPointInPath(30, 20), false, "ctx.isPointInPath(30, 20)", "false")
+	});
+
+	it("2d.path.isPointInPath.unclosed", function () {
+		// isPointInPath() works on unclosed subpaths
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(0, 0);
+		ctx.lineTo(20, 0);
+		ctx.lineTo(20, 20);
+		ctx.lineTo(0, 20);
+		assert.strictEqual(ctx.isPointInPath(10, 10), true, "ctx.isPointInPath(10, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(30, 10), false, "ctx.isPointInPath(30, 10)", "false")
+	});
+
+	it("2d.path.isPointInPath.arc", function () {
+		// isPointInPath() works on arcs
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.arc(50, 25, 10, 0, Math.PI, false);
+		assert.strictEqual(ctx.isPointInPath(50, 10), false, "ctx.isPointInPath(50, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(50, 20), false, "ctx.isPointInPath(50, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(50, 30), true, "ctx.isPointInPath(50, 30)", "true")
+		assert.strictEqual(ctx.isPointInPath(50, 40), false, "ctx.isPointInPath(50, 40)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 20), false, "ctx.isPointInPath(30, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(70, 20), false, "ctx.isPointInPath(70, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 30), false, "ctx.isPointInPath(30, 30)", "false")
+		assert.strictEqual(ctx.isPointInPath(70, 30), false, "ctx.isPointInPath(70, 30)", "false")
+	});
+
+	it("2d.path.isPointInPath.bigarc", function () {
+		// isPointInPath() works on unclosed arcs larger than 2pi
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.arc(50, 25, 10, 0, 7, false);
+		assert.strictEqual(ctx.isPointInPath(50, 10), false, "ctx.isPointInPath(50, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(50, 20), true, "ctx.isPointInPath(50, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(50, 30), true, "ctx.isPointInPath(50, 30)", "true")
+		assert.strictEqual(ctx.isPointInPath(50, 40), false, "ctx.isPointInPath(50, 40)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 20), false, "ctx.isPointInPath(30, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(70, 20), false, "ctx.isPointInPath(70, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 30), false, "ctx.isPointInPath(30, 30)", "false")
+		assert.strictEqual(ctx.isPointInPath(70, 30), false, "ctx.isPointInPath(70, 30)", "false")
+	});
+
+	it("2d.path.isPointInPath.bezier", function () {
+		// isPointInPath() works on Bezier curves
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.moveTo(25, 25);
+		ctx.bezierCurveTo(50, -50, 50, 100, 75, 25);
+		assert.strictEqual(ctx.isPointInPath(25, 20), false, "ctx.isPointInPath(25, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(25, 30), false, "ctx.isPointInPath(25, 30)", "false")
+		assert.strictEqual(ctx.isPointInPath(30, 20), true, "ctx.isPointInPath(30, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(30, 30), false, "ctx.isPointInPath(30, 30)", "false")
+		assert.strictEqual(ctx.isPointInPath(40, 2), false, "ctx.isPointInPath(40, 2)", "false")
+		assert.strictEqual(ctx.isPointInPath(40, 20), true, "ctx.isPointInPath(40, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(40, 30), false, "ctx.isPointInPath(40, 30)", "false")
+		assert.strictEqual(ctx.isPointInPath(40, 47), false, "ctx.isPointInPath(40, 47)", "false")
+		assert.strictEqual(ctx.isPointInPath(45, 20), true, "ctx.isPointInPath(45, 20)", "true")
+		assert.strictEqual(ctx.isPointInPath(45, 30), false, "ctx.isPointInPath(45, 30)", "false")
+		assert.strictEqual(ctx.isPointInPath(55, 20), false, "ctx.isPointInPath(55, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(55, 30), true, "ctx.isPointInPath(55, 30)", "true")
+		assert.strictEqual(ctx.isPointInPath(60, 2), false, "ctx.isPointInPath(60, 2)", "false")
+		assert.strictEqual(ctx.isPointInPath(60, 20), false, "ctx.isPointInPath(60, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(60, 30), true, "ctx.isPointInPath(60, 30)", "true")
+		assert.strictEqual(ctx.isPointInPath(60, 47), false, "ctx.isPointInPath(60, 47)", "false")
+		assert.strictEqual(ctx.isPointInPath(70, 20), false, "ctx.isPointInPath(70, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(70, 30), true, "ctx.isPointInPath(70, 30)", "true")
+		assert.strictEqual(ctx.isPointInPath(75, 20), false, "ctx.isPointInPath(75, 20)", "false")
+		assert.strictEqual(ctx.isPointInPath(75, 30), false, "ctx.isPointInPath(75, 30)", "false")
+	});
+
+	it("2d.path.isPointInPath.winding", function () {
+		// isPointInPath() uses the non-zero winding number rule
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		// Create a square ring, using opposite windings to make a hole in the centre
+		ctx.moveTo(0, 0);
+		ctx.lineTo(50, 0);
+		ctx.lineTo(50, 50);
+		ctx.lineTo(0, 50);
+		ctx.lineTo(0, 0);
+		ctx.lineTo(10, 10);
+		ctx.lineTo(10, 40);
+		ctx.lineTo(40, 40);
+		ctx.lineTo(40, 10);
+		ctx.lineTo(10, 10);
+		
+		assert.strictEqual(ctx.isPointInPath(5, 5), true, "ctx.isPointInPath(5, 5)", "true")
+		assert.strictEqual(ctx.isPointInPath(25, 5), true, "ctx.isPointInPath(25, 5)", "true")
+		assert.strictEqual(ctx.isPointInPath(45, 5), true, "ctx.isPointInPath(45, 5)", "true")
+		assert.strictEqual(ctx.isPointInPath(5, 25), true, "ctx.isPointInPath(5, 25)", "true")
+		assert.strictEqual(ctx.isPointInPath(25, 25), false, "ctx.isPointInPath(25, 25)", "false")
+		assert.strictEqual(ctx.isPointInPath(45, 25), true, "ctx.isPointInPath(45, 25)", "true")
+		assert.strictEqual(ctx.isPointInPath(5, 45), true, "ctx.isPointInPath(5, 45)", "true")
+		assert.strictEqual(ctx.isPointInPath(25, 45), true, "ctx.isPointInPath(25, 45)", "true")
+		assert.strictEqual(ctx.isPointInPath(45, 45), true, "ctx.isPointInPath(45, 45)", "true")
+	});
+
+	it("2d.path.isPointInPath.transform.1", function () {
+		// isPointInPath() handles transformations correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.translate(50, 0);
+		ctx.rect(0, 0, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(-40, 10), false, "ctx.isPointInPath(-40, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(10, 10), false, "ctx.isPointInPath(10, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(49, 10), false, "ctx.isPointInPath(49, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(51, 10), true, "ctx.isPointInPath(51, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(69, 10), true, "ctx.isPointInPath(69, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(71, 10), false, "ctx.isPointInPath(71, 10)", "false")
+	});
+
+	it("2d.path.isPointInPath.transform.2", function () {
+		// isPointInPath() handles transformations correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(50, 0, 20, 20);
+		ctx.translate(50, 0);
+		assert.strictEqual(ctx.isPointInPath(-40, 10), false, "ctx.isPointInPath(-40, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(10, 10), false, "ctx.isPointInPath(10, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(49, 10), false, "ctx.isPointInPath(49, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(51, 10), true, "ctx.isPointInPath(51, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(69, 10), true, "ctx.isPointInPath(69, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(71, 10), false, "ctx.isPointInPath(71, 10)", "false")
+	});
+
+	it("2d.path.isPointInPath.transform.3", function () {
+		// isPointInPath() handles transformations correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.scale(-1, 1);
+		ctx.rect(-70, 0, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(-40, 10), false, "ctx.isPointInPath(-40, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(10, 10), false, "ctx.isPointInPath(10, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(49, 10), false, "ctx.isPointInPath(49, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(51, 10), true, "ctx.isPointInPath(51, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(69, 10), true, "ctx.isPointInPath(69, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(71, 10), false, "ctx.isPointInPath(71, 10)", "false")
+	});
+
+	it("2d.path.isPointInPath.transform.4", function () {
+		// isPointInPath() handles transformations correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.translate(50, 0);
+		ctx.rect(50, 0, 20, 20);
+		ctx.translate(0, 50);
+		assert.strictEqual(ctx.isPointInPath(60, 10), false, "ctx.isPointInPath(60, 10)", "false")
+		assert.strictEqual(ctx.isPointInPath(110, 10), true, "ctx.isPointInPath(110, 10)", "true")
+		assert.strictEqual(ctx.isPointInPath(110, 60), false, "ctx.isPointInPath(110, 60)", "false")
+	});
+
+	it("2d.path.isPointInPath.nonfinite", function () {
+		// isPointInPath() returns false for non-finite arguments
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.rect(-100, -50, 200, 100);
+		assert.strictEqual(ctx.isPointInPath(Infinity, 0), false, "ctx.isPointInPath(Infinity, 0)", "false")
+		assert.strictEqual(ctx.isPointInPath(-Infinity, 0), false, "ctx.isPointInPath(-Infinity, 0)", "false")
+		assert.strictEqual(ctx.isPointInPath(NaN, 0), false, "ctx.isPointInPath(NaN, 0)", "false")
+		assert.strictEqual(ctx.isPointInPath(0, Infinity), false, "ctx.isPointInPath(0, Infinity)", "false")
+		assert.strictEqual(ctx.isPointInPath(0, -Infinity), false, "ctx.isPointInPath(0, -Infinity)", "false")
+		assert.strictEqual(ctx.isPointInPath(0, NaN), false, "ctx.isPointInPath(0, NaN)", "false")
+		assert.strictEqual(ctx.isPointInPath(NaN, NaN), false, "ctx.isPointInPath(NaN, NaN)", "false")
+	});
+
+	it("2d.path.isPointInStroke.scaleddashes", function () {
+		// isPointInStroke() should return correct results on dashed paths at high scale factors
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var scale = 20;
+		ctx.setLineDash([10, 21.4159]); // dash from t=0 to t=10 along the circle
+		ctx.scale(scale, scale);
+		ctx.ellipse(6, 10, 5, 5, 0, 2*Math.PI, false);
+		ctx.stroke();
+		
+		// hit-test the beginning of the dash (t=0)
+		assert.strictEqual(ctx.isPointInStroke(11*scale, 10*scale), true, "ctx.isPointInStroke(11*scale, 10*scale)", "true")
+		// hit-test the middle of the dash (t=5)
+		assert.strictEqual(ctx.isPointInStroke(8.70*scale, 14.21*scale), true, "ctx.isPointInStroke(8.70*scale, 14.21*scale)", "true")
+		// hit-test the end of the dash (t=9.8)
+		assert.strictEqual(ctx.isPointInStroke(4.10*scale, 14.63*scale), true, "ctx.isPointInStroke(4.10*scale, 14.63*scale)", "true")
+		// hit-test past the end of the dash (t=10.2)
+		assert.strictEqual(ctx.isPointInStroke(3.74*scale, 14.46*scale), false, "ctx.isPointInStroke(3.74*scale, 14.46*scale)", "false")
+	});
+
+	it("2d.path.isPointInPath.basic", function () {
+		// Verify the winding rule in isPointInPath works for for rect path.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		canvas.width = 200;
+		canvas.height = 200;
+		
+		// Testing default isPointInPath
+		ctx.beginPath();
+		ctx.rect(0, 0, 100, 100);
+		ctx.rect(25, 25, 50, 50);
+		assert.strictEqual(ctx.isPointInPath(50, 50), true, "ctx.isPointInPath(50, 50)", "true")
+		assert.strictEqual(ctx.isPointInPath(NaN, 50), false, "ctx.isPointInPath(NaN, 50)", "false")
+		assert.strictEqual(ctx.isPointInPath(50, NaN), false, "ctx.isPointInPath(50, NaN)", "false")
+		
+		// Testing nonzero isPointInPath
+		ctx.beginPath();
+		ctx.rect(0, 0, 100, 100);
+		ctx.rect(25, 25, 50, 50);
+		assert.strictEqual(ctx.isPointInPath(50, 50, 'nonzero'), true, "ctx.isPointInPath(50, 50, 'nonzero')", "true")
+		
+		// Testing evenodd isPointInPath
+		ctx.beginPath();
+		ctx.rect(0, 0, 100, 100);
+		ctx.rect(25, 25, 50, 50);
+		assert.strictEqual(ctx.isPointInPath(50, 50, 'evenodd'), false, "ctx.isPointInPath(50, 50, 'evenodd')", "false")
+		
+		// Testing extremely large scale
+		ctx.save();
+		ctx.scale(Number.MAX_VALUE, Number.MAX_VALUE);
+		ctx.beginPath();
+		ctx.rect(-10, -10, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(0, 0, 'nonzero'), true, "ctx.isPointInPath(0, 0, 'nonzero')", "true")
+		assert.strictEqual(ctx.isPointInPath(0, 0, 'evenodd'), true, "ctx.isPointInPath(0, 0, 'evenodd')", "true")
+		ctx.restore();
+		
+		// Check with non-invertible ctm.
+		ctx.save();
+		ctx.scale(0, 0);
+		ctx.beginPath();
+		ctx.rect(-10, -10, 20, 20);
+		assert.strictEqual(ctx.isPointInPath(0, 0, 'nonzero'), false, "ctx.isPointInPath(0, 0, 'nonzero')", "false")
+		assert.strictEqual(ctx.isPointInPath(0, 0, 'evenodd'), false, "ctx.isPointInPath(0, 0, 'evenodd')", "false")
+		ctx.restore();
+	});
+
+	it("2d.path.isPointInpath.multi.path", function () {
+		// Verify the winding rule in isPointInPath works for path object.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		canvas.width = 200;
+		canvas.height = 200;
+		
+		// Testing default isPointInPath with Path object');
+		path = new Path2D();
+		path.rect(0, 0, 100, 100);
+		path.rect(25, 25, 50, 50);
+		assert.strictEqual(ctx.isPointInPath(path, 50, 50), true, "ctx.isPointInPath(path, 50, 50)", "true")
+		assert.strictEqual(ctx.isPointInPath(path, 50, 50, undefined), true, "ctx.isPointInPath(path, 50, 50, undefined)", "true")
+		assert.strictEqual(ctx.isPointInPath(path, NaN, 50), false, "ctx.isPointInPath(path, NaN, 50)", "false")
+		assert.strictEqual(ctx.isPointInPath(path, 50, NaN), false, "ctx.isPointInPath(path, 50, NaN)", "false")
+		
+		// Testing nonzero isPointInPath with Path object');
+		path = new Path2D();
+		path.rect(0, 0, 100, 100);
+		path.rect(25, 25, 50, 50);
+		assert.strictEqual(ctx.isPointInPath(path, 50, 50, 'nonzero'), true, "ctx.isPointInPath(path, 50, 50, 'nonzero')", "true")
+		
+		// Testing evenodd isPointInPath with Path object');
+		path = new Path2D();
+		path.rect(0, 0, 100, 100);
+		path.rect(25, 25, 50, 50);
+		assert_false(ctx.isPointInPath(path, 50, 50, 'evenodd'));
+	});
+
+	it("2d.path.isPointInpath.invalid", function () {
+		// Verify isPointInPath throws exceptions with invalid inputs.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		canvas.width = 200;
+		canvas.height = 200;
+		path = new Path2D();
+		path.rect(0, 0, 100, 100);
+		path.rect(25, 25, 50, 50);
+		// Testing invalid enumeration isPointInPath (w/ and w/o Path object');
+		assert.throws(function() { ctx.isPointInPath(path, 50, 50, 'gazonk'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(50, 50, 'gazonk'); }, TypeError);
+		
+		// Testing invalid type isPointInPath with Path object');
+		assert.throws(function() { ctx.isPointInPath(null, 50, 50); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(null, 50, 50, 'nonzero'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(null, 50, 50, 'evenodd'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(null, 50, 50, null); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(path, 50, 50, null); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(undefined, 50, 50); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(undefined, 50, 50, 'nonzero'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(undefined, 50, 50, 'evenodd'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath(undefined, 50, 50, undefined); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath([], 50, 50); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath([], 50, 50, 'nonzero'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath([], 50, 50, 'evenodd'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath({}, 50, 50); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath({}, 50, 50, 'nonzero'); }, TypeError);
+		assert.throws(function() { ctx.isPointInPath({}, 50, 50, 'evenodd'); }, TypeError);
+	});
+});

--- a/test/wpt/generated/pixel-manipulation.js
+++ b/test/wpt/generated/pixel-manipulation.js
@@ -1,0 +1,1448 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: pixel-manipulation", function () {
+
+	it("2d.imageData.create2.basic", function () {
+		// createImageData(sw, sh) exists and returns something
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(ctx.createImageData(1, 1), null, "ctx.createImageData(1, 1)", "null");
+	});
+
+	it("2d.imageData.create1.basic", function () {
+		// createImageData(imgdata) exists and returns something
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(ctx.createImageData(ctx.createImageData(1, 1)), null, "ctx.createImageData(ctx.createImageData(1, 1))", "null");
+	});
+
+	it("2d.imageData.create2.type", function () {
+		// createImageData(sw, sh) returns an ImageData object containing a Uint8ClampedArray object
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(window.ImageData, undefined, "window.ImageData", "undefined");
+		assert.notStrictEqual(window.Uint8ClampedArray, undefined, "window.Uint8ClampedArray", "undefined");
+		window.ImageData.prototype.thisImplementsImageData = true;
+		window.Uint8ClampedArray.prototype.thisImplementsUint8ClampedArray = true;
+		var imgdata = ctx.createImageData(1, 1);
+		assert(imgdata.thisImplementsImageData, "imgdata.thisImplementsImageData");
+		assert(imgdata.data.thisImplementsUint8ClampedArray, "imgdata.data.thisImplementsUint8ClampedArray");
+	});
+
+	it("2d.imageData.create1.type", function () {
+		// createImageData(imgdata) returns an ImageData object containing a Uint8ClampedArray object
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(window.ImageData, undefined, "window.ImageData", "undefined");
+		assert.notStrictEqual(window.Uint8ClampedArray, undefined, "window.Uint8ClampedArray", "undefined");
+		window.ImageData.prototype.thisImplementsImageData = true;
+		window.Uint8ClampedArray.prototype.thisImplementsUint8ClampedArray = true;
+		var imgdata = ctx.createImageData(ctx.createImageData(1, 1));
+		assert(imgdata.thisImplementsImageData, "imgdata.thisImplementsImageData");
+		assert(imgdata.data.thisImplementsUint8ClampedArray, "imgdata.data.thisImplementsUint8ClampedArray");
+	});
+
+	it("2d.imageData.create2.this", function () {
+		// createImageData(sw, sh) should throw when called with the wrong |this|
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { CanvasRenderingContext2D.prototype.createImageData.call(null, 1, 1); }, TypeError);
+		assert.throws(function() { CanvasRenderingContext2D.prototype.createImageData.call(undefined, 1, 1); }, TypeError);
+		assert.throws(function() { CanvasRenderingContext2D.prototype.createImageData.call({}, 1, 1); }, TypeError);
+	});
+
+	it("2d.imageData.create1.this", function () {
+		// createImageData(imgdata) should throw when called with the wrong |this|
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.createImageData(1, 1);
+		assert.throws(function() { CanvasRenderingContext2D.prototype.createImageData.call(null, imgdata); }, TypeError);
+		assert.throws(function() { CanvasRenderingContext2D.prototype.createImageData.call(undefined, imgdata); }, TypeError);
+		assert.throws(function() { CanvasRenderingContext2D.prototype.createImageData.call({}, imgdata); }, TypeError);
+	});
+
+	it("2d.imageData.create2.initial", function () {
+		// createImageData(sw, sh) returns transparent black data of the right size
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.createImageData(10, 20);
+		assert.strictEqual(imgdata.data.length, imgdata.width*imgdata.height*4, "imgdata.data.length", "imgdata.width*imgdata.height*4")
+		assert(imgdata.width < imgdata.height, "imgdata.width < imgdata.height");
+		assert(imgdata.width > 0, "imgdata.width > 0");
+		var isTransparentBlack = true;
+		for (var i = 0; i < imgdata.data.length; ++i)
+		    if (imgdata.data[i] !== 0)
+		        isTransparentBlack = false;
+		assert(isTransparentBlack, "isTransparentBlack");
+	});
+
+	it("2d.imageData.create1.initial", function () {
+		// createImageData(imgdata) returns transparent black data of the right size
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		var imgdata1 = ctx.getImageData(0, 0, 10, 20);
+		var imgdata2 = ctx.createImageData(imgdata1);
+		assert.strictEqual(imgdata2.data.length, imgdata1.data.length, "imgdata2.data.length", "imgdata1.data.length")
+		assert.strictEqual(imgdata2.width, imgdata1.width, "imgdata2.width", "imgdata1.width")
+		assert.strictEqual(imgdata2.height, imgdata1.height, "imgdata2.height", "imgdata1.height")
+		var isTransparentBlack = true;
+		for (var i = 0; i < imgdata2.data.length; ++i)
+		    if (imgdata2.data[i] !== 0)
+		        isTransparentBlack = false;
+		assert(isTransparentBlack, "isTransparentBlack");
+	});
+
+	it("2d.imageData.create2.large", function () {
+		// createImageData(sw, sh) works for sizes much larger than the canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.createImageData(1000, 2000);
+		assert.strictEqual(imgdata.data.length, imgdata.width*imgdata.height*4, "imgdata.data.length", "imgdata.width*imgdata.height*4")
+		assert(imgdata.width < imgdata.height, "imgdata.width < imgdata.height");
+		assert(imgdata.width > 0, "imgdata.width > 0");
+		var isTransparentBlack = true;
+		for (var i = 0; i < imgdata.data.length; i += 7813) // check ~1024 points (assuming normal scaling)
+		    if (imgdata.data[i] !== 0)
+		        isTransparentBlack = false;
+		assert(isTransparentBlack, "isTransparentBlack");
+	});
+
+	it.skip("2d.imageData.create2.negative", function () {
+		// createImageData(sw, sh) takes the absolute magnitude of the size arguments
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata1 = ctx.createImageData(10, 20);
+		var imgdata2 = ctx.createImageData(-10, 20);
+		var imgdata3 = ctx.createImageData(10, -20);
+		var imgdata4 = ctx.createImageData(-10, -20);
+		assert.strictEqual(imgdata1.data.length, imgdata2.data.length, "imgdata1.data.length", "imgdata2.data.length")
+		assert.strictEqual(imgdata2.data.length, imgdata3.data.length, "imgdata2.data.length", "imgdata3.data.length")
+		assert.strictEqual(imgdata3.data.length, imgdata4.data.length, "imgdata3.data.length", "imgdata4.data.length")
+	});
+
+	it.skip("2d.imageData.create2.zero", function () {
+		// createImageData(sw, sh) throws INDEX_SIZE_ERR if size is zero
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.createImageData(10, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.createImageData(0, 10); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.createImageData(0, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.createImageData(0.99, 10); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.createImageData(10, 0.1); }, /INDEX_SIZE_ERR/);
+	});
+
+	it.skip("2d.imageData.create2.nonfinite", function () {
+		// createImageData() throws TypeError if arguments are not finite
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.createImageData(Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.createImageData(-Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.createImageData(NaN, 10); }, TypeError);
+		assert.throws(function() { ctx.createImageData(10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.createImageData(10, -Infinity); }, TypeError);
+		assert.throws(function() { ctx.createImageData(10, NaN); }, TypeError);
+		assert.throws(function() { ctx.createImageData(Infinity, Infinity); }, TypeError);
+		var posinfobj = { valueOf: function() { return Infinity; } },
+		    neginfobj = { valueOf: function() { return -Infinity; } },
+		    nanobj = { valueOf: function() { return -Infinity; } };
+		assert.throws(function() { ctx.createImageData(posinfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.createImageData(neginfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.createImageData(nanobj, 10); }, TypeError);
+		assert.throws(function() { ctx.createImageData(10, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.createImageData(10, neginfobj); }, TypeError);
+		assert.throws(function() { ctx.createImageData(10, nanobj); }, TypeError);
+		assert.throws(function() { ctx.createImageData(posinfobj, posinfobj); }, TypeError);
+	});
+
+	it.skip("2d.imageData.create1.zero", function () {
+		// createImageData(null) throws TypeError
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.createImageData(null); }, TypeError);
+	});
+
+	it.skip("2d.imageData.create2.double", function () {
+		// createImageData(w, h) double is converted to long
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata1 = ctx.createImageData(10.01, 10.99);
+		var imgdata2 = ctx.createImageData(-10.01, -10.99);
+		assert.strictEqual(imgdata1.width, 10, "imgdata1.width", "10")
+		assert.strictEqual(imgdata1.height, 10, "imgdata1.height", "10")
+		assert.strictEqual(imgdata2.width, 10, "imgdata2.width", "10")
+		assert.strictEqual(imgdata2.height, 10, "imgdata2.height", "10")
+	});
+
+	it("2d.imageData.create.and.resize", function () {
+		// Verify no crash when resizing an image bitmap to zero.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var image = new Image();
+		image.onload = t.step_func(function() {
+		  var options = { resizeHeight: 0 };
+		  var p1 = createImageBitmap(image, options);
+		  p1.catch(function(error){});
+		  t.done();
+		});
+		image.src = 'red.png';
+	});
+
+	it("2d.imageData.get.basic", function () {
+		// getImageData() exists and returns something
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(ctx.getImageData(0, 0, 100, 50), null, "ctx.getImageData(0, 0, 100, 50)", "null");
+	});
+
+	it("2d.imageData.get.type", function () {
+		// getImageData() returns an ImageData object containing a Uint8ClampedArray object
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(window.ImageData, undefined, "window.ImageData", "undefined");
+		assert.notStrictEqual(window.Uint8ClampedArray, undefined, "window.Uint8ClampedArray", "undefined");
+		window.ImageData.prototype.thisImplementsImageData = true;
+		window.Uint8ClampedArray.prototype.thisImplementsUint8ClampedArray = true;
+		var imgdata = ctx.getImageData(0, 0, 1, 1);
+		assert(imgdata.thisImplementsImageData, "imgdata.thisImplementsImageData");
+		assert(imgdata.data.thisImplementsUint8ClampedArray, "imgdata.data.thisImplementsUint8ClampedArray");
+	});
+
+	it("2d.imageData.get.zero", function () {
+		// getImageData() throws INDEX_SIZE_ERR if size is zero
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.getImageData(1, 1, 10, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.getImageData(1, 1, 0, 10); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.getImageData(1, 1, 0, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.getImageData(1, 1, 0.1, 10); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.getImageData(1, 1, 10, 0.99); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.getImageData(1, 1, -0.1, 10); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { ctx.getImageData(1, 1, 10, -0.99); }, /INDEX_SIZE_ERR/);
+	});
+
+	it("2d.imageData.get.nonfinite", function () {
+		// getImageData() throws TypeError if arguments are not finite
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.getImageData(Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(-Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(NaN, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, -Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, NaN, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, -Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, NaN, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, 10, -Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, 10, NaN); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(Infinity, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, Infinity, Infinity); }, TypeError);
+		var posinfobj = { valueOf: function() { return Infinity; } },
+		    neginfobj = { valueOf: function() { return -Infinity; } },
+		    nanobj = { valueOf: function() { return -Infinity; } };
+		assert.throws(function() { ctx.getImageData(posinfobj, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(neginfobj, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(nanobj, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, posinfobj, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, neginfobj, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, nanobj, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, posinfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, neginfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, nanobj, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, 10, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, 10, neginfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, 10, nanobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, posinfobj, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, posinfobj, posinfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, posinfobj, posinfobj, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, posinfobj, 10, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, 10, posinfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, 10, posinfobj, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(posinfobj, 10, 10, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, posinfobj, posinfobj, 10); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, posinfobj, posinfobj, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, posinfobj, 10, posinfobj); }, TypeError);
+		assert.throws(function() { ctx.getImageData(10, 10, posinfobj, posinfobj); }, TypeError);
+	});
+
+	it.skip("2d.imageData.get.source.outside", function () {
+		// getImageData() returns transparent black outside the canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#08f';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		var imgdata1 = ctx.getImageData(-10, 5, 1, 1);
+		assert.strictEqual(imgdata1.data[0], 0, "imgdata1.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata1.data[1], 0, "imgdata1.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata1.data[2], 0, "imgdata1.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata1.data[3], 0, "imgdata1.data[\""+(3)+"\"]", "0")
+		
+		var imgdata2 = ctx.getImageData(10, -5, 1, 1);
+		assert.strictEqual(imgdata2.data[0], 0, "imgdata2.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata2.data[1], 0, "imgdata2.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata2.data[2], 0, "imgdata2.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata2.data[3], 0, "imgdata2.data[\""+(3)+"\"]", "0")
+		
+		var imgdata3 = ctx.getImageData(200, 5, 1, 1);
+		assert.strictEqual(imgdata3.data[0], 0, "imgdata3.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata3.data[1], 0, "imgdata3.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata3.data[2], 0, "imgdata3.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata3.data[3], 0, "imgdata3.data[\""+(3)+"\"]", "0")
+		
+		var imgdata4 = ctx.getImageData(10, 60, 1, 1);
+		assert.strictEqual(imgdata4.data[0], 0, "imgdata4.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata4.data[1], 0, "imgdata4.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata4.data[2], 0, "imgdata4.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata4.data[3], 0, "imgdata4.data[\""+(3)+"\"]", "0")
+		
+		var imgdata5 = ctx.getImageData(100, 10, 1, 1);
+		assert.strictEqual(imgdata5.data[0], 0, "imgdata5.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata5.data[1], 0, "imgdata5.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata5.data[2], 0, "imgdata5.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata5.data[3], 0, "imgdata5.data[\""+(3)+"\"]", "0")
+		
+		var imgdata6 = ctx.getImageData(0, 10, 1, 1);
+		assert.strictEqual(imgdata6.data[0], 0, "imgdata6.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata6.data[1], 136, "imgdata6.data[\""+(1)+"\"]", "136")
+		assert.strictEqual(imgdata6.data[2], 255, "imgdata6.data[\""+(2)+"\"]", "255")
+		assert.strictEqual(imgdata6.data[3], 255, "imgdata6.data[\""+(3)+"\"]", "255")
+		
+		var imgdata7 = ctx.getImageData(-10, 10, 20, 20);
+		assert.strictEqual(imgdata7.data[ 0*4+0], 0, "imgdata7.data[ 0*4+0]", "0")
+		assert.strictEqual(imgdata7.data[ 0*4+1], 0, "imgdata7.data[ 0*4+1]", "0")
+		assert.strictEqual(imgdata7.data[ 0*4+2], 0, "imgdata7.data[ 0*4+2]", "0")
+		assert.strictEqual(imgdata7.data[ 0*4+3], 0, "imgdata7.data[ 0*4+3]", "0")
+		assert.strictEqual(imgdata7.data[ 9*4+0], 0, "imgdata7.data[ 9*4+0]", "0")
+		assert.strictEqual(imgdata7.data[ 9*4+1], 0, "imgdata7.data[ 9*4+1]", "0")
+		assert.strictEqual(imgdata7.data[ 9*4+2], 0, "imgdata7.data[ 9*4+2]", "0")
+		assert.strictEqual(imgdata7.data[ 9*4+3], 0, "imgdata7.data[ 9*4+3]", "0")
+		assert.strictEqual(imgdata7.data[10*4+0], 0, "imgdata7.data[10*4+0]", "0")
+		assert.strictEqual(imgdata7.data[10*4+1], 136, "imgdata7.data[10*4+1]", "136")
+		assert.strictEqual(imgdata7.data[10*4+2], 255, "imgdata7.data[10*4+2]", "255")
+		assert.strictEqual(imgdata7.data[10*4+3], 255, "imgdata7.data[10*4+3]", "255")
+		assert.strictEqual(imgdata7.data[19*4+0], 0, "imgdata7.data[19*4+0]", "0")
+		assert.strictEqual(imgdata7.data[19*4+1], 136, "imgdata7.data[19*4+1]", "136")
+		assert.strictEqual(imgdata7.data[19*4+2], 255, "imgdata7.data[19*4+2]", "255")
+		assert.strictEqual(imgdata7.data[19*4+3], 255, "imgdata7.data[19*4+3]", "255")
+		assert.strictEqual(imgdata7.data[20*4+0], 0, "imgdata7.data[20*4+0]", "0")
+		assert.strictEqual(imgdata7.data[20*4+1], 0, "imgdata7.data[20*4+1]", "0")
+		assert.strictEqual(imgdata7.data[20*4+2], 0, "imgdata7.data[20*4+2]", "0")
+		assert.strictEqual(imgdata7.data[20*4+3], 0, "imgdata7.data[20*4+3]", "0")
+	});
+
+	it.skip("2d.imageData.get.source.negative", function () {
+		// getImageData() works with negative width and height, and returns top-to-bottom left-to-right
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#fff';
+		ctx.fillRect(20, 10, 60, 10);
+		
+		var imgdata1 = ctx.getImageData(85, 25, -10, -10);
+		assert.strictEqual(imgdata1.data[0], 255, "imgdata1.data[\""+(0)+"\"]", "255")
+		assert.strictEqual(imgdata1.data[1], 255, "imgdata1.data[\""+(1)+"\"]", "255")
+		assert.strictEqual(imgdata1.data[2], 255, "imgdata1.data[\""+(2)+"\"]", "255")
+		assert.strictEqual(imgdata1.data[3], 255, "imgdata1.data[\""+(3)+"\"]", "255")
+		assert.strictEqual(imgdata1.data[imgdata1.data.length-4+0], 0, "imgdata1.data[imgdata1.data.length-4+0]", "0")
+		assert.strictEqual(imgdata1.data[imgdata1.data.length-4+1], 0, "imgdata1.data[imgdata1.data.length-4+1]", "0")
+		assert.strictEqual(imgdata1.data[imgdata1.data.length-4+2], 0, "imgdata1.data[imgdata1.data.length-4+2]", "0")
+		assert.strictEqual(imgdata1.data[imgdata1.data.length-4+3], 255, "imgdata1.data[imgdata1.data.length-4+3]", "255")
+		
+		var imgdata2 = ctx.getImageData(0, 0, -1, -1);
+		assert.strictEqual(imgdata2.data[0], 0, "imgdata2.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata2.data[1], 0, "imgdata2.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata2.data[2], 0, "imgdata2.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata2.data[3], 0, "imgdata2.data[\""+(3)+"\"]", "0")
+	});
+
+	it("2d.imageData.get.source.size", function () {
+		// getImageData() returns bigger ImageData for bigger source rectangle
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata1 = ctx.getImageData(0, 0, 10, 10);
+		var imgdata2 = ctx.getImageData(0, 0, 20, 20);
+		assert(imgdata2.width > imgdata1.width, "imgdata2.width > imgdata1.width");
+		assert(imgdata2.height > imgdata1.height, "imgdata2.height > imgdata1.height");
+	});
+
+	it.skip("2d.imageData.get.double", function () {
+		// createImageData(w, h) double is converted to long
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata1 = ctx.getImageData(0, 0, 10.01, 10.99);
+		var imgdata2 = ctx.getImageData(0, 0, -10.01, -10.99);
+		assert.strictEqual(imgdata1.width, 10, "imgdata1.width", "10")
+		assert.strictEqual(imgdata1.height, 10, "imgdata1.height", "10")
+		assert.strictEqual(imgdata2.width, 10, "imgdata2.width", "10")
+		assert.strictEqual(imgdata2.height, 10, "imgdata2.height", "10")
+	});
+
+	it("2d.imageData.get.nonpremul", function () {
+		// getImageData() returns non-premultiplied colors
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+		ctx.fillRect(0, 0, 100, 50);
+		var imgdata = ctx.getImageData(10, 10, 10, 10);
+		assert(imgdata.data[0] > 200, "imgdata.data[\""+(0)+"\"] > 200");
+		assert(imgdata.data[1] > 200, "imgdata.data[\""+(1)+"\"] > 200");
+		assert(imgdata.data[2] > 200, "imgdata.data[\""+(2)+"\"] > 200");
+		assert(imgdata.data[3] > 100, "imgdata.data[\""+(3)+"\"] > 100");
+		assert(imgdata.data[3] < 200, "imgdata.data[\""+(3)+"\"] < 200");
+	});
+
+	it("2d.imageData.get.range", function () {
+		// getImageData() returns values in the range [0, 255]
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#fff';
+		ctx.fillRect(20, 10, 60, 10);
+		var imgdata1 = ctx.getImageData(10, 5, 1, 1);
+		assert.strictEqual(imgdata1.data[0], 0, "imgdata1.data[\""+(0)+"\"]", "0")
+		var imgdata2 = ctx.getImageData(30, 15, 1, 1);
+		assert.strictEqual(imgdata2.data[0], 255, "imgdata2.data[\""+(0)+"\"]", "255")
+	});
+
+	it("2d.imageData.get.clamp", function () {
+		// getImageData() clamps colors to the range [0, 255]
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = 'rgb(-100, -200, -300)';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = 'rgb(256, 300, 400)';
+		ctx.fillRect(20, 10, 60, 10);
+		var imgdata1 = ctx.getImageData(10, 5, 1, 1);
+		assert.strictEqual(imgdata1.data[0], 0, "imgdata1.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata1.data[1], 0, "imgdata1.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata1.data[2], 0, "imgdata1.data[\""+(2)+"\"]", "0")
+		var imgdata2 = ctx.getImageData(30, 15, 1, 1);
+		assert.strictEqual(imgdata2.data[0], 255, "imgdata2.data[\""+(0)+"\"]", "255")
+		assert.strictEqual(imgdata2.data[1], 255, "imgdata2.data[\""+(1)+"\"]", "255")
+		assert.strictEqual(imgdata2.data[2], 255, "imgdata2.data[\""+(2)+"\"]", "255")
+	});
+
+	it("2d.imageData.get.length", function () {
+		// getImageData() returns a correctly-sized Uint8ClampedArray
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert.strictEqual(imgdata.data.length, imgdata.width*imgdata.height*4, "imgdata.data.length", "imgdata.width*imgdata.height*4")
+	});
+
+	it("2d.imageData.get.order.cols", function () {
+		// getImageData() returns leftmost columns first
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#fff';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 2, 50);
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata.data[Math.round(imgdata.width/2*4)], 255, "imgdata.data[Math.round(imgdata.width/2*4)]", "255")
+		assert.strictEqual(imgdata.data[Math.round((imgdata.height/2)*imgdata.width*4)], 0, "imgdata.data[Math.round((imgdata.height/2)*imgdata.width*4)]", "0")
+	});
+
+	it("2d.imageData.get.order.rows", function () {
+		// getImageData() returns topmost rows first
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#fff';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#000';
+		ctx.fillRect(0, 0, 100, 2);
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata.data[Math.floor(imgdata.width/2*4)], 0, "imgdata.data[Math.floor(imgdata.width/2*4)]", "0")
+		assert.strictEqual(imgdata.data[(imgdata.height/2)*imgdata.width*4], 255, "imgdata.data[(imgdata.height/2)*imgdata.width*4]", "255")
+	});
+
+	it("2d.imageData.get.order.rgb", function () {
+		// getImageData() returns R then G then B
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#48c';
+		ctx.fillRect(0, 0, 100, 50);
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert.strictEqual(imgdata.data[0], 0x44, "imgdata.data[\""+(0)+"\"]", "0x44")
+		assert.strictEqual(imgdata.data[1], 0x88, "imgdata.data[\""+(1)+"\"]", "0x88")
+		assert.strictEqual(imgdata.data[2], 0xCC, "imgdata.data[\""+(2)+"\"]", "0xCC")
+		assert.strictEqual(imgdata.data[3], 255, "imgdata.data[\""+(3)+"\"]", "255")
+		assert.strictEqual(imgdata.data[4], 0x44, "imgdata.data[\""+(4)+"\"]", "0x44")
+		assert.strictEqual(imgdata.data[5], 0x88, "imgdata.data[\""+(5)+"\"]", "0x88")
+		assert.strictEqual(imgdata.data[6], 0xCC, "imgdata.data[\""+(6)+"\"]", "0xCC")
+		assert.strictEqual(imgdata.data[7], 255, "imgdata.data[\""+(7)+"\"]", "255")
+	});
+
+	it("2d.imageData.get.order.alpha", function () {
+		// getImageData() returns A in the fourth component
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+		ctx.fillRect(0, 0, 100, 50);
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert(imgdata.data[3] < 200, "imgdata.data[\""+(3)+"\"] < 200");
+		assert(imgdata.data[3] > 100, "imgdata.data[\""+(3)+"\"] > 100");
+	});
+
+	it("2d.imageData.get.unaffected", function () {
+		// getImageData() is not affected by context state
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 50)
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(50, 0, 50, 50)
+		ctx.save();
+		ctx.translate(50, 0);
+		ctx.globalAlpha = 0.1;
+		ctx.globalCompositeOperation = 'destination-atop';
+		ctx.shadowColor = '#f00';
+		ctx.rect(0, 0, 5, 5);
+		ctx.clip();
+		var imgdata = ctx.getImageData(0, 0, 50, 50);
+		ctx.restore();
+		ctx.putImageData(imgdata, 50, 0);
+		_assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 75,25, 0,255,0,255);
+	});
+
+	it.skip("2d.imageData.get.large.crash", function () {
+		// Test that canvas crash when image data cannot be allocated.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.getImageData(10, 0xffffffff, 2147483647, 10); }, TypeError);
+	});
+
+	it("2d.imageData.get.rounding", function () {
+		// Test the handling of non-integer source coordinates in getImageData().
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		function testDimensions(sx, sy, sw, sh, width, height)
+		{
+		    imageData = ctx.getImageData(sx, sy, sw, sh);
+		    assert(imageData.width == width, "imageData.width == width");
+		    assert(imageData.height == height, "imageData.height == height");
+		}
+		
+		testDimensions(0, 0, 20, 10, 20, 10);
+		
+		testDimensions(.1, .2, 20, 10, 20, 10);
+		testDimensions(.9, .8, 20, 10, 20, 10);
+		
+		testDimensions(0, 0, 20.9, 10.9, 20, 10);
+		testDimensions(0, 0, 20.1, 10.1, 20, 10);
+		
+		testDimensions(-1, -1, 20, 10, 20, 10);
+		
+		testDimensions(-1.1, 0, 20, 10, 20, 10);
+		testDimensions(-1.9,  0, 20, 10, 20, 10);
+	});
+
+	it("2d.imageData.get.invalid", function () {
+		// Verify getImageData() behavior in invalid cases.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		imageData = ctx.getImageData(0,0,2,2);
+		var testValues = [NaN, true, false, "\"garbage\"", "-1",
+		                  "0", "1", "2", Infinity, -Infinity,
+		                  -5, -0.5, 0, 0.5, 5,
+		                  5.4, 255, 256, null, undefined];
+		var testResults = [0, 1, 0, 0, 0,
+		                   0, 1, 2, 255, 0,
+		                   0, 0, 0, 0, 5,
+		                   5, 255, 255, 0, 0];
+		for (var i = 0; i < testValues.length; i++) {
+		    imageData.data[0] = testValues[i];
+		    assert(imageData.data[0] == testResults[i], "imageData.data[\""+(0)+"\"] == testResults[\""+(i)+"\"]");
+		}
+		imageData.data['foo']='garbage';
+		assert(imageData.data['foo'] == 'garbage', "imageData.data['foo'] == 'garbage'");
+		imageData.data[-1]='garbage';
+		assert(imageData.data[-1] == undefined, "imageData.data[-1] == undefined");
+		imageData.data[17]='garbage';
+		assert(imageData.data[17] == undefined, "imageData.data[\""+(17)+"\"] == undefined");
+	});
+
+	it("2d.imageData.object.properties", function () {
+		// ImageData objects have the right properties
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert.strictEqual(typeof(imgdata.width), 'number', "typeof(imgdata.width)", "'number'")
+		assert.strictEqual(typeof(imgdata.height), 'number', "typeof(imgdata.height)", "'number'")
+		assert.strictEqual(typeof(imgdata.data), 'object', "typeof(imgdata.data)", "'object'")
+	});
+
+	it("2d.imageData.object.readonly", function () {
+		// ImageData objects properties are read-only
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		var w = imgdata.width;
+		var h = imgdata.height;
+		var d = imgdata.data;
+		imgdata.width = 123;
+		imgdata.height = 123;
+		imgdata.data = [100,100,100,100];
+		assert.strictEqual(imgdata.width, w, "imgdata.width", "w")
+		assert.strictEqual(imgdata.height, h, "imgdata.height", "h")
+		assert.strictEqual(imgdata.data, d, "imgdata.data", "d")
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		assert.strictEqual(imgdata.data[1], 0, "imgdata.data[\""+(1)+"\"]", "0")
+		assert.strictEqual(imgdata.data[2], 0, "imgdata.data[\""+(2)+"\"]", "0")
+		assert.strictEqual(imgdata.data[3], 0, "imgdata.data[\""+(3)+"\"]", "0")
+	});
+
+	it("2d.imageData.object.ctor.size", function () {
+		// ImageData has a usable constructor
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(window.ImageData, undefined, "window.ImageData", "undefined");
+		
+		var imgdata = new window.ImageData(2, 3);
+		assert.strictEqual(imgdata.width, 2, "imgdata.width", "2")
+		assert.strictEqual(imgdata.height, 3, "imgdata.height", "3")
+		assert.strictEqual(imgdata.data.length, 2 * 3 * 4, "imgdata.data.length", "2 * 3 * 4")
+		for (var i = 0; i < imgdata.data.length; ++i) {
+		  assert.strictEqual(imgdata.data[i], 0, "imgdata.data[\""+(i)+"\"]", "0")
+		}
+	});
+
+	it("2d.imageData.object.ctor.basics", function () {
+		// Testing different type of ImageData constructor
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		function setRGBA(imageData, i, rgba)
+		{
+		    var s = i * 4;
+		    imageData[s] = rgba[0];
+		    imageData[s + 1] = rgba[1];
+		    imageData[s + 2] = rgba[2];
+		    imageData[s + 3] = rgba[3];
+		}
+		
+		function getRGBA(imageData, i)
+		{
+		    var result = [];
+		    var s = i * 4;
+		    for (var j = 0; j < 4; j++) {
+		        result[j] = imageData[s + j];
+		    }
+		    return result;
+		}
+		
+		function assertArrayEquals(actual, expected)
+		{
+		    assert.strictEqual(typeof actual, "object", "typeof actual", "\"object\"")
+		    assert.notStrictEqual(actual, null, "actual", "null");
+		    assert.strictEqual("length" in actual, true, "\"length\" in actual", "true")
+		    assert.strictEqual(actual.length, expected.length, "actual.length", "expected.length")
+		    for (var i = 0; i < actual.length; i++) {
+		        assert.strictEqual(actual.hasOwnProperty(i), expected.hasOwnProperty(i), "actual.hasOwnProperty(i)", "expected.hasOwnProperty(i)")
+		        assert.strictEqual(actual[i], expected[i], "actual[\""+(i)+"\"]", "expected[\""+(i)+"\"]")
+		    }
+		}
+		
+		assert.notStrictEqual(ImageData, undefined, "ImageData", "undefined");
+		imageData = new ImageData(100, 50);
+		
+		assert.notStrictEqual(imageData, null, "imageData", "null");
+		assert.notStrictEqual(imageData.data, null, "imageData.data", "null");
+		assert.strictEqual(imageData.width, 100, "imageData.width", "100")
+		assert.strictEqual(imageData.height, 50, "imageData.height", "50")
+		assertArrayEquals(getRGBA(imageData.data, 4), [0, 0, 0, 0]);
+		
+		var testColor = [0, 255, 255, 128];
+		setRGBA(imageData.data, 4, testColor);
+		assertArrayEquals(getRGBA(imageData.data, 4), testColor);
+		
+		assert.throws(function() { new ImageData(10); }, TypeError);
+		assert.throws(function() { new ImageData(0, 10); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(10, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData('width', 'height'); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(1 << 31, 1 << 31); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(0)); }, TypeError);
+		assert.throws(function() { new ImageData(new Uint8Array(100), 25); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(27), 2); }, /INVALID_STATE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(28), 7, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(104), 14); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray([12, 34, 168, 65328]), 1, 151); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(self, 4, 4); }, TypeError);
+		assert.throws(function() { new ImageData(null, 4, 4); }, TypeError);
+		assert.throws(function() { new ImageData(imageData.data, 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(imageData.data, 13); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(imageData.data, 1 << 31); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(imageData.data, 'biggish'); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(imageData.data, 1 << 24, 1 << 31); }, /INDEX_SIZE_ERR/);
+		assert.strictEqual(new ImageData(new Uint8ClampedArray(28), 7).height, 1, "new ImageData(new Uint8ClampedArray(28), 7).height", "1")
+		
+		imageDataFromData = new ImageData(imageData.data, 100);
+		assert.strictEqual(imageDataFromData.width, 100, "imageDataFromData.width", "100")
+		assert.strictEqual(imageDataFromData.height, 50, "imageDataFromData.height", "50")
+		assert.strictEqual(imageDataFromData.data, imageData.data, "imageDataFromData.data", "imageData.data")
+		assertArrayEquals(getRGBA(imageDataFromData.data, 10), getRGBA(imageData.data, 10));
+		setRGBA(imageData.data, 10, testColor);
+		assertArrayEquals(getRGBA(imageDataFromData.data, 10), getRGBA(imageData.data, 10));
+		
+		var data = new Uint8ClampedArray(400);
+		data[22] = 129;
+		imageDataFromData = new ImageData(data, 20, 5);
+		assert.strictEqual(imageDataFromData.width, 20, "imageDataFromData.width", "20")
+		assert.strictEqual(imageDataFromData.height, 5, "imageDataFromData.height", "5")
+		assert.strictEqual(imageDataFromData.data, data, "imageDataFromData.data", "data")
+		assertArrayEquals(getRGBA(imageDataFromData.data, 2), getRGBA(data, 2));
+		setRGBA(imageDataFromData.data, 2, testColor);
+		assertArrayEquals(getRGBA(imageDataFromData.data, 2), getRGBA(data, 2));
+		
+		if (window.SharedArrayBuffer) {
+		    assert.throws(function() { new ImageData(new Uint16Array(new SharedArrayBuffer(32)), 4, 2); }, TypeError);
+		}
+	});
+
+	it("2d.imageData.object.ctor.array", function () {
+		// ImageData has a usable constructor
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(window.ImageData, undefined, "window.ImageData", "undefined");
+		
+		var array = new Uint8ClampedArray(8);
+		var imgdata = new window.ImageData(array, 1, 2);
+		assert.strictEqual(imgdata.width, 1, "imgdata.width", "1")
+		assert.strictEqual(imgdata.height, 2, "imgdata.height", "2")
+		assert.strictEqual(imgdata.data, array, "imgdata.data", "array")
+	});
+
+	it("2d.imageData.object.ctor.array.bounds", function () {
+		// ImageData has a usable constructor
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(window.ImageData, undefined, "window.ImageData", "undefined");
+		
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(0), 1); }, /INVALID_STATE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(3), 1); }, /INVALID_STATE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(4), 0); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8ClampedArray(4), 1, 2); }, /INDEX_SIZE_ERR/);
+		assert.throws(function() { new ImageData(new Uint8Array(8), 1, 2); }, TypeError);
+		assert.throws(function() { new ImageData(new Int8Array(8), 1, 2); }, TypeError);
+	});
+
+	it("2d.imageData.object.set", function () {
+		// ImageData.data can be modified
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		imgdata.data[0] = 100;
+		assert.strictEqual(imgdata.data[0], 100, "imgdata.data[\""+(0)+"\"]", "100")
+		imgdata.data[0] = 200;
+		assert.strictEqual(imgdata.data[0], 200, "imgdata.data[\""+(0)+"\"]", "200")
+	});
+
+	it("2d.imageData.object.undefined", function () {
+		// ImageData.data converts undefined to 0
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		imgdata.data[0] = 100;
+		imgdata.data[0] = undefined;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+	});
+
+	it("2d.imageData.object.nan", function () {
+		// ImageData.data converts NaN to 0
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		imgdata.data[0] = 100;
+		imgdata.data[0] = NaN;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = "cheese";
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+	});
+
+	it("2d.imageData.object.string", function () {
+		// ImageData.data converts strings to numbers with ToNumber
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		imgdata.data[0] = 100;
+		imgdata.data[0] = "110";
+		assert.strictEqual(imgdata.data[0], 110, "imgdata.data[\""+(0)+"\"]", "110")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = "0x78";
+		assert.strictEqual(imgdata.data[0], 120, "imgdata.data[\""+(0)+"\"]", "120")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = " +130e0 ";
+		assert.strictEqual(imgdata.data[0], 130, "imgdata.data[\""+(0)+"\"]", "130")
+	});
+
+	it("2d.imageData.object.clamp", function () {
+		// ImageData.data clamps numbers to [0, 255]
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		
+		imgdata.data[0] = 100;
+		imgdata.data[0] = 300;
+		assert.strictEqual(imgdata.data[0], 255, "imgdata.data[\""+(0)+"\"]", "255")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = -100;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		
+		imgdata.data[0] = 100;
+		imgdata.data[0] = 200+Math.pow(2, 32);
+		assert.strictEqual(imgdata.data[0], 255, "imgdata.data[\""+(0)+"\"]", "255")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = -200-Math.pow(2, 32);
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		
+		imgdata.data[0] = 100;
+		imgdata.data[0] = Math.pow(10, 39);
+		assert.strictEqual(imgdata.data[0], 255, "imgdata.data[\""+(0)+"\"]", "255")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = -Math.pow(10, 39);
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		
+		imgdata.data[0] = 100;
+		imgdata.data[0] = -Infinity;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		imgdata.data[0] = 100;
+		imgdata.data[0] = Infinity;
+		assert.strictEqual(imgdata.data[0], 255, "imgdata.data[\""+(0)+"\"]", "255")
+	});
+
+	it("2d.imageData.object.round", function () {
+		// ImageData.data rounds numbers with round-to-zero
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		imgdata.data[0] = 0.499;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		imgdata.data[0] = 0.5;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		imgdata.data[0] = 0.501;
+		assert.strictEqual(imgdata.data[0], 1, "imgdata.data[\""+(0)+"\"]", "1")
+		imgdata.data[0] = 1.499;
+		assert.strictEqual(imgdata.data[0], 1, "imgdata.data[\""+(0)+"\"]", "1")
+		imgdata.data[0] = 1.5;
+		assert.strictEqual(imgdata.data[0], 2, "imgdata.data[\""+(0)+"\"]", "2")
+		imgdata.data[0] = 1.501;
+		assert.strictEqual(imgdata.data[0], 2, "imgdata.data[\""+(0)+"\"]", "2")
+		imgdata.data[0] = 2.5;
+		assert.strictEqual(imgdata.data[0], 2, "imgdata.data[\""+(0)+"\"]", "2")
+		imgdata.data[0] = 3.5;
+		assert.strictEqual(imgdata.data[0], 4, "imgdata.data[\""+(0)+"\"]", "4")
+		imgdata.data[0] = 252.5;
+		assert.strictEqual(imgdata.data[0], 252, "imgdata.data[\""+(0)+"\"]", "252")
+		imgdata.data[0] = 253.5;
+		assert.strictEqual(imgdata.data[0], 254, "imgdata.data[\""+(0)+"\"]", "254")
+		imgdata.data[0] = 254.5;
+		assert.strictEqual(imgdata.data[0], 254, "imgdata.data[\""+(0)+"\"]", "254")
+		imgdata.data[0] = 256.5;
+		assert.strictEqual(imgdata.data[0], 255, "imgdata.data[\""+(0)+"\"]", "255")
+		imgdata.data[0] = -0.5;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+		imgdata.data[0] = -1.5;
+		assert.strictEqual(imgdata.data[0], 0, "imgdata.data[\""+(0)+"\"]", "0")
+	});
+
+	it("2d.imageData.put.null", function () {
+		// putImageData() with null imagedata throws TypeError
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.throws(function() { ctx.putImageData(null, 0, 0); }, TypeError);
+	});
+
+	it("2d.imageData.put.nonfinite", function () {
+		// putImageData() throws TypeError if arguments are not finite
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.getImageData(0, 0, 10, 10);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, -Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, NaN, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, -Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, NaN); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, -Infinity, 10, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, NaN, 10, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, -Infinity, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, NaN, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, -Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, NaN, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, -Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, NaN, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, -Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, NaN, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, 10, -Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, 10, NaN); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, Infinity, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, Infinity, 10, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, Infinity, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, Infinity, 10, 10, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, 10, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, Infinity, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, Infinity, 10, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, Infinity, 10, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, 10, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, 10, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, Infinity, 10, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, Infinity, Infinity, 10); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, Infinity, Infinity, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, Infinity, 10, Infinity); }, TypeError);
+		assert.throws(function() { ctx.putImageData(imgdata, 10, 10, 10, 10, Infinity, Infinity); }, TypeError);
+	});
+
+	it("2d.imageData.put.basic", function () {
+		// putImageData() puts image data from getImageData() onto the canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.putImageData(imgdata, 0, 0);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.created", function () {
+		// putImageData() puts image data from createImageData() onto the canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = ctx.createImageData(100, 50);
+		for (var i = 0; i < imgdata.data.length; i += 4) {
+		    imgdata.data[i] = 0;
+		    imgdata.data[i+1] = 255;
+		    imgdata.data[i+2] = 0;
+		    imgdata.data[i+3] = 255;
+		}
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.putImageData(imgdata, 0, 0);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.wrongtype", function () {
+		// putImageData() does not accept non-ImageData objects
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var imgdata = { width: 1, height: 1, data: [255, 0, 0, 255] };
+		assert.throws(function() { ctx.putImageData(imgdata, 0, 0); }, TypeError);
+		assert.throws(function() { ctx.putImageData("cheese", 0, 0); }, TypeError);
+		assert.throws(function() { ctx.putImageData(42, 0, 0); }, TypeError);
+	});
+
+	it("2d.imageData.put.cross", function () {
+		// putImageData() accepts image data got from a different canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		var ctx2 = canvas2.getContext('2d');
+		ctx2.fillStyle = '#0f0';
+		ctx2.fillRect(0, 0, 100, 50)
+		var imgdata = ctx2.getImageData(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.putImageData(imgdata, 0, 0);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.alpha", function () {
+		// putImageData() puts non-solid image data correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = 'rgba(0, 255, 0, 0.25)';
+		ctx.fillRect(0, 0, 100, 50)
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.putImageData(imgdata, 0, 0);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,64);
+	});
+
+	it("2d.imageData.put.modified", function () {
+		// putImageData() puts modified image data correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(45, 20, 10, 10)
+		var imgdata = ctx.getImageData(45, 20, 10, 10);
+		for (var i = 0, len = imgdata.width*imgdata.height*4; i < len; i += 4)
+		{
+		    imgdata.data[i] = 0;
+		    imgdata.data[i+1] = 255;
+		}
+		ctx.putImageData(imgdata, 45, 20);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.dirty.zero", function () {
+		// putImageData() with zero-sized dirty rectangle puts nothing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.putImageData(imgdata, 0, 0, 0, 0, 0, 0);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.dirty.rect1", function () {
+		// putImageData() only modifies areas inside the dirty rectangle, using width and height
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 20, 20)
+		
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(40, 20, 20, 20)
+		ctx.putImageData(imgdata, 40, 20, 0, 0, 20, 20);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 35,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 65,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,15, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,45, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.dirty.rect2", function () {
+		// putImageData() only modifies areas inside the dirty rectangle, using x and y
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(60, 30, 20, 20)
+		
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(40, 20, 20, 20)
+		ctx.putImageData(imgdata, -20, -10, 60, 30, 20, 20);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 35,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 65,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,15, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,45, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.dirty.negative", function () {
+		// putImageData() handles negative-sized dirty rectangles correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 20, 20)
+		
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(40, 20, 20, 20)
+		ctx.putImageData(imgdata, 40, 20, 20, 20, -20, -20);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 35,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 65,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,15, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,45, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.dirty.outside", function () {
+		// putImageData() handles dirty rectangles outside the canvas correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		
+		ctx.putImageData(imgdata, 100, 20, 20, 20, -20, -20);
+		ctx.putImageData(imgdata, 200, 200, 0, 0, 100, 50);
+		ctx.putImageData(imgdata, 40, 20, -30, -20, 30, 20);
+		ctx.putImageData(imgdata, -30, 20, 0, 0, 30, 20);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 98,15, 0,255,0,255);
+		_assertPixelApprox(canvas, 98,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 98,45, 0,255,0,255);
+		_assertPixelApprox(canvas, 1,5, 0,255,0,255);
+		_assertPixelApprox(canvas, 1,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 1,45, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.unchanged", function () {
+		// putImageData(getImageData(...), ...) has no effect
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var i = 0;
+		for (var y = 0; y < 16; ++y) {
+		    for (var x = 0; x < 16; ++x, ++i) {
+		        ctx.fillStyle = 'rgba(' + i + ',' + (Math.floor(i*1.5) % 256) + ',' + (Math.floor(i*23.3) % 256) + ',' + (i/256) + ')';
+		        ctx.fillRect(x, y, 1, 1);
+		    }
+		}
+		var imgdata1 = ctx.getImageData(0.1, 0.2, 15.8, 15.9);
+		var olddata = [];
+		for (var i = 0; i < imgdata1.data.length; ++i)
+		    olddata[i] = imgdata1.data[i];
+		
+		ctx.putImageData(imgdata1, 0.1, 0.2);
+		
+		var imgdata2 = ctx.getImageData(0.1, 0.2, 15.8, 15.9);
+		for (var i = 0; i < imgdata2.data.length; ++i) {
+		    assert.strictEqual(olddata[i], imgdata2.data[i], "olddata[\""+(i)+"\"]", "imgdata2.data[\""+(i)+"\"]")
+		}
+	});
+
+	it("2d.imageData.put.unaffected", function () {
+		// putImageData() is not affected by context state
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.globalAlpha = 0.1;
+		ctx.globalCompositeOperation = 'destination-atop';
+		ctx.shadowColor = '#f00';
+		ctx.shadowBlur = 1;
+		ctx.translate(100, 50);
+		ctx.scale(0.1, 0.1);
+		ctx.putImageData(imgdata, 0, 0);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.clip", function () {
+		// putImageData() is not affected by clipping regions
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50)
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.beginPath();
+		ctx.rect(0, 0, 50, 50);
+		ctx.clip();
+		ctx.putImageData(imgdata, 0, 0);
+		_assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.imageData.put.path", function () {
+		// putImageData() does not affect the current path
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50)
+		ctx.rect(0, 0, 100, 50);
+		var imgdata = ctx.getImageData(0, 0, 100, 50);
+		ctx.putImageData(imgdata, 0, 0);
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+});

--- a/test/wpt/generated/shadows.js
+++ b/test/wpt/generated/shadows.js
@@ -1,0 +1,1203 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: shadows", function () {
+
+	it("2d.shadow.attributes.shadowBlur.initial", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.shadowBlur, 0, "ctx.shadowBlur", "0")
+	});
+
+	it("2d.shadow.attributes.shadowBlur.valid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowBlur = 1;
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 0.5;
+		assert.strictEqual(ctx.shadowBlur, 0.5, "ctx.shadowBlur", "0.5")
+		
+		ctx.shadowBlur = 1e6;
+		assert.strictEqual(ctx.shadowBlur, 1e6, "ctx.shadowBlur", "1e6")
+		
+		ctx.shadowBlur = 0;
+		assert.strictEqual(ctx.shadowBlur, 0, "ctx.shadowBlur", "0")
+	});
+
+	it("2d.shadow.attributes.shadowBlur.invalid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = -2;
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = Infinity;
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = -Infinity;
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = NaN;
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = 'string';
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = true;
+		assert.strictEqual(ctx.shadowBlur, 1, "ctx.shadowBlur", "1")
+		
+		ctx.shadowBlur = 1;
+		ctx.shadowBlur = false;
+		assert.strictEqual(ctx.shadowBlur, 0, "ctx.shadowBlur", "0")
+	});
+
+	it("2d.shadow.attributes.shadowOffset.initial", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.shadowOffsetX, 0, "ctx.shadowOffsetX", "0")
+		assert.strictEqual(ctx.shadowOffsetY, 0, "ctx.shadowOffsetY", "0")
+	});
+
+	it("2d.shadow.attributes.shadowOffset.valid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		assert.strictEqual(ctx.shadowOffsetX, 1, "ctx.shadowOffsetX", "1")
+		assert.strictEqual(ctx.shadowOffsetY, 2, "ctx.shadowOffsetY", "2")
+		
+		ctx.shadowOffsetX = 0.5;
+		ctx.shadowOffsetY = 0.25;
+		assert.strictEqual(ctx.shadowOffsetX, 0.5, "ctx.shadowOffsetX", "0.5")
+		assert.strictEqual(ctx.shadowOffsetY, 0.25, "ctx.shadowOffsetY", "0.25")
+		
+		ctx.shadowOffsetX = -0.5;
+		ctx.shadowOffsetY = -0.25;
+		assert.strictEqual(ctx.shadowOffsetX, -0.5, "ctx.shadowOffsetX", "-0.5")
+		assert.strictEqual(ctx.shadowOffsetY, -0.25, "ctx.shadowOffsetY", "-0.25")
+		
+		ctx.shadowOffsetX = 0;
+		ctx.shadowOffsetY = 0;
+		assert.strictEqual(ctx.shadowOffsetX, 0, "ctx.shadowOffsetX", "0")
+		assert.strictEqual(ctx.shadowOffsetY, 0, "ctx.shadowOffsetY", "0")
+		
+		ctx.shadowOffsetX = 1e6;
+		ctx.shadowOffsetY = 1e6;
+		assert.strictEqual(ctx.shadowOffsetX, 1e6, "ctx.shadowOffsetX", "1e6")
+		assert.strictEqual(ctx.shadowOffsetY, 1e6, "ctx.shadowOffsetY", "1e6")
+	});
+
+	it("2d.shadow.attributes.shadowOffset.invalid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		ctx.shadowOffsetX = Infinity;
+		ctx.shadowOffsetY = Infinity;
+		assert.strictEqual(ctx.shadowOffsetX, 1, "ctx.shadowOffsetX", "1")
+		assert.strictEqual(ctx.shadowOffsetY, 2, "ctx.shadowOffsetY", "2")
+		
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		ctx.shadowOffsetX = -Infinity;
+		ctx.shadowOffsetY = -Infinity;
+		assert.strictEqual(ctx.shadowOffsetX, 1, "ctx.shadowOffsetX", "1")
+		assert.strictEqual(ctx.shadowOffsetY, 2, "ctx.shadowOffsetY", "2")
+		
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		ctx.shadowOffsetX = NaN;
+		ctx.shadowOffsetY = NaN;
+		assert.strictEqual(ctx.shadowOffsetX, 1, "ctx.shadowOffsetX", "1")
+		assert.strictEqual(ctx.shadowOffsetY, 2, "ctx.shadowOffsetY", "2")
+		
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		ctx.shadowOffsetX = 'string';
+		ctx.shadowOffsetY = 'string';
+		assert.strictEqual(ctx.shadowOffsetX, 1, "ctx.shadowOffsetX", "1")
+		assert.strictEqual(ctx.shadowOffsetY, 2, "ctx.shadowOffsetY", "2")
+		
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		ctx.shadowOffsetX = true;
+		ctx.shadowOffsetY = true;
+		assert.strictEqual(ctx.shadowOffsetX, 1, "ctx.shadowOffsetX", "1")
+		assert.strictEqual(ctx.shadowOffsetY, 1, "ctx.shadowOffsetY", "1")
+		
+		ctx.shadowOffsetX = 1;
+		ctx.shadowOffsetY = 2;
+		ctx.shadowOffsetX = false;
+		ctx.shadowOffsetY = false;
+		assert.strictEqual(ctx.shadowOffsetX, 0, "ctx.shadowOffsetX", "0")
+		assert.strictEqual(ctx.shadowOffsetY, 0, "ctx.shadowOffsetY", "0")
+	});
+
+	it("2d.shadow.attributes.shadowColor.initial", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.shadowColor, 'rgba(0, 0, 0, 0)', "ctx.shadowColor", "'rgba(0, 0, 0, 0)'")
+	});
+
+	it("2d.shadow.attributes.shadowColor.valid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowColor = 'lime';
+		assert.strictEqual(ctx.shadowColor, '#00ff00', "ctx.shadowColor", "'#00ff00'")
+		
+		ctx.shadowColor = 'RGBA(0,255, 0,0)';
+		assert.strictEqual(ctx.shadowColor, 'rgba(0, 255, 0, 0)', "ctx.shadowColor", "'rgba(0, 255, 0, 0)'")
+	});
+
+	it("2d.shadow.attributes.shadowColor.invalid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowColor = '#00ff00';
+		ctx.shadowColor = 'bogus';
+		assert.strictEqual(ctx.shadowColor, '#00ff00', "ctx.shadowColor", "'#00ff00'")
+		
+		ctx.shadowColor = '#00ff00';
+		ctx.shadowColor = 'red bogus';
+		assert.strictEqual(ctx.shadowColor, '#00ff00', "ctx.shadowColor", "'#00ff00'")
+		
+		ctx.shadowColor = '#00ff00';
+		ctx.shadowColor = ctx;
+		assert.strictEqual(ctx.shadowColor, '#00ff00', "ctx.shadowColor", "'#00ff00'")
+		
+		ctx.shadowColor = '#00ff00';
+		ctx.shadowColor = undefined;
+		assert.strictEqual(ctx.shadowColor, '#00ff00', "ctx.shadowColor", "'#00ff00'")
+	});
+
+	it("2d.shadow.enable.off.1", function () {
+		// Shadows are not drawn when only shadowColor is set
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.shadowColor = '#f00';
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.enable.off.2", function () {
+		// Shadows are not drawn when only shadowColor is set
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.globalCompositeOperation = 'destination-atop';
+		ctx.shadowColor = '#f00';
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.enable.blur", function () {
+		// Shadows are drawn if shadowBlur is set
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.globalCompositeOperation = 'destination-atop';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowBlur = 0.1;
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.enable.x", function () {
+		// Shadows are drawn if shadowOffsetX is set
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.globalCompositeOperation = 'destination-atop';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = 0.1;
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.enable.y", function () {
+		// Shadows are drawn if shadowOffsetY is set
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.globalCompositeOperation = 'destination-atop';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 0.1;
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.offset.positiveX", function () {
+		// Shadows can be offset with positive x
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = 50;
+		ctx.fillRect(0, 0, 50, 50);
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.offset.negativeX", function () {
+		// Shadows can be offset with negative x
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = -50;
+		ctx.fillRect(50, 0, 50, 50);
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.offset.positiveY", function () {
+		// Shadows can be offset with positive y
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 25;
+		ctx.fillRect(0, 0, 100, 25);
+		_assertPixel(canvas, 50,12, 0,255,0,255);
+		_assertPixel(canvas, 50,37, 0,255,0,255);
+	});
+
+	it("2d.shadow.offset.negativeY", function () {
+		// Shadows can be offset with negative y
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = -25;
+		ctx.fillRect(0, 25, 100, 25);
+		_assertPixel(canvas, 50,12, 0,255,0,255);
+		_assertPixel(canvas, 50,37, 0,255,0,255);
+	});
+
+	it("2d.shadow.outside", function () {
+		// Shadows of shapes outside the visible area can be offset onto the visible area
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = 100;
+		ctx.fillRect(-100, 0, 25, 50);
+		ctx.shadowOffsetX = -100;
+		ctx.fillRect(175, 0, 25, 50);
+		ctx.shadowOffsetX = 0;
+		ctx.shadowOffsetY = 100;
+		ctx.fillRect(25, -100, 50, 25);
+		ctx.shadowOffsetY = -100;
+		ctx.fillRect(25, 125, 50, 25);
+		_assertPixel(canvas, 12,25, 0,255,0,255);
+		_assertPixel(canvas, 87,25, 0,255,0,255);
+		_assertPixel(canvas, 50,12, 0,255,0,255);
+		_assertPixel(canvas, 50,37, 0,255,0,255);
+	});
+
+	it("2d.shadow.clip.1", function () {
+		// Shadows of clipped shapes are still drawn within the clipping region
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(50, 0, 50, 50);
+		
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(50, 0, 50, 50);
+		ctx.clip();
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = 50;
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.restore();
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.clip.2", function () {
+		// Shadows are not drawn outside the clipping region
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(50, 0, 50, 50);
+		
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(0, 0, 50, 50);
+		ctx.clip();
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetX = 50;
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.restore();
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.clip.3", function () {
+		// Shadows of clipped shapes are still drawn within the clipping region
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(50, 0, 50, 50);
+		
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(0, 0, 50, 50);
+		ctx.clip();
+		ctx.fillStyle = '#f00';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = 50;
+		ctx.fillRect(-50, 0, 50, 50);
+		ctx.restore();
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.stroke.basic", function () {
+		// Shadows are drawn for strokes
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 50;
+		ctx.beginPath();
+		ctx.lineWidth = 50;
+		ctx.moveTo(0, -25);
+		ctx.lineTo(100, -25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.stroke.cap.1", function () {
+		// Shadows are not drawn for areas outside stroke caps
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetY = 50;
+		ctx.beginPath();
+		ctx.lineWidth = 50;
+		ctx.lineCap = 'butt';
+		ctx.moveTo(-50, -25);
+		ctx.lineTo(0, -25);
+		ctx.moveTo(100, -25);
+		ctx.lineTo(150, -25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.stroke.cap.2", function () {
+		// Shadows are drawn for stroke caps
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 50;
+		ctx.beginPath();
+		ctx.lineWidth = 50;
+		ctx.lineCap = 'square';
+		ctx.moveTo(25, -25);
+		ctx.lineTo(75, -25);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.stroke.join.1", function () {
+		// Shadows are not drawn for areas outside stroke joins
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetX = 100;
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'bevel';
+		ctx.beginPath();
+		ctx.moveTo(-200, -50);
+		ctx.lineTo(-150, -50);
+		ctx.lineTo(-151, -100);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.shadow.stroke.join.2", function () {
+		// Shadows are drawn for stroke joins
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(50, 0, 50, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetX = 100;
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'miter';
+		ctx.beginPath();
+		ctx.moveTo(-200, -50);
+		ctx.lineTo(-150, -50);
+		ctx.lineTo(-151, -100);
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.shadow.stroke.join.3", function () {
+		// Shadows are drawn for stroke joins respecting miter limit
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.strokeStyle = '#f00';
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetX = 100;
+		ctx.lineWidth = 200;
+		ctx.lineJoin = 'miter';
+		ctx.miterLimit = 0.1;
+		ctx.beginPath();
+		ctx.moveTo(-200, -50);
+		ctx.lineTo(-150, -50);
+		ctx.lineTo(-151, -100); // (not an exact right angle, to avoid some other bug in Firefox 3)
+		ctx.stroke();
+		
+		_assertPixel(canvas, 1,1, 0,255,0,255);
+		_assertPixel(canvas, 48,48, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,48, 0,255,0,255);
+	});
+
+	it("2d.shadow.image.basic", function () {
+		// Shadows are drawn for images
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 50;
+		ctx.drawImage(document.getElementById('red.png'), 0, -50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.image.transparent.1", function () {
+		// Shadows are not drawn for transparent images
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetY = 50;
+		ctx.drawImage(document.getElementById('transparent.png'), 0, -50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.image.transparent.2", function () {
+		// Shadows are not drawn for transparent parts of images
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(50, 0, 50, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.drawImage(document.getElementById('redtransparent.png'), 50, -50);
+		ctx.shadowColor = '#f00';
+		ctx.drawImage(document.getElementById('redtransparent.png'), -50, -50);
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.image.alpha", function () {
+		// Shadows are drawn correctly for partially-transparent images
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#00f';
+		ctx.drawImage(document.getElementById('transparent50.png'), 0, -50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.image.section", function () {
+		// Shadows are not drawn for areas outside image source rectangles
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#f00';
+		ctx.drawImage(document.getElementById('redtransparent.png'), 50, 0, 50, 50, 0, -50, 50, 50);
+		
+		_assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.image.scale", function () {
+		// Shadows are drawn correctly for scaled images
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.drawImage(document.getElementById('redtransparent.png'), 0, 0, 100, 50, -10, -50, 240, 50);
+		
+		_assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+		_assertPixelApprox(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.canvas.basic", function () {
+		// Shadows are drawn for canvases
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		canvas2.width = 100;
+		canvas2.height = 50;
+		var ctx2 = canvas2.getContext('2d');
+		ctx2.fillStyle = '#f00';
+		ctx2.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 50;
+		ctx.drawImage(canvas2, 0, -50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.canvas.transparent.1", function () {
+		// Shadows are not drawn for transparent canvases
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		canvas2.width = 100;
+		canvas2.height = 50;
+		var ctx2 = canvas2.getContext('2d');
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetY = 50;
+		ctx.drawImage(canvas2, 0, -50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.canvas.transparent.2", function () {
+		// Shadows are not drawn for transparent parts of canvases
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		canvas2.width = 100;
+		canvas2.height = 50;
+		var ctx2 = canvas2.getContext('2d');
+		ctx2.fillStyle = '#f00';
+		ctx2.fillRect(0, 0, 50, 50);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(50, 0, 50, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.drawImage(canvas2, 50, -50);
+		ctx.shadowColor = '#f00';
+		ctx.drawImage(canvas2, -50, -50);
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.canvas.alpha", function () {
+		// Shadows are drawn correctly for partially-transparent canvases
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		canvas2.width = 100;
+		canvas2.height = 50;
+		var ctx2 = canvas2.getContext('2d');
+		ctx2.fillStyle = 'rgba(255, 0, 0, 0.5)';
+		ctx2.fillRect(0, 0, 100, 50);
+		
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#00f';
+		ctx.drawImage(canvas2, 0, -50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.pattern.basic", function () {
+		// Shadows are drawn for fill patterns
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var pattern = ctx.createPattern(document.getElementById('red.png'), 'repeat');
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 50;
+		ctx.fillStyle = pattern;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.pattern.transparent.1", function () {
+		// Shadows are not drawn for transparent fill patterns
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var pattern = ctx.createPattern(document.getElementById('transparent.png'), 'repeat');
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetY = 50;
+		ctx.fillStyle = pattern;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.pattern.transparent.2", function () {
+		// Shadows are not drawn for transparent parts of fill patterns
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var pattern = ctx.createPattern(document.getElementById('redtransparent.png'), 'repeat');
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(50, 0, 50, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.fillStyle = pattern;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.pattern.alpha", function () {
+		// Shadows are drawn correctly for partially-transparent fill patterns
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var pattern = ctx.createPattern(document.getElementById('transparent50.png'), 'repeat');
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#00f';
+		ctx.fillStyle = pattern;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.gradient.basic", function () {
+		// Shadows are drawn for gradient fills
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+		gradient.addColorStop(0, '#f00');
+		gradient.addColorStop(1, '#f00');
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#0f0';
+		ctx.shadowOffsetY = 50;
+		ctx.fillStyle = gradient;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.gradient.transparent.1", function () {
+		// Shadows are not drawn for transparent gradient fills
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+		gradient.addColorStop(0, 'rgba(0,0,0,0)');
+		gradient.addColorStop(1, 'rgba(0,0,0,0)');
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetY = 50;
+		ctx.fillStyle = gradient;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.gradient.transparent.2", function () {
+		// Shadows are not drawn for transparent parts of gradient fills
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+		gradient.addColorStop(0, '#f00');
+		gradient.addColorStop(0.499, '#f00');
+		gradient.addColorStop(0.5, 'rgba(0,0,0,0)');
+		gradient.addColorStop(1, 'rgba(0,0,0,0)');
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 50, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(50, 0, 50, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.fillStyle = gradient;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.gradient.alpha", function () {
+		// Shadows are drawn correctly for partially-transparent gradient fills
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+		gradient.addColorStop(0, 'rgba(255,0,0,0.5)');
+		gradient.addColorStop(1, 'rgba(255,0,0,0.5)');
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#00f';
+		ctx.fillStyle = gradient;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.transform.1", function () {
+		// Shadows take account of transformations
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.translate(100, 100);
+		ctx.fillRect(-100, -150, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.transform.2", function () {
+		// Shadow offsets are not affected by transformations
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowOffsetY = 50;
+		ctx.shadowColor = '#0f0';
+		ctx.rotate(Math.PI)
+		ctx.fillRect(-100, 0, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.blur.low", function () {
+		// Shadows look correct for small blurs
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#ff0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#00f';
+		ctx.shadowOffsetY = 25;
+		for (var x = 0; x < 100; ++x) {
+		    ctx.save();
+		    ctx.beginPath();
+		    ctx.rect(x, 0, 1, 50);
+		    ctx.clip();
+		    ctx.shadowBlur = x;
+		    ctx.fillRect(-200, -200, 500, 200);
+		    ctx.restore();
+		}
+	});
+
+	it("2d.shadow.blur.high", function () {
+		// Shadows look correct for large blurs
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#ff0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = '#00f';
+		ctx.shadowOffsetY = 0;
+		ctx.shadowBlur = 100;
+		ctx.fillRect(-200, -200, 200, 400);
+	});
+
+	it("2d.shadow.alpha.1", function () {
+		// Shadow color alpha components are used
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = 'rgba(255, 0, 0, 0.01)';
+		ctx.shadowOffsetY = 50;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255, 4);
+	});
+
+	it("2d.shadow.alpha.2", function () {
+		// Shadow color alpha components are used
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.shadowColor = 'rgba(0, 0, 255, 0.5)';
+		ctx.shadowOffsetY = 50;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.alpha.3", function () {
+		// Shadows are affected by globalAlpha
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00'; // (work around broken Firefox globalAlpha caching)
+		ctx.shadowColor = '#00f';
+		ctx.shadowOffsetY = 50;
+		ctx.globalAlpha = 0.5;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.alpha.4", function () {
+		// Shadows with alpha components are correctly affected by globalAlpha
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00'; // (work around broken Firefox globalAlpha caching)
+		ctx.shadowColor = 'rgba(0, 0, 255, 0.707)';
+		ctx.shadowOffsetY = 50;
+		ctx.globalAlpha = 0.707;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.alpha.5", function () {
+		// Shadows of shapes with alpha components are drawn correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = 'rgba(64, 0, 0, 0.5)';
+		ctx.shadowColor = '#00f';
+		ctx.shadowOffsetY = 50;
+		ctx.fillRect(0, -50, 100, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 127,0,127,255);
+	});
+
+	it("2d.shadow.composite.1", function () {
+		// Shadows are drawn using globalCompositeOperation
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.globalCompositeOperation = 'xor';
+		ctx.shadowColor = '#f00';
+		ctx.shadowOffsetX = 100;
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, 0, 200, 50);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.composite.2", function () {
+		// Shadows are drawn using globalCompositeOperation
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.globalCompositeOperation = 'xor';
+		ctx.shadowColor = '#f00';
+		ctx.shadowBlur = 1;
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-10, -10, 120, 70);
+		
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.shadow.composite.3", function () {
+		// Areas outside shadows are drawn correctly with destination-out
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.globalCompositeOperation = 'destination-out';
+		ctx.shadowColor = '#f00';
+		ctx.shadowBlur = 10;
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(200, 0, 100, 50);
+		
+		_assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		_assertPixelApprox(canvas, 50,25, 0,255,0,255);
+	});
+});

--- a/test/wpt/generated/text-styles.js
+++ b/test/wpt/generated/text-styles.js
@@ -1,0 +1,614 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: text-styles", function () {
+
+	it("2d.text.font.parse.basic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '20px serif';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20PX   SERIF';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+	});
+
+	it("2d.text.font.parse.tiny", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '1px sans-serif';
+		assert.strictEqual(ctx.font, '1px sans-serif', "ctx.font", "'1px sans-serif'")
+	});
+
+	it("2d.text.font.parse.complex", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = 'small-caps italic 400 12px/2 Unknown Font, sans-serif';
+		assert.strictEqual(ctx.font, 'italic small-caps 12px "Unknown Font", sans-serif', "ctx.font", "'italic small-caps 12px \"Unknown Font\", sans-serif'")
+	});
+
+	it("2d.text.font.parse.family", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '20px cursive,fantasy,monospace,sans-serif,serif,UnquotedFont,"QuotedFont\\\\\\","';
+		assert.strictEqual(ctx.font, '20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\\\\","', "ctx.font", "'20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, \"QuotedFont\\\\\\\\\\\\\",\"'")
+	});
+
+	it("2d.text.font.parse.size.percentage", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50% serif';
+		assert.strictEqual(ctx.font, '72px serif', "ctx.font", "'72px serif'")
+		canvas.setAttribute('style', 'font-size: 100px');
+		assert.strictEqual(ctx.font, '72px serif', "ctx.font", "'72px serif'")
+	});
+
+	it("2d.text.font.parse.size.percentage.default", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		var ctx2 = canvas2.getContext('2d');
+		ctx2.font = '1000% serif';
+		assert.strictEqual(ctx2.font, '100px serif', "ctx2.font", "'100px serif'")
+	});
+
+	it("2d.text.font.parse.system", function () {
+		// System fonts must be computed to explicit values
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = 'message-box';
+		assert.notStrictEqual(ctx.font, 'message-box', "ctx.font", "'message-box'");
+	});
+
+	it("2d.text.font.parse.invalid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '20px serif';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = 'bogus';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = 'inherit';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '10px {bogus}';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '10px initial';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '10px default';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '10px inherit';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '10px revert';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = 'var(--x)';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = 'var(--x, 10px serif)';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+		
+		ctx.font = '20px serif';
+		ctx.font = '1em serif; background: green; margin: 10px';
+		assert.strictEqual(ctx.font, '20px serif', "ctx.font", "'20px serif'")
+	});
+
+	it("2d.text.font.default", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.font, '10px sans-serif', "ctx.font", "'10px sans-serif'")
+	});
+
+	it("2d.text.font.relative_size", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var canvas2 = document.createElement('canvas');
+		var ctx2 = canvas2.getContext('2d');
+		ctx2.font = '1em sans-serif';
+		assert.strictEqual(ctx2.font, '10px sans-serif', "ctx2.font", "'10px sans-serif'")
+	});
+
+	it("2d.text.align.valid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.textAlign = 'start';
+		assert.strictEqual(ctx.textAlign, 'start', "ctx.textAlign", "'start'")
+		
+		ctx.textAlign = 'end';
+		assert.strictEqual(ctx.textAlign, 'end', "ctx.textAlign", "'end'")
+		
+		ctx.textAlign = 'left';
+		assert.strictEqual(ctx.textAlign, 'left', "ctx.textAlign", "'left'")
+		
+		ctx.textAlign = 'right';
+		assert.strictEqual(ctx.textAlign, 'right', "ctx.textAlign", "'right'")
+		
+		ctx.textAlign = 'center';
+		assert.strictEqual(ctx.textAlign, 'center', "ctx.textAlign", "'center'")
+	});
+
+	it("2d.text.align.invalid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.textAlign = 'start';
+		ctx.textAlign = 'bogus';
+		assert.strictEqual(ctx.textAlign, 'start', "ctx.textAlign", "'start'")
+		
+		ctx.textAlign = 'start';
+		ctx.textAlign = 'END';
+		assert.strictEqual(ctx.textAlign, 'start', "ctx.textAlign", "'start'")
+		
+		ctx.textAlign = 'start';
+		ctx.textAlign = 'end ';
+		assert.strictEqual(ctx.textAlign, 'start', "ctx.textAlign", "'start'")
+		
+		ctx.textAlign = 'start';
+		ctx.textAlign = 'end\0';
+		assert.strictEqual(ctx.textAlign, 'start', "ctx.textAlign", "'start'")
+	});
+
+	it("2d.text.align.default", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.textAlign, 'start', "ctx.textAlign", "'start'")
+	});
+
+	it("2d.text.baseline.valid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.textBaseline = 'top';
+		assert.strictEqual(ctx.textBaseline, 'top', "ctx.textBaseline", "'top'")
+		
+		ctx.textBaseline = 'hanging';
+		assert.strictEqual(ctx.textBaseline, 'hanging', "ctx.textBaseline", "'hanging'")
+		
+		ctx.textBaseline = 'middle';
+		assert.strictEqual(ctx.textBaseline, 'middle', "ctx.textBaseline", "'middle'")
+		
+		ctx.textBaseline = 'alphabetic';
+		assert.strictEqual(ctx.textBaseline, 'alphabetic', "ctx.textBaseline", "'alphabetic'")
+		
+		ctx.textBaseline = 'ideographic';
+		assert.strictEqual(ctx.textBaseline, 'ideographic', "ctx.textBaseline", "'ideographic'")
+		
+		ctx.textBaseline = 'bottom';
+		assert.strictEqual(ctx.textBaseline, 'bottom', "ctx.textBaseline", "'bottom'")
+	});
+
+	it("2d.text.baseline.invalid", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.textBaseline = 'top';
+		ctx.textBaseline = 'bogus';
+		assert.strictEqual(ctx.textBaseline, 'top', "ctx.textBaseline", "'top'")
+		
+		ctx.textBaseline = 'top';
+		ctx.textBaseline = 'MIDDLE';
+		assert.strictEqual(ctx.textBaseline, 'top', "ctx.textBaseline", "'top'")
+		
+		ctx.textBaseline = 'top';
+		ctx.textBaseline = 'middle ';
+		assert.strictEqual(ctx.textBaseline, 'top', "ctx.textBaseline", "'top'")
+		
+		ctx.textBaseline = 'top';
+		ctx.textBaseline = 'middle\0';
+		assert.strictEqual(ctx.textBaseline, 'top', "ctx.textBaseline", "'top'")
+	});
+
+	it("2d.text.baseline.default", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.textBaseline, 'alphabetic', "ctx.textBaseline", "'alphabetic'")
+	});
+
+	it("2d.text.draw.baseline.top", function () {
+		// textBaseline top is the top of the em square (not the bounding box)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textBaseline = 'top';
+		    ctx.fillText('CC', 0, 0);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.baseline.bottom", function () {
+		// textBaseline bottom is the bottom of the em square (not the bounding box)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textBaseline = 'bottom';
+		    ctx.fillText('CC', 0, 50);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.baseline.middle", function () {
+		// textBaseline middle is the middle of the em square (not the bounding box)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textBaseline = 'middle';
+		    ctx.fillText('CC', 0, 25);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.baseline.alphabetic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textBaseline = 'alphabetic';
+		    ctx.fillText('CC', 0, 37.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.baseline.ideographic", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textBaseline = 'ideographic';
+		    ctx.fillText('CC', 0, 31.25);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.baseline.hanging", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textBaseline = 'hanging';
+		    ctx.fillText('CC', 0, 12.5);
+		    _assertPixelApprox(canvas, 5,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,5, 0,255,0,255);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 5,45, 0,255,0,255);
+		    _assertPixelApprox(canvas, 95,45, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.space.collapse.space", function () {
+		// Space characters are converted to U+0020, and collapsed (per CSS)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('E  EE', -100, 37.5);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.space.collapse.other", function () {
+		// Space characters are converted to U+0020, and collapsed (per CSS)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText('E \x09\x0a\x0c\x0d  \x09\x0a\x0c\x0dEE', -100, 37.5);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.space.collapse.start", function () {
+		// Space characters at the start of a line are collapsed (per CSS)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.fillText(' EE', 0, 37.5);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.draw.space.collapse.end", function () {
+		// Space characters at the end of a line are collapsed (per CSS)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.font = '50px CanvasTest';
+		deferTest();
+		step_timeout(t.step_func_done(function () {
+		    ctx.fillStyle = '#f00';
+		    ctx.fillRect(0, 0, 100, 50);
+		    ctx.fillStyle = '#0f0';
+		    ctx.textAlign = 'right';
+		    ctx.fillText('EE ', 100, 37.5);
+		    _assertPixelApprox(canvas, 25,25, 0,255,0,255);
+		    _assertPixelApprox(canvas, 75,25, 0,255,0,255);
+		}), 500);
+	});
+
+	it("2d.text.measure.width.space", function () {
+		// Space characters are converted to U+0020 and collapsed (per CSS)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		deferTest();
+		var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+		document.fonts.add(f);
+		document.fonts.ready.then(() => {
+		    step_timeout(t.step_func_done(function () {
+		        ctx.font = '50px CanvasTest';
+		        assert.strictEqual(ctx.measureText('A B').width, 150, "ctx.measureText('A B').width", "150")
+		        assert.strictEqual(ctx.measureText('A  B').width, 200, "ctx.measureText('A  B').width", "200")
+		        assert.strictEqual(ctx.measureText('A \x09\x0a\x0c\x0d  \x09\x0a\x0c\x0dB').width, 150, "ctx.measureText('A \\x09\\x0a\\x0c\\x0d  \\x09\\x0a\\x0c\\x0dB').width", "150")
+		        assert(ctx.measureText('A \x0b B').width >= 200, "ctx.measureText('A \\x0b B').width >= 200");
+		
+		        assert.strictEqual(ctx.measureText(' AB').width, 100, "ctx.measureText(' AB').width", "100")
+		        assert.strictEqual(ctx.measureText('AB ').width, 100, "ctx.measureText('AB ').width", "100")
+		    }), 500);
+		});
+	});
+
+	it("2d.text.measure.rtl.text", function () {
+		// Measurement should follow canvas direction instead text direction
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		metrics = ctx.measureText('اَلْعَرَبِيَّةُ');
+		assert(metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight, "metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight");
+		
+		metrics = ctx.measureText('hello');
+		assert(metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight, "metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight");
+	});
+
+	it("2d.text.measure.boundingBox.textAlign", function () {
+		// Measurement should be related to textAlignment
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.textAlign = "right";
+		metrics = ctx.measureText('hello');
+		assert(metrics.actualBoundingBoxLeft > metrics.actualBoundingBoxRight, "metrics.actualBoundingBoxLeft > metrics.actualBoundingBoxRight");
+		
+		ctx.textAlign = "left"
+		metrics = ctx.measureText('hello');
+		assert(metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight, "metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight");
+	});
+
+	it("2d.text.measure.boundingBox.direction", function () {
+		// Measurement should follow text direction
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.direction = "ltr";
+		metrics = ctx.measureText('hello');
+		assert(metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight, "metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight");
+		
+		ctx.direction = "rtl";
+		metrics = ctx.measureText('hello');
+		assert(metrics.actualBoundingBoxLeft > metrics.actualBoundingBoxRight, "metrics.actualBoundingBoxLeft > metrics.actualBoundingBoxRight");
+	});
+});

--- a/test/wpt/generated/the-canvas-element.js
+++ b/test/wpt/generated/the-canvas-element.js
@@ -1,0 +1,273 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: the-canvas-element", function () {
+
+	it("2d.getcontext.exists", function () {
+		// The 2D context is implemented
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(canvas.getContext('2d'), null, "canvas.getContext('2d')", "null");
+	});
+
+	it("2d.getcontext.invalid.args", function () {
+		// Calling getContext with invalid arguments.
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(canvas.getContext(''), null, "canvas.getContext('')", "null")
+		assert.strictEqual(canvas.getContext('2d#'), null, "canvas.getContext('2d#')", "null")
+		assert.strictEqual(canvas.getContext('This is clearly not a valid context name.'), null, "canvas.getContext('This is clearly not a valid context name.')", "null")
+		assert.strictEqual(canvas.getContext('2d\0'), null, "canvas.getContext('2d\\0')", "null")
+		assert.strictEqual(canvas.getContext('2\uFF44'), null, "canvas.getContext('2\\uFF44')", "null")
+		assert.strictEqual(canvas.getContext('2D'), null, "canvas.getContext('2D')", "null")
+		assert.throws(function() { canvas.getContext(); }, TypeError);
+		assert.strictEqual(canvas.getContext('null'), null, "canvas.getContext('null')", "null")
+		assert.strictEqual(canvas.getContext('undefined'), null, "canvas.getContext('undefined')", "null")
+	});
+
+	it("2d.getcontext.extraargs.create", function () {
+		// The 2D context doesn't throw with extra getContext arguments (new context)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(document.createElement("canvas").getContext('2d', false, {}, [], 1, "2"), null, "document.createElement(\"canvas\").getContext('2d', false, {}, [], 1, \"2\")", "null");
+		assert.notStrictEqual(document.createElement("canvas").getContext('2d', 123), null, "document.createElement(\"canvas\").getContext('2d', 123)", "null");
+		assert.notStrictEqual(document.createElement("canvas").getContext('2d', "test"), null, "document.createElement(\"canvas\").getContext('2d', \"test\")", "null");
+		assert.notStrictEqual(document.createElement("canvas").getContext('2d', undefined), null, "document.createElement(\"canvas\").getContext('2d', undefined)", "null");
+		assert.notStrictEqual(document.createElement("canvas").getContext('2d', null), null, "document.createElement(\"canvas\").getContext('2d', null)", "null");
+		assert.notStrictEqual(document.createElement("canvas").getContext('2d', Symbol.hasInstance), null, "document.createElement(\"canvas\").getContext('2d', Symbol.hasInstance)", "null");
+	});
+
+	it("2d.getcontext.extraargs.cache", function () {
+		// The 2D context doesn't throw with extra getContext arguments (cached)
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.notStrictEqual(canvas.getContext('2d', false, {}, [], 1, "2"), null, "canvas.getContext('2d', false, {}, [], 1, \"2\")", "null");
+		assert.notStrictEqual(canvas.getContext('2d', 123), null, "canvas.getContext('2d', 123)", "null");
+		assert.notStrictEqual(canvas.getContext('2d', "test"), null, "canvas.getContext('2d', \"test\")", "null");
+		assert.notStrictEqual(canvas.getContext('2d', undefined), null, "canvas.getContext('2d', undefined)", "null");
+		assert.notStrictEqual(canvas.getContext('2d', null), null, "canvas.getContext('2d', null)", "null");
+		assert.notStrictEqual(canvas.getContext('2d', Symbol.hasInstance), null, "canvas.getContext('2d', Symbol.hasInstance)", "null");
+	});
+
+	it("2d.type.exists", function () {
+		// The 2D context interface is a property of 'window'
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert(window.CanvasRenderingContext2D, "window.CanvasRenderingContext2D");
+	});
+
+	it("2d.type.prototype", function () {
+		// window.CanvasRenderingContext2D.prototype are not [[Writable]] and not [[Configurable]], and its methods are [[Configurable]].
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert(window.CanvasRenderingContext2D.prototype, "window.CanvasRenderingContext2D.prototype");
+		assert(window.CanvasRenderingContext2D.prototype.fill, "window.CanvasRenderingContext2D.prototype.fill");
+		window.CanvasRenderingContext2D.prototype = null;
+		assert(window.CanvasRenderingContext2D.prototype, "window.CanvasRenderingContext2D.prototype");
+		delete window.CanvasRenderingContext2D.prototype;
+		assert(window.CanvasRenderingContext2D.prototype, "window.CanvasRenderingContext2D.prototype");
+		window.CanvasRenderingContext2D.prototype.fill = 1;
+		assert.strictEqual(window.CanvasRenderingContext2D.prototype.fill, 1, "window.CanvasRenderingContext2D.prototype.fill", "1")
+		delete window.CanvasRenderingContext2D.prototype.fill;
+		assert.strictEqual(window.CanvasRenderingContext2D.prototype.fill, undefined, "window.CanvasRenderingContext2D.prototype.fill", "undefined")
+	});
+
+	it("2d.type.replace", function () {
+		// Interface methods can be overridden
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var fillRect = window.CanvasRenderingContext2D.prototype.fillRect;
+		window.CanvasRenderingContext2D.prototype.fillRect = function (x, y, w, h)
+		{
+		    this.fillStyle = '#0f0';
+		    fillRect.call(this, x, y, w, h);
+		};
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.type.extend", function () {
+		// Interface methods can be added
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		window.CanvasRenderingContext2D.prototype.fillRectGreen = function (x, y, w, h)
+		{
+		    this.fillStyle = '#0f0';
+		    this.fillRect(x, y, w, h);
+		};
+		ctx.fillStyle = '#f00';
+		ctx.fillRectGreen(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.getcontext.unique", function () {
+		// getContext('2d') returns the same object
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(canvas.getContext('2d'), canvas.getContext('2d'), "canvas.getContext('2d')", "canvas.getContext('2d')")
+	});
+
+	it("2d.getcontext.shared", function () {
+		// getContext('2d') returns objects which share canvas state
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var ctx2 = canvas.getContext('2d');
+		ctx.fillStyle = '#f00';
+		ctx2.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.scaled", function () {
+		// CSS-scaled canvases get drawn correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#00f';
+		ctx.fillRect(0, 0, 50, 25);
+		ctx.fillStyle = '#0ff';
+		ctx.fillRect(0, 0, 25, 10);
+	});
+
+	it("2d.canvas.reference", function () {
+		// CanvasRenderingContext2D.canvas refers back to its canvas
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(ctx.canvas, canvas, "ctx.canvas", "canvas")
+	});
+
+	it("2d.canvas.readonly", function () {
+		// CanvasRenderingContext2D.canvas is readonly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var c = document.createElement('canvas');
+		var d = ctx.canvas;
+		assert.notStrictEqual(c, d, "c", "d");
+		ctx.canvas = c;
+		assert.strictEqual(ctx.canvas, d, "ctx.canvas", "d")
+	});
+
+	it("2d.canvas.context", function () {
+		// checks CanvasRenderingContext2D prototype
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		assert.strictEqual(Object.getPrototypeOf(CanvasRenderingContext2D.prototype), Object.prototype, "Object.getPrototypeOf(CanvasRenderingContext2D.prototype)", "Object.prototype")
+		assert.strictEqual(Object.getPrototypeOf(ctx), CanvasRenderingContext2D.prototype, "Object.getPrototypeOf(ctx)", "CanvasRenderingContext2D.prototype")
+		t.done();
+	});
+});

--- a/test/wpt/generated/the-canvas-state.js
+++ b/test/wpt/generated/the-canvas-state.js
@@ -1,0 +1,206 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: the-canvas-state", function () {
+
+	it("2d.state.saverestore.transformation", function () {
+		// save()/restore() affects the current transformation matrix
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.save();
+		ctx.translate(200, 0);
+		ctx.restore();
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(-200, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.state.saverestore.clip", function () {
+		// save()/restore() affects the clipping path
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.save();
+		ctx.rect(0, 0, 1, 1);
+		ctx.clip();
+		ctx.restore();
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.state.saverestore.path", function () {
+		// save()/restore() does not affect the current path
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.save();
+		ctx.rect(0, 0, 100, 50);
+		ctx.restore();
+		ctx.fillStyle = '#0f0';
+		ctx.fill();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.state.saverestore.bitmap", function () {
+		// save()/restore() does not affect the current bitmap
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.save();
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.restore();
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.state.saverestore.stack", function () {
+		// save()/restore() can be nested as a stack
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.lineWidth = 1;
+		ctx.save();
+		ctx.lineWidth = 2;
+		ctx.save();
+		ctx.lineWidth = 3;
+		assert.strictEqual(ctx.lineWidth, 3, "ctx.lineWidth", "3")
+		ctx.restore();
+		assert.strictEqual(ctx.lineWidth, 2, "ctx.lineWidth", "2")
+		ctx.restore();
+		assert.strictEqual(ctx.lineWidth, 1, "ctx.lineWidth", "1")
+	});
+
+	it("2d.state.saverestore.stackdepth", function () {
+		// save()/restore() stack depth is not unreasonably limited
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		var limit = 512;
+		for (var i = 1; i < limit; ++i)
+		{
+		    ctx.save();
+		    ctx.lineWidth = i;
+		}
+		for (var i = limit-1; i > 0; --i)
+		{
+		    assert.strictEqual(ctx.lineWidth, i, "ctx.lineWidth", "i")
+		    ctx.restore();
+		}
+	});
+
+	it("2d.state.saverestore.underflow", function () {
+		// restore() with an empty stack has no effect
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		for (var i = 0; i < 16; ++i)
+		    ctx.restore();
+		ctx.lineWidth = 0.5;
+		ctx.restore();
+		assert.strictEqual(ctx.lineWidth, 0.5, "ctx.lineWidth", "0.5")
+	});
+});

--- a/test/wpt/generated/transformations.js
+++ b/test/wpt/generated/transformations.js
@@ -1,0 +1,675 @@
+// THIS FILE WAS AUTO-GENERATED. DO NOT EDIT BY HAND.
+
+const assert = require('assert');
+const path = require('path');
+
+const {
+	createCanvas,
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	CanvasPattern,
+	CanvasGradient
+} = require('../../..');
+
+const window = {
+	CanvasRenderingContext2D,
+	ImageData,
+	Image,
+	DOMMatrix,
+	DOMPoint,
+	Uint8ClampedArray,
+	CanvasPattern,
+	CanvasGradient
+};
+
+const document = {
+	createElement(type, ...args) {
+		if (type !== "canvas")
+			throw new Error(`createElement(${type}) not supported`);
+		return createCanvas(...args);
+	}
+};
+
+function _getPixel(canvas, x, y) {
+	const ctx = canvas.getContext('2d');
+	const imgdata = ctx.getImageData(x, y, 1, 1);
+	return [ imgdata.data[0], imgdata.data[1], imgdata.data[2], imgdata.data[3] ];
+}
+
+function _assertApprox(actual, expected, epsilon=0, msg="") {
+	assert(typeof actual === "number", "actual should be a number but got a ${typeof type_actual}");
+
+	// The epsilon math below does not place nice with NaN and Infinity
+	// But in this case Infinity = Infinity and NaN = NaN
+	if (isFinite(actual) || isFinite(expected)) {
+		assert(Math.abs(actual - expected) <= epsilon,
+			`expected ${actual} to equal ${expected} +/- ${epsilon}. ${msg}`);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}
+
+function _assertPixel(canvas, x, y, r, g, b, a, pos, color) {
+	const c = _getPixel(canvas, x,y);
+	assert.strictEqual(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	assert.strictEqual(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelApprox(canvas, x, y, r, g, b, a, pos, color, tolerance) {
+	const c = _getPixel(canvas, x,y);
+	_assertApprox(c[0], r, tolerance, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+	_assertApprox(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function assert_throws_js(Type, fn) {
+	assert.throws(fn, Type);
+}
+
+// Used by font tests to allow fonts to load.
+function deferTest() {}
+
+class Test {
+	// Two cases of this in the tests, look unnecessary.
+	done() {}
+	// Used by font tests to allow fonts to load.
+	step_func_done(func) { func(); }
+	// Used for image onload callback.
+	step_func(func) { func(); }
+}
+
+function step_timeout(result, time) {
+	// Nothing; code needs to be converted for this to work.
+}
+
+describe("WPT: transformations", function () {
+
+	it("2d.transformation.order", function () {
+		// Transformations are applied in the right order
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.scale(2, 1);
+		ctx.rotate(Math.PI / 2);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, -50, 50, 50);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.scale.basic", function () {
+		// scale() works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.scale(2, 4);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 12.5);
+		_assertPixel(canvas, 90,40, 0,255,0,255);
+	});
+
+	it("2d.transformation.scale.zero", function () {
+		// scale() with a scale factor of zero works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.save();
+		ctx.translate(50, 0);
+		ctx.scale(0, 1);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.restore();
+		
+		ctx.save();
+		ctx.translate(0, 25);
+		ctx.scale(1, 0);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.restore();
+		
+		canvas.toDataURL();
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.scale.negative", function () {
+		// scale() with negative scale factors works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.save();
+		ctx.scale(-1, 1);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-50, 0, 50, 50);
+		ctx.restore();
+		
+		ctx.save();
+		ctx.scale(1, -1);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(50, -50, 50, 50);
+		ctx.restore();
+		_assertPixel(canvas, 25,25, 0,255,0,255);
+		_assertPixel(canvas, 75,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.scale.large", function () {
+		// scale() with large scale factors works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.scale(1e5, 1e5);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 1, 1);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.scale.nonfinite", function () {
+		// scale() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(100, 10);
+		ctx.scale(Infinity, 0.1);
+		ctx.scale(-Infinity, 0.1);
+		ctx.scale(NaN, 0.1);
+		ctx.scale(0.1, Infinity);
+		ctx.scale(0.1, -Infinity);
+		ctx.scale(0.1, NaN);
+		ctx.scale(Infinity, Infinity);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -10, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.scale.multiple", function () {
+		// Multiple scale()s combine
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.scale(Math.sqrt(2), Math.sqrt(2));
+		ctx.scale(Math.sqrt(2), Math.sqrt(2));
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 25);
+		_assertPixel(canvas, 90,40, 0,255,0,255);
+	});
+
+	it("2d.transformation.rotate.zero", function () {
+		// rotate() by 0 does nothing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.rotate(0);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.rotate.radians", function () {
+		// rotate() uses radians
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.rotate(Math.PI); // should fail obviously if this is 3.1 degrees
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -50, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.rotate.direction", function () {
+		// rotate() is clockwise
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.rotate(Math.PI / 2);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, -100, 50, 100);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.rotate.wrap", function () {
+		// rotate() wraps large positive values correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.rotate(Math.PI * (1 + 4096)); // == pi (mod 2*pi)
+		// We need about pi +/- 0.001 in order to get correct-looking results
+		// 32-bit floats can store pi*4097 with precision 2^-10, so that should
+		// be safe enough on reasonable implementations
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -50, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,2, 0,255,0,255);
+		_assertPixel(canvas, 98,47, 0,255,0,255);
+	});
+
+	it("2d.transformation.rotate.wrapnegative", function () {
+		// rotate() wraps large negative values correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.rotate(-Math.PI * (1 + 4096));
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -50, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+		_assertPixel(canvas, 98,2, 0,255,0,255);
+		_assertPixel(canvas, 98,47, 0,255,0,255);
+	});
+
+	it("2d.transformation.rotate.nonfinite", function () {
+		// rotate() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(100, 10);
+		ctx.rotate(Infinity);
+		ctx.rotate(-Infinity);
+		ctx.rotate(NaN);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -10, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.translate.basic", function () {
+		// translate() works
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(100, 50);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -50, 100, 50);
+		_assertPixel(canvas, 90,40, 0,255,0,255);
+	});
+
+	it("2d.transformation.translate.nonfinite", function () {
+		// translate() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(100, 10);
+		ctx.translate(Infinity, 0.1);
+		ctx.translate(-Infinity, 0.1);
+		ctx.translate(NaN, 0.1);
+		ctx.translate(0.1, Infinity);
+		ctx.translate(0.1, -Infinity);
+		ctx.translate(0.1, NaN);
+		ctx.translate(Infinity, Infinity);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -10, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.transform.identity", function () {
+		// transform() with the identity matrix does nothing
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.transform(1,0, 0,1, 0,0);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.transform.skewed", function () {
+		// transform() with skewy matrix transforms correctly
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		// Create green with a red square ring inside it
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(20, 10, 60, 30);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(40, 20, 20, 10);
+		
+		// Draw a skewed shape to fill that gap, to make sure it is aligned correctly
+		ctx.transform(1,4, 2,3, 5,6);
+		// Post-transform coordinates:
+		//   [[20,10],[80,10],[80,40],[20,40],[20,10],[40,20],[40,30],[60,30],[60,20],[40,20],[20,10]];
+		// Hence pre-transform coordinates:
+		var pts=[[-7.4,11.2],[-43.4,59.2],[-31.4,53.2],[4.6,5.2],[-7.4,11.2],
+		         [-15.4,25.2],[-11.4,23.2],[-23.4,39.2],[-27.4,41.2],[-15.4,25.2],
+		         [-7.4,11.2]];
+		ctx.beginPath();
+		ctx.moveTo(pts[0][0], pts[0][1]);
+		for (var i = 0; i < pts.length; ++i)
+		    ctx.lineTo(pts[i][0], pts[i][1]);
+		ctx.fill();
+		_assertPixel(canvas, 21,11, 0,255,0,255);
+		_assertPixel(canvas, 79,11, 0,255,0,255);
+		_assertPixel(canvas, 21,39, 0,255,0,255);
+		_assertPixel(canvas, 79,39, 0,255,0,255);
+		_assertPixel(canvas, 39,19, 0,255,0,255);
+		_assertPixel(canvas, 61,19, 0,255,0,255);
+		_assertPixel(canvas, 39,31, 0,255,0,255);
+		_assertPixel(canvas, 61,31, 0,255,0,255);
+	});
+
+	it("2d.transformation.transform.multiply", function () {
+		// transform() multiplies the CTM
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.transform(1,2, 3,4, 5,6);
+		ctx.transform(-2,1, 3/2,-1/2, 1,-2);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.transform.nonfinite", function () {
+		// transform() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(100, 10);
+		ctx.transform(Infinity, 0, 0, 0, 0, 0);
+		ctx.transform(-Infinity, 0, 0, 0, 0, 0);
+		ctx.transform(NaN, 0, 0, 0, 0, 0);
+		ctx.transform(0, Infinity, 0, 0, 0, 0);
+		ctx.transform(0, -Infinity, 0, 0, 0, 0);
+		ctx.transform(0, NaN, 0, 0, 0, 0);
+		ctx.transform(0, 0, Infinity, 0, 0, 0);
+		ctx.transform(0, 0, -Infinity, 0, 0, 0);
+		ctx.transform(0, 0, NaN, 0, 0, 0);
+		ctx.transform(0, 0, 0, Infinity, 0, 0);
+		ctx.transform(0, 0, 0, -Infinity, 0, 0);
+		ctx.transform(0, 0, 0, NaN, 0, 0);
+		ctx.transform(0, 0, 0, 0, Infinity, 0);
+		ctx.transform(0, 0, 0, 0, -Infinity, 0);
+		ctx.transform(0, 0, 0, 0, NaN, 0);
+		ctx.transform(0, 0, 0, 0, 0, Infinity);
+		ctx.transform(0, 0, 0, 0, 0, -Infinity);
+		ctx.transform(0, 0, 0, 0, 0, NaN);
+		ctx.transform(Infinity, Infinity, 0, 0, 0, 0);
+		ctx.transform(Infinity, Infinity, Infinity, 0, 0, 0);
+		ctx.transform(Infinity, Infinity, Infinity, Infinity, 0, 0);
+		ctx.transform(Infinity, Infinity, Infinity, Infinity, Infinity, 0);
+		ctx.transform(Infinity, Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.transform(Infinity, Infinity, Infinity, Infinity, 0, Infinity);
+		ctx.transform(Infinity, Infinity, Infinity, 0, Infinity, 0);
+		ctx.transform(Infinity, Infinity, Infinity, 0, Infinity, Infinity);
+		ctx.transform(Infinity, Infinity, Infinity, 0, 0, Infinity);
+		ctx.transform(Infinity, Infinity, 0, Infinity, 0, 0);
+		ctx.transform(Infinity, Infinity, 0, Infinity, Infinity, 0);
+		ctx.transform(Infinity, Infinity, 0, Infinity, Infinity, Infinity);
+		ctx.transform(Infinity, Infinity, 0, Infinity, 0, Infinity);
+		ctx.transform(Infinity, Infinity, 0, 0, Infinity, 0);
+		ctx.transform(Infinity, Infinity, 0, 0, Infinity, Infinity);
+		ctx.transform(Infinity, Infinity, 0, 0, 0, Infinity);
+		ctx.transform(Infinity, 0, Infinity, 0, 0, 0);
+		ctx.transform(Infinity, 0, Infinity, Infinity, 0, 0);
+		ctx.transform(Infinity, 0, Infinity, Infinity, Infinity, 0);
+		ctx.transform(Infinity, 0, Infinity, Infinity, Infinity, Infinity);
+		ctx.transform(Infinity, 0, Infinity, Infinity, 0, Infinity);
+		ctx.transform(Infinity, 0, Infinity, 0, Infinity, 0);
+		ctx.transform(Infinity, 0, Infinity, 0, Infinity, Infinity);
+		ctx.transform(Infinity, 0, Infinity, 0, 0, Infinity);
+		ctx.transform(Infinity, 0, 0, Infinity, 0, 0);
+		ctx.transform(Infinity, 0, 0, Infinity, Infinity, 0);
+		ctx.transform(Infinity, 0, 0, Infinity, Infinity, Infinity);
+		ctx.transform(Infinity, 0, 0, Infinity, 0, Infinity);
+		ctx.transform(Infinity, 0, 0, 0, Infinity, 0);
+		ctx.transform(Infinity, 0, 0, 0, Infinity, Infinity);
+		ctx.transform(Infinity, 0, 0, 0, 0, Infinity);
+		ctx.transform(0, Infinity, Infinity, 0, 0, 0);
+		ctx.transform(0, Infinity, Infinity, Infinity, 0, 0);
+		ctx.transform(0, Infinity, Infinity, Infinity, Infinity, 0);
+		ctx.transform(0, Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.transform(0, Infinity, Infinity, Infinity, 0, Infinity);
+		ctx.transform(0, Infinity, Infinity, 0, Infinity, 0);
+		ctx.transform(0, Infinity, Infinity, 0, Infinity, Infinity);
+		ctx.transform(0, Infinity, Infinity, 0, 0, Infinity);
+		ctx.transform(0, Infinity, 0, Infinity, 0, 0);
+		ctx.transform(0, Infinity, 0, Infinity, Infinity, 0);
+		ctx.transform(0, Infinity, 0, Infinity, Infinity, Infinity);
+		ctx.transform(0, Infinity, 0, Infinity, 0, Infinity);
+		ctx.transform(0, Infinity, 0, 0, Infinity, 0);
+		ctx.transform(0, Infinity, 0, 0, Infinity, Infinity);
+		ctx.transform(0, Infinity, 0, 0, 0, Infinity);
+		ctx.transform(0, 0, Infinity, Infinity, 0, 0);
+		ctx.transform(0, 0, Infinity, Infinity, Infinity, 0);
+		ctx.transform(0, 0, Infinity, Infinity, Infinity, Infinity);
+		ctx.transform(0, 0, Infinity, Infinity, 0, Infinity);
+		ctx.transform(0, 0, Infinity, 0, Infinity, 0);
+		ctx.transform(0, 0, Infinity, 0, Infinity, Infinity);
+		ctx.transform(0, 0, Infinity, 0, 0, Infinity);
+		ctx.transform(0, 0, 0, Infinity, Infinity, 0);
+		ctx.transform(0, 0, 0, Infinity, Infinity, Infinity);
+		ctx.transform(0, 0, 0, Infinity, 0, Infinity);
+		ctx.transform(0, 0, 0, 0, Infinity, Infinity);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -10, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+
+	it("2d.transformation.setTransform.skewed", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		// Create green with a red square ring inside it
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 100, 50);
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(20, 10, 60, 30);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(40, 20, 20, 10);
+		
+		// Draw a skewed shape to fill that gap, to make sure it is aligned correctly
+		ctx.setTransform(1,4, 2,3, 5,6);
+		// Post-transform coordinates:
+		//   [[20,10],[80,10],[80,40],[20,40],[20,10],[40,20],[40,30],[60,30],[60,20],[40,20],[20,10]];
+		// Hence pre-transform coordinates:
+		var pts=[[-7.4,11.2],[-43.4,59.2],[-31.4,53.2],[4.6,5.2],[-7.4,11.2],
+		         [-15.4,25.2],[-11.4,23.2],[-23.4,39.2],[-27.4,41.2],[-15.4,25.2],
+		         [-7.4,11.2]];
+		ctx.beginPath();
+		ctx.moveTo(pts[0][0], pts[0][1]);
+		for (var i = 0; i < pts.length; ++i)
+		    ctx.lineTo(pts[i][0], pts[i][1]);
+		ctx.fill();
+		_assertPixel(canvas, 21,11, 0,255,0,255);
+		_assertPixel(canvas, 79,11, 0,255,0,255);
+		_assertPixel(canvas, 21,39, 0,255,0,255);
+		_assertPixel(canvas, 79,39, 0,255,0,255);
+		_assertPixel(canvas, 39,19, 0,255,0,255);
+		_assertPixel(canvas, 61,19, 0,255,0,255);
+		_assertPixel(canvas, 39,31, 0,255,0,255);
+		_assertPixel(canvas, 61,31, 0,255,0,255);
+	});
+
+	it("2d.transformation.setTransform.multiple", function () {
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.setTransform(1/2,0, 0,1/2, 0,0);
+		ctx.setTransform();
+		ctx.setTransform(2,0, 0,2, 0,0);
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(0, 0, 50, 25);
+		_assertPixel(canvas, 75,35, 0,255,0,255);
+	});
+
+	it("2d.transformation.setTransform.nonfinite", function () {
+		// setTransform() with Infinity/NaN is ignored
+		const canvas = createCanvas(100, 50);
+		const ctx = canvas.getContext("2d");
+		const t = new Test();
+
+		ctx.fillStyle = '#f00';
+		ctx.fillRect(0, 0, 100, 50);
+		
+		ctx.translate(100, 10);
+		ctx.setTransform(Infinity, 0, 0, 0, 0, 0);
+		ctx.setTransform(-Infinity, 0, 0, 0, 0, 0);
+		ctx.setTransform(NaN, 0, 0, 0, 0, 0);
+		ctx.setTransform(0, Infinity, 0, 0, 0, 0);
+		ctx.setTransform(0, -Infinity, 0, 0, 0, 0);
+		ctx.setTransform(0, NaN, 0, 0, 0, 0);
+		ctx.setTransform(0, 0, Infinity, 0, 0, 0);
+		ctx.setTransform(0, 0, -Infinity, 0, 0, 0);
+		ctx.setTransform(0, 0, NaN, 0, 0, 0);
+		ctx.setTransform(0, 0, 0, Infinity, 0, 0);
+		ctx.setTransform(0, 0, 0, -Infinity, 0, 0);
+		ctx.setTransform(0, 0, 0, NaN, 0, 0);
+		ctx.setTransform(0, 0, 0, 0, Infinity, 0);
+		ctx.setTransform(0, 0, 0, 0, -Infinity, 0);
+		ctx.setTransform(0, 0, 0, 0, NaN, 0);
+		ctx.setTransform(0, 0, 0, 0, 0, Infinity);
+		ctx.setTransform(0, 0, 0, 0, 0, -Infinity);
+		ctx.setTransform(0, 0, 0, 0, 0, NaN);
+		ctx.setTransform(Infinity, Infinity, 0, 0, 0, 0);
+		ctx.setTransform(Infinity, Infinity, Infinity, 0, 0, 0);
+		ctx.setTransform(Infinity, Infinity, Infinity, Infinity, 0, 0);
+		ctx.setTransform(Infinity, Infinity, Infinity, Infinity, Infinity, 0);
+		ctx.setTransform(Infinity, Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.setTransform(Infinity, Infinity, Infinity, Infinity, 0, Infinity);
+		ctx.setTransform(Infinity, Infinity, Infinity, 0, Infinity, 0);
+		ctx.setTransform(Infinity, Infinity, Infinity, 0, Infinity, Infinity);
+		ctx.setTransform(Infinity, Infinity, Infinity, 0, 0, Infinity);
+		ctx.setTransform(Infinity, Infinity, 0, Infinity, 0, 0);
+		ctx.setTransform(Infinity, Infinity, 0, Infinity, Infinity, 0);
+		ctx.setTransform(Infinity, Infinity, 0, Infinity, Infinity, Infinity);
+		ctx.setTransform(Infinity, Infinity, 0, Infinity, 0, Infinity);
+		ctx.setTransform(Infinity, Infinity, 0, 0, Infinity, 0);
+		ctx.setTransform(Infinity, Infinity, 0, 0, Infinity, Infinity);
+		ctx.setTransform(Infinity, Infinity, 0, 0, 0, Infinity);
+		ctx.setTransform(Infinity, 0, Infinity, 0, 0, 0);
+		ctx.setTransform(Infinity, 0, Infinity, Infinity, 0, 0);
+		ctx.setTransform(Infinity, 0, Infinity, Infinity, Infinity, 0);
+		ctx.setTransform(Infinity, 0, Infinity, Infinity, Infinity, Infinity);
+		ctx.setTransform(Infinity, 0, Infinity, Infinity, 0, Infinity);
+		ctx.setTransform(Infinity, 0, Infinity, 0, Infinity, 0);
+		ctx.setTransform(Infinity, 0, Infinity, 0, Infinity, Infinity);
+		ctx.setTransform(Infinity, 0, Infinity, 0, 0, Infinity);
+		ctx.setTransform(Infinity, 0, 0, Infinity, 0, 0);
+		ctx.setTransform(Infinity, 0, 0, Infinity, Infinity, 0);
+		ctx.setTransform(Infinity, 0, 0, Infinity, Infinity, Infinity);
+		ctx.setTransform(Infinity, 0, 0, Infinity, 0, Infinity);
+		ctx.setTransform(Infinity, 0, 0, 0, Infinity, 0);
+		ctx.setTransform(Infinity, 0, 0, 0, Infinity, Infinity);
+		ctx.setTransform(Infinity, 0, 0, 0, 0, Infinity);
+		ctx.setTransform(0, Infinity, Infinity, 0, 0, 0);
+		ctx.setTransform(0, Infinity, Infinity, Infinity, 0, 0);
+		ctx.setTransform(0, Infinity, Infinity, Infinity, Infinity, 0);
+		ctx.setTransform(0, Infinity, Infinity, Infinity, Infinity, Infinity);
+		ctx.setTransform(0, Infinity, Infinity, Infinity, 0, Infinity);
+		ctx.setTransform(0, Infinity, Infinity, 0, Infinity, 0);
+		ctx.setTransform(0, Infinity, Infinity, 0, Infinity, Infinity);
+		ctx.setTransform(0, Infinity, Infinity, 0, 0, Infinity);
+		ctx.setTransform(0, Infinity, 0, Infinity, 0, 0);
+		ctx.setTransform(0, Infinity, 0, Infinity, Infinity, 0);
+		ctx.setTransform(0, Infinity, 0, Infinity, Infinity, Infinity);
+		ctx.setTransform(0, Infinity, 0, Infinity, 0, Infinity);
+		ctx.setTransform(0, Infinity, 0, 0, Infinity, 0);
+		ctx.setTransform(0, Infinity, 0, 0, Infinity, Infinity);
+		ctx.setTransform(0, Infinity, 0, 0, 0, Infinity);
+		ctx.setTransform(0, 0, Infinity, Infinity, 0, 0);
+		ctx.setTransform(0, 0, Infinity, Infinity, Infinity, 0);
+		ctx.setTransform(0, 0, Infinity, Infinity, Infinity, Infinity);
+		ctx.setTransform(0, 0, Infinity, Infinity, 0, Infinity);
+		ctx.setTransform(0, 0, Infinity, 0, Infinity, 0);
+		ctx.setTransform(0, 0, Infinity, 0, Infinity, Infinity);
+		ctx.setTransform(0, 0, Infinity, 0, 0, Infinity);
+		ctx.setTransform(0, 0, 0, Infinity, Infinity, 0);
+		ctx.setTransform(0, 0, 0, Infinity, Infinity, Infinity);
+		ctx.setTransform(0, 0, 0, Infinity, 0, Infinity);
+		ctx.setTransform(0, 0, 0, 0, Infinity, Infinity);
+		
+		ctx.fillStyle = '#0f0';
+		ctx.fillRect(-100, -10, 100, 50);
+		
+		_assertPixel(canvas, 50,25, 0,255,0,255);
+	});
+});

--- a/test/wpt/line-styles.yaml
+++ b/test/wpt/line-styles.yaml
@@ -1,0 +1,1017 @@
+- name: 2d.line.defaults
+  testing:
+  - 2d.lineWidth.default
+  - 2d.lineCap.default
+  - 2d.lineJoin.default
+  - 2d.miterLimit.default
+  code: |
+    @assert ctx.lineWidth === 1;
+    @assert ctx.lineCap === 'butt';
+    @assert ctx.lineJoin === 'miter';
+    @assert ctx.miterLimit === 10;
+
+- name: 2d.line.width.basic
+  desc: lineWidth determines the width of line strokes
+  testing:
+  - 2d.lineWidth
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 20;
+    // Draw a green line over a red box, to check the line is not too small
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.fillRect(15, 15, 20, 20);
+    ctx.beginPath();
+    ctx.moveTo(25, 15);
+    ctx.lineTo(25, 35);
+    ctx.stroke();
+
+    // Draw a green box over a red line, to check the line is not too large
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(75, 15);
+    ctx.lineTo(75, 35);
+    ctx.stroke();
+    ctx.fillRect(65, 15, 20, 20);
+
+    @assert pixel 14,25 == 0,255,0,255;
+    @assert pixel 15,25 == 0,255,0,255;
+    @assert pixel 16,25 == 0,255,0,255;
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 34,25 == 0,255,0,255;
+    @assert pixel 35,25 == 0,255,0,255;
+    @assert pixel 36,25 == 0,255,0,255;
+
+    @assert pixel 64,25 == 0,255,0,255;
+    @assert pixel 65,25 == 0,255,0,255;
+    @assert pixel 66,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+    @assert pixel 84,25 == 0,255,0,255;
+    @assert pixel 85,25 == 0,255,0,255;
+    @assert pixel 86,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.width.transformed
+  desc: Line stroke widths are affected by scale transformations
+  testing:
+  - 2d.lineWidth
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 4;
+    // Draw a green line over a red box, to check the line is not too small
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.fillRect(15, 15, 20, 20);
+    ctx.save();
+     ctx.scale(5, 1);
+     ctx.beginPath();
+     ctx.moveTo(5, 15);
+     ctx.lineTo(5, 35);
+     ctx.stroke();
+    ctx.restore();
+
+    // Draw a green box over a red line, to check the line is not too large
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.save();
+     ctx.scale(-5, 1);
+     ctx.beginPath();
+     ctx.moveTo(-15, 15);
+     ctx.lineTo(-15, 35);
+     ctx.stroke();
+    ctx.restore();
+    ctx.fillRect(65, 15, 20, 20);
+
+    @assert pixel 14,25 == 0,255,0,255;
+    @assert pixel 15,25 == 0,255,0,255;
+    @assert pixel 16,25 == 0,255,0,255;
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 34,25 == 0,255,0,255;
+    @assert pixel 35,25 == 0,255,0,255;
+    @assert pixel 36,25 == 0,255,0,255;
+
+    @assert pixel 64,25 == 0,255,0,255;
+    @assert pixel 65,25 == 0,255,0,255;
+    @assert pixel 66,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+    @assert pixel 84,25 == 0,255,0,255;
+    @assert pixel 85,25 == 0,255,0,255;
+    @assert pixel 86,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.width.scaledefault
+  desc: Default lineWidth strokes are affected by scale transformations
+  testing:
+  - 2d.lineWidth
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.scale(50, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.moveTo(0, 0.5);
+    ctx.lineTo(2, 0.5);
+    ctx.stroke();
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+    @assert pixel 50,5 == 0,255,0,255;
+    @assert pixel 50,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.width.valid
+  desc: Setting lineWidth to valid values works
+  testing:
+  - 2d.lineWidth.set
+  - 2d.lineWidth.get
+  code: |
+    ctx.lineWidth = 1.5;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = "1e1";
+    @assert ctx.lineWidth === 10;
+
+    ctx.lineWidth = 1/1024;
+    @assert ctx.lineWidth === 1/1024;
+
+    ctx.lineWidth = 1000;
+    @assert ctx.lineWidth === 1000;
+
+- name: 2d.line.width.invalid
+  desc: Setting lineWidth to invalid values is ignored
+  testing:
+  - 2d.lineWidth.invalid
+  code: |
+    ctx.lineWidth = 1.5;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = 0;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = -1;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = Infinity;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = -Infinity;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = NaN;
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = 'string';
+    @assert ctx.lineWidth === 1.5;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = true;
+    @assert ctx.lineWidth === 1;
+
+    ctx.lineWidth = 1.5;
+    ctx.lineWidth = false;
+    @assert ctx.lineWidth === 1.5;
+
+- name: 2d.line.cap.butt
+  desc: lineCap 'butt' is rendered correctly
+  testing:
+  - 2d.lineCap.butt
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineCap = 'butt';
+    ctx.lineWidth = 20;
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.fillRect(15, 15, 20, 20);
+    ctx.beginPath();
+    ctx.moveTo(25, 15);
+    ctx.lineTo(25, 35);
+    ctx.stroke();
+
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(75, 15);
+    ctx.lineTo(75, 35);
+    ctx.stroke();
+    ctx.fillRect(65, 15, 20, 20);
+
+    @assert pixel 25,14 == 0,255,0,255;
+    @assert pixel 25,15 == 0,255,0,255;
+    @assert pixel 25,16 == 0,255,0,255;
+    @assert pixel 25,34 == 0,255,0,255;
+    @assert pixel 25,35 == 0,255,0,255;
+    @assert pixel 25,36 == 0,255,0,255;
+
+    @assert pixel 75,14 == 0,255,0,255;
+    @assert pixel 75,15 == 0,255,0,255;
+    @assert pixel 75,16 == 0,255,0,255;
+    @assert pixel 75,34 == 0,255,0,255;
+    @assert pixel 75,35 == 0,255,0,255;
+    @assert pixel 75,36 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.cap.round
+  desc: lineCap 'round' is rendered correctly
+  testing:
+  - 2d.lineCap.round
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var tol = 1; // tolerance to avoid antialiasing artifacts
+
+    ctx.lineCap = 'round';
+    ctx.lineWidth = 20;
+
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+
+    ctx.beginPath();
+    ctx.moveTo(35-tol, 15);
+    ctx.arc(25, 15, 10-tol, 0, Math.PI, true);
+    ctx.arc(25, 35, 10-tol, Math.PI, 0, true);
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.moveTo(25, 15);
+    ctx.lineTo(25, 35);
+    ctx.stroke();
+
+
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+
+    ctx.beginPath();
+    ctx.moveTo(75, 15);
+    ctx.lineTo(75, 35);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(85+tol, 15);
+    ctx.arc(75, 15, 10+tol, 0, Math.PI, true);
+    ctx.arc(75, 35, 10+tol, Math.PI, 0, true);
+    ctx.fill();
+
+    @assert pixel 17,6 == 0,255,0,255;
+    @assert pixel 25,6 == 0,255,0,255;
+    @assert pixel 32,6 == 0,255,0,255;
+    @assert pixel 17,43 == 0,255,0,255;
+    @assert pixel 25,43 == 0,255,0,255;
+    @assert pixel 32,43 == 0,255,0,255;
+
+    @assert pixel 67,6 == 0,255,0,255;
+    @assert pixel 75,6 == 0,255,0,255;
+    @assert pixel 82,6 == 0,255,0,255;
+    @assert pixel 67,43 == 0,255,0,255;
+    @assert pixel 75,43 == 0,255,0,255;
+    @assert pixel 82,43 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.cap.square
+  desc: lineCap 'square' is rendered correctly
+  testing:
+  - 2d.lineCap.square
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineCap = 'square';
+    ctx.lineWidth = 20;
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.fillRect(15, 5, 20, 40);
+    ctx.beginPath();
+    ctx.moveTo(25, 15);
+    ctx.lineTo(25, 35);
+    ctx.stroke();
+
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(75, 15);
+    ctx.lineTo(75, 35);
+    ctx.stroke();
+    ctx.fillRect(65, 5, 20, 40);
+
+    @assert pixel 25,4 == 0,255,0,255;
+    @assert pixel 25,5 == 0,255,0,255;
+    @assert pixel 25,6 == 0,255,0,255;
+    @assert pixel 25,44 == 0,255,0,255;
+    @assert pixel 25,45 == 0,255,0,255;
+    @assert pixel 25,46 == 0,255,0,255;
+
+    @assert pixel 75,4 == 0,255,0,255;
+    @assert pixel 75,5 == 0,255,0,255;
+    @assert pixel 75,6 == 0,255,0,255;
+    @assert pixel 75,44 == 0,255,0,255;
+    @assert pixel 75,45 == 0,255,0,255;
+    @assert pixel 75,46 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.cap.open
+  desc: Line caps are drawn at the corners of an unclosed rectangle
+  testing:
+  - 2d.lineCap.end
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineCap = 'square';
+    ctx.lineWidth = 400;
+
+    ctx.beginPath();
+    ctx.moveTo(200, 200);
+    ctx.lineTo(200, 1000);
+    ctx.lineTo(1000, 1000);
+    ctx.lineTo(1000, 200);
+    ctx.lineTo(200, 200);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.cap.closed
+  desc: Line caps are not drawn at the corners of an unclosed rectangle
+  testing:
+  - 2d.lineCap.end
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineCap = 'square';
+    ctx.lineWidth = 400;
+
+    ctx.beginPath();
+    ctx.moveTo(200, 200);
+    ctx.lineTo(200, 1000);
+    ctx.lineTo(1000, 1000);
+    ctx.lineTo(1000, 200);
+    ctx.closePath();
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.cap.valid
+  desc: Setting lineCap to valid values works
+  testing:
+  - 2d.lineCap.set
+  - 2d.lineCap.get
+  code: |
+    ctx.lineCap = 'butt'
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'round';
+    @assert ctx.lineCap === 'round';
+
+    ctx.lineCap = 'square';
+    @assert ctx.lineCap === 'square';
+
+- name: 2d.line.cap.invalid
+  desc: Setting lineCap to invalid values is ignored
+  testing:
+  - 2d.lineCap.invalid
+  code: |
+    ctx.lineCap = 'butt'
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'butt';
+    ctx.lineCap = 'invalid';
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'butt';
+    ctx.lineCap = 'ROUND';
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'butt';
+    ctx.lineCap = 'round\0';
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'butt';
+    ctx.lineCap = 'round ';
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'butt';
+    ctx.lineCap = "";
+    @assert ctx.lineCap === 'butt';
+
+    ctx.lineCap = 'butt';
+    ctx.lineCap = 'bevel';
+    @assert ctx.lineCap === 'butt';
+
+- name: 2d.line.join.bevel
+  desc: lineJoin 'bevel' is rendered correctly
+  testing:
+  - 2d.lineJoin.common
+  - 2d.lineJoin.bevel
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var tol = 1; // tolerance to avoid antialiasing artifacts
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineWidth = 20;
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+
+    ctx.fillRect(10, 10, 20, 20);
+    ctx.fillRect(20, 20, 20, 20);
+    ctx.beginPath();
+    ctx.moveTo(30, 20);
+    ctx.lineTo(40-tol, 20);
+    ctx.lineTo(30, 10+tol);
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.moveTo(10, 20);
+    ctx.lineTo(30, 20);
+    ctx.lineTo(30, 40);
+    ctx.stroke();
+
+
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+
+    ctx.beginPath();
+    ctx.moveTo(60, 20);
+    ctx.lineTo(80, 20);
+    ctx.lineTo(80, 40);
+    ctx.stroke();
+
+    ctx.fillRect(60, 10, 20, 20);
+    ctx.fillRect(70, 20, 20, 20);
+    ctx.beginPath();
+    ctx.moveTo(80, 20);
+    ctx.lineTo(90+tol, 20);
+    ctx.lineTo(80, 10-tol);
+    ctx.fill();
+
+    @assert pixel 34,16 == 0,255,0,255;
+    @assert pixel 34,15 == 0,255,0,255;
+    @assert pixel 35,15 == 0,255,0,255;
+    @assert pixel 36,15 == 0,255,0,255;
+    @assert pixel 36,14 == 0,255,0,255;
+
+    @assert pixel 84,16 == 0,255,0,255;
+    @assert pixel 84,15 == 0,255,0,255;
+    @assert pixel 85,15 == 0,255,0,255;
+    @assert pixel 86,15 == 0,255,0,255;
+    @assert pixel 86,14 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.join.round
+  desc: lineJoin 'round' is rendered correctly
+  testing:
+  - 2d.lineJoin.round
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var tol = 1; // tolerance to avoid antialiasing artifacts
+
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = 20;
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+
+    ctx.fillRect(10, 10, 20, 20);
+    ctx.fillRect(20, 20, 20, 20);
+    ctx.beginPath();
+    ctx.moveTo(30, 20);
+    ctx.arc(30, 20, 10-tol, 0, 2*Math.PI, true);
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.moveTo(10, 20);
+    ctx.lineTo(30, 20);
+    ctx.lineTo(30, 40);
+    ctx.stroke();
+
+
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+
+    ctx.beginPath();
+    ctx.moveTo(60, 20);
+    ctx.lineTo(80, 20);
+    ctx.lineTo(80, 40);
+    ctx.stroke();
+
+    ctx.fillRect(60, 10, 20, 20);
+    ctx.fillRect(70, 20, 20, 20);
+    ctx.beginPath();
+    ctx.moveTo(80, 20);
+    ctx.arc(80, 20, 10+tol, 0, 2*Math.PI, true);
+    ctx.fill();
+
+    @assert pixel 36,14 == 0,255,0,255;
+    @assert pixel 36,13 == 0,255,0,255;
+    @assert pixel 37,13 == 0,255,0,255;
+    @assert pixel 38,13 == 0,255,0,255;
+    @assert pixel 38,12 == 0,255,0,255;
+
+    @assert pixel 86,14 == 0,255,0,255;
+    @assert pixel 86,13 == 0,255,0,255;
+    @assert pixel 87,13 == 0,255,0,255;
+    @assert pixel 88,13 == 0,255,0,255;
+    @assert pixel 88,12 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.join.miter
+  desc: lineJoin 'miter' is rendered correctly
+  testing:
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineJoin = 'miter';
+    ctx.lineWidth = 20;
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+
+    ctx.fillRect(10, 10, 30, 20);
+    ctx.fillRect(20, 10, 20, 30);
+
+    ctx.beginPath();
+    ctx.moveTo(10, 20);
+    ctx.lineTo(30, 20);
+    ctx.lineTo(30, 40);
+    ctx.stroke();
+
+
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+
+    ctx.beginPath();
+    ctx.moveTo(60, 20);
+    ctx.lineTo(80, 20);
+    ctx.lineTo(80, 40);
+    ctx.stroke();
+
+    ctx.fillRect(60, 10, 30, 20);
+    ctx.fillRect(70, 10, 20, 30);
+
+    @assert pixel 38,12 == 0,255,0,255;
+    @assert pixel 39,11 == 0,255,0,255;
+    @assert pixel 40,10 == 0,255,0,255;
+    @assert pixel 41,9 == 0,255,0,255;
+    @assert pixel 42,8 == 0,255,0,255;
+
+    @assert pixel 88,12 == 0,255,0,255;
+    @assert pixel 89,11 == 0,255,0,255;
+    @assert pixel 90,10 == 0,255,0,255;
+    @assert pixel 91,9 == 0,255,0,255;
+    @assert pixel 92,8 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.join.open
+  desc: Line joins are not drawn at the corner of an unclosed rectangle
+  testing:
+  - 2d.lineJoin.joins
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.strokeStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineJoin = 'miter';
+    ctx.lineWidth = 200;
+
+    ctx.beginPath();
+    ctx.moveTo(100, 50);
+    ctx.lineTo(100, 1000);
+    ctx.lineTo(1000, 1000);
+    ctx.lineTo(1000, 50);
+    ctx.lineTo(100, 50);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.join.closed
+  desc: Line joins are drawn at the corner of a closed rectangle
+  testing:
+  - 2d.lineJoin.joinclosed
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.strokeStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineJoin = 'miter';
+    ctx.lineWidth = 200;
+
+    ctx.beginPath();
+    ctx.moveTo(100, 50);
+    ctx.lineTo(100, 1000);
+    ctx.lineTo(1000, 1000);
+    ctx.lineTo(1000, 50);
+    ctx.closePath();
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.join.parallel
+  desc: Line joins are drawn at 180-degree joins
+  testing:
+  - 2d.lineJoin.joins
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 300;
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(-100, 25);
+    ctx.lineTo(0, 25);
+    ctx.lineTo(-100, 25);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.join.valid
+  desc: Setting lineJoin to valid values works
+  testing:
+  - 2d.lineJoin.set
+  - 2d.lineJoin.get
+  code: |
+    ctx.lineJoin = 'bevel'
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'round';
+    @assert ctx.lineJoin === 'round';
+
+    ctx.lineJoin = 'miter';
+    @assert ctx.lineJoin === 'miter';
+
+- name: 2d.line.join.invalid
+  desc: Setting lineJoin to invalid values is ignored
+  testing:
+  - 2d.lineJoin.invalid
+  code: |
+    ctx.lineJoin = 'bevel'
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineJoin = 'invalid';
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineJoin = 'ROUND';
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineJoin = 'round\0';
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineJoin = 'round ';
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineJoin = "";
+    @assert ctx.lineJoin === 'bevel';
+
+    ctx.lineJoin = 'bevel';
+    ctx.lineJoin = 'butt';
+    @assert ctx.lineJoin === 'bevel';
+
+- name: 2d.line.miter.exceeded
+  desc: Miter joins are not drawn when the miter limit is exceeded
+  testing:
+  - 2d.lineJoin.miterLimit
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 400;
+    ctx.lineJoin = 'miter';
+
+    ctx.strokeStyle = '#f00';
+    ctx.miterLimit = 1.414;
+    ctx.beginPath();
+    ctx.moveTo(200, 1000);
+    ctx.lineTo(200, 200);
+    ctx.lineTo(1000, 201); // slightly non-right-angle to avoid being a special case
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.miter.acute
+  desc: Miter joins are drawn correctly with acute angles
+  testing:
+  - 2d.lineJoin.miterLimit
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'miter';
+
+    ctx.strokeStyle = '#0f0';
+    ctx.miterLimit = 2.614;
+    ctx.beginPath();
+    ctx.moveTo(100, 1000);
+    ctx.lineTo(100, 100);
+    ctx.lineTo(1000, 1000);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.miterLimit = 2.613;
+    ctx.beginPath();
+    ctx.moveTo(100, 1000);
+    ctx.lineTo(100, 100);
+    ctx.lineTo(1000, 1000);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.miter.obtuse
+  desc: Miter joins are drawn correctly with obtuse angles
+  testing:
+  - 2d.lineJoin.miterLimit
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 1600;
+    ctx.lineJoin = 'miter';
+
+    ctx.strokeStyle = '#0f0';
+    ctx.miterLimit = 1.083;
+    ctx.beginPath();
+    ctx.moveTo(800, 10000);
+    ctx.lineTo(800, 300);
+    ctx.lineTo(10000, -8900);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.miterLimit = 1.082;
+    ctx.beginPath();
+    ctx.moveTo(800, 10000);
+    ctx.lineTo(800, 300);
+    ctx.lineTo(10000, -8900);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.miter.rightangle
+  desc: Miter joins are not drawn when the miter limit is exceeded, on exact right
+    angles
+  testing:
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 400;
+    ctx.lineJoin = 'miter';
+
+    ctx.strokeStyle = '#f00';
+    ctx.miterLimit = 1.414;
+    ctx.beginPath();
+    ctx.moveTo(200, 1000);
+    ctx.lineTo(200, 200);
+    ctx.lineTo(1000, 200);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.miter.lineedge
+  desc: Miter joins are not drawn when the miter limit is exceeded at the corners
+    of a zero-height rectangle
+  testing:
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'miter';
+
+    ctx.strokeStyle = '#f00';
+    ctx.miterLimit = 1.414;
+    ctx.beginPath();
+    ctx.strokeRect(100, 25, 200, 0);
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.miter.within
+  desc: Miter joins are drawn when the miter limit is not quite exceeded
+  testing:
+  - 2d.lineJoin.miter
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 400;
+    ctx.lineJoin = 'miter';
+
+    ctx.strokeStyle = '#0f0';
+    ctx.miterLimit = 1.416;
+    ctx.beginPath();
+    ctx.moveTo(200, 1000);
+    ctx.lineTo(200, 200);
+    ctx.lineTo(1000, 201);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.miter.valid
+  desc: Setting miterLimit to valid values works
+  testing:
+  - 2d.miterLimit.set
+  - 2d.miterLimit.get
+  code: |
+    ctx.miterLimit = 1.5;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = "1e1";
+    @assert ctx.miterLimit === 10;
+
+    ctx.miterLimit = 1/1024;
+    @assert ctx.miterLimit === 1/1024;
+
+    ctx.miterLimit = 1000;
+    @assert ctx.miterLimit === 1000;
+
+- name: 2d.line.miter.invalid
+  desc: Setting miterLimit to invalid values is ignored
+  testing:
+  - 2d.miterLimit.invalid
+  code: |
+    ctx.miterLimit = 1.5;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = 0;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = -1;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = Infinity;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = -Infinity;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = NaN;
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = 'string';
+    @assert ctx.miterLimit === 1.5;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = true;
+    @assert ctx.miterLimit === 1;
+
+    ctx.miterLimit = 1.5;
+    ctx.miterLimit = false;
+    @assert ctx.miterLimit === 1.5;
+
+- name: 2d.line.cross
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'bevel';
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(110, 50);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(100, 60);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.line.union
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 24);
+    ctx.lineTo(100, 25);
+    ctx.lineTo(0, 26);
+    ctx.closePath();
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 25,1 == 0,255,0,255;
+    @assert pixel 48,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 25,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+  expected: green
+
+
+
+
+
+
+
+- name: 2d.line.invalid.strokestyle
+  desc: Verify correct behavior of canvas on an invalid strokeStyle()
+  testing:
+  - 2d.strokestyle.invalid
+  code: |
+    ctx.strokeStyle = 'rgb(0, 255, 0)';
+    ctx.strokeStyle = 'nonsense';
+    ctx.lineWidth = 200;
+    ctx.moveTo(0,100);
+    ctx.lineTo(200,100);
+    ctx.stroke();
+    var imageData = ctx.getImageData(0, 0, 200, 200);
+    var imgdata = imageData.data;
+    @assert imgdata[4] == 0;
+    @assert imgdata[5] == 255;
+    @assert imgdata[6] == 0;
+

--- a/test/wpt/meta.yaml
+++ b/test/wpt/meta.yaml
@@ -1,0 +1,555 @@
+- meta: |
+    cases = [
+        ("zero", "0", 0),
+        ("empty", "", None),
+        ("onlyspace", "  ", None),
+        ("space", "  100", 100),
+        ("whitespace", "\r\n\t\f100", 100),
+        ("plus", "+100", 100),
+        ("minus", "-100", None),
+        ("octal", "0100", 100),
+        ("hex", "0x100", 0),
+        ("exp", "100e1", 100),
+        ("decimal", "100.999", 100),
+        ("percent", "100%", 100),
+        ("em", "100em", 100),
+        ("junk", "#!?", None),
+        ("trailingjunk", "100#!?", 100),
+    ]
+    def gen(name, string, exp, code):
+        testing = ["size.nonnegativeinteger"]
+        if exp is None:
+            testing.append("size.error")
+            code += "@assert canvas.width === 300;\n@assert canvas.height === 150;\n"
+            expected = "size 300 150"
+        else:
+            code += "@assert canvas.width === %s;\n@assert canvas.height === %s;\n" % (exp, exp)
+            expected = "size %s %s" % (exp, exp)
+
+            # With "100%", Opera gets canvas.width = 100 but renders at 100% of the frame width,
+            # so check the CSS display width
+            code += '@assert window.getComputedStyle(canvas, null).getPropertyValue("width") === "%spx";\n' % (exp, )
+
+        code += "@assert canvas.getAttribute('width') === %r;\n" % string
+        code += "@assert canvas.getAttribute('height') === %r;\n" % string
+
+        if exp == 0:
+            expected = None # can't generate zero-sized PNGs for the expected image
+
+        return code, testing, expected
+
+    for name, string, exp in cases:
+        code = ""
+        code, testing, expected = gen(name, string, exp, code)
+        # We need to replace \r with &#xD; because \r\n gets converted to \n in the HTML parser.
+        htmlString = string.replace('\r', '&#xD;')
+        tests.append( {
+            "name": "size.attributes.parse.%s" % name,
+            "desc": "Parsing of non-negative integers",
+            "testing": testing,
+            "canvas": 'width="%s" height="%s"' % (htmlString, htmlString),
+            "code": code,
+            "expected": expected
+        } )
+
+    for name, string, exp in cases:
+        code = "canvas.setAttribute('width', %r);\ncanvas.setAttribute('height', %r);\n" % (string, string)
+        code, testing, expected = gen(name, string, exp, code)
+        tests.append( {
+            "name": "size.attributes.setAttribute.%s" % name,
+            "desc": "Parsing of non-negative integers in setAttribute",
+            "testing": testing,
+            "canvas": 'width="50" height="50"',
+            "code": code,
+            "expected": expected
+        } )
+
+- meta: |
+    state = [ # some non-default values to test with
+        ('strokeStyle', '"#ff0000"'),
+        ('fillStyle', '"#ff0000"'),
+        ('globalAlpha', 0.5),
+        ('lineWidth', 0.5),
+        ('lineCap', '"round"'),
+        ('lineJoin', '"round"'),
+        ('miterLimit', 0.5),
+        ('shadowOffsetX', 5),
+        ('shadowOffsetY', 5),
+        ('shadowBlur', 5),
+        ('shadowColor', '"#ff0000"'),
+        ('globalCompositeOperation', '"copy"'),
+        ('font', '"25px serif"'),
+        ('textAlign', '"center"'),
+        ('textBaseline', '"bottom"'),
+    ]
+    for key,value in state:
+        tests.append( {
+            'name': '2d.state.saverestore.%s' % key,
+            'desc': 'save()/restore() works for %s' % key,
+            'testing': [ '2d.state.%s' % key ],
+            'code':
+    """// Test that restore() undoes any modifications
+    var old = ctx.%(key)s;
+    ctx.save();
+    ctx.%(key)s = %(value)s;
+    ctx.restore();
+    @assert ctx.%(key)s === old;
+
+    // Also test that save() doesn't modify the values
+    ctx.%(key)s = %(value)s;
+    old = ctx.%(key)s;
+        // we're not interested in failures caused by get(set(x)) != x (e.g.
+        // from rounding), so compare against 'old' instead of against %(value)s
+    ctx.save();
+    @assert ctx.%(key)s === old;
+    ctx.restore();
+    """ % { 'key':key, 'value':value }
+        } )
+
+    tests.append( {
+        'name': 'initial.reset.2dstate',
+        'desc': 'Resetting the canvas state resets 2D state variables',
+        'testing': [ 'initial.reset' ],
+        'code':
+    """canvas.width = 100;
+    var default_val;
+    """ + "".join(
+    """
+    default_val = ctx.%(key)s;
+    ctx.%(key)s = %(value)s;
+    canvas.width = 100;
+    @assert ctx.%(key)s === default_val;
+    """ % { 'key':key, 'value':value }
+        for key,value in state),
+    } )
+
+- meta: |
+    # Composite operation tests
+    # <http://lists.whatwg.org/htdig.cgi/whatwg-whatwg.org/2007-March/010608.html>
+    ops = [
+        # name               FA      FB
+        ('source-over',      '1',    '1-aA'),
+        ('destination-over', '1-aB', '1'),
+        ('source-in',        'aB',   '0'),
+        ('destination-in',   '0',    'aA'),
+        ('source-out',       '1-aB', '0'),
+        ('destination-out',  '0',    '1-aA'),
+        ('source-atop',      'aB',   '1-aA'),
+        ('destination-atop', '1-aB', 'aA'),
+        ('xor',              '1-aB', '1-aA'),
+        ('copy',             '1',    '0'),
+        ('lighter',          '1',    '1'),
+    ]
+
+    # The ones that change the output when src = (0,0,0,0):
+    ops_trans = [ 'source-in', 'destination-in', 'source-out', 'destination-atop', 'copy' ];
+
+    def calc_output(A, B, FA_code, FB_code):
+        (RA, GA, BA, aA) = A
+        (RB, GB, BB, aB) = B
+        rA, gA, bA = RA*aA, GA*aA, BA*aA
+        rB, gB, bB = RB*aB, GB*aB, BB*aB
+
+        FA = eval(FA_code)
+        FB = eval(FB_code)
+
+        rO = rA*FA + rB*FB
+        gO = gA*FA + gB*FB
+        bO = bA*FA + bB*FB
+        aO = aA*FA + aB*FB
+
+        rO = min(255, rO)
+        gO = min(255, gO)
+        bO = min(255, bO)
+        aO = min(1, aO)
+
+        if aO:
+            RO = rO / aO
+            GO = gO / aO
+            BO = bO / aO
+        else: RO = GO = BO = 0
+
+        return (RO, GO, BO, aO)
+
+    def to_test(color):
+        r, g, b, a = color
+        return '%d,%d,%d,%d' % (round(r), round(g), round(b), round(a*255))
+    def to_cairo(color):
+        r, g, b, a = color
+        return '%f,%f,%f,%f' % (r/255., g/255., b/255., a)
+
+    for (name, src, dest) in [
+        ('solid', (255, 255, 0, 1.0), (0, 255, 255, 1.0)),
+        ('transparent', (0, 0, 255, 0.75), (0, 255, 0, 0.5)),
+            # catches the atop, xor and lighter bugs in Opera 9.10
+    ]:
+        for op, FA_code, FB_code in ops:
+            expected = calc_output(src, dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'testing': [ '2d.composite.%s' % op ],
+                'code': """
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, src, to_test(expected)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % to_cairo(expected),
+            } )
+
+    for (name, src, dest) in [ ('image', (255, 255, 0, 0.75), (0, 255, 255, 0.5)) ]:
+        for op, FA_code, FB_code in ops:
+            expected = calc_output(src, dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'testing': [ '2d.composite.%s' % op ],
+                'images': [ 'yellow75.png' ],
+                'code': """
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.drawImage(document.getElementById('yellow75.png'), 0, 0);
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, to_test(expected)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % to_cairo(expected),
+            } )
+
+    for (name, src, dest) in [ ('canvas', (255, 255, 0, 0.75), (0, 255, 255, 0.5)) ]:
+        for op, FA_code, FB_code in ops:
+            expected = calc_output(src, dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'testing': [ '2d.composite.%s' % op ],
+                'images': [ 'yellow75.png' ],
+                'code': """
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = canvas.width;
+    canvas2.height = canvas.height;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.drawImage(document.getElementById('yellow75.png'), 0, 0);
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.drawImage(canvas2, 0, 0);
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, to_test(expected)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % to_cairo(expected),
+            } )
+
+
+    for (name, src, dest) in [ ('uncovered.fill', (0, 0, 255, 0.75), (0, 255, 0, 0.5)) ]:
+        for op, FA_code, FB_code in ops:
+            if op not in ops_trans: continue
+            expected0 = calc_output((0,0,0,0.0), dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'desc': 'fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.',
+                'testing': [ '2d.composite.%s' % op ],
+                'code': """
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.fillStyle = 'rgba%s';
+    ctx.translate(0, 25);
+    ctx.fillRect(0, 50, 100, 50);
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, src, to_test(expected0)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % (to_cairo(expected0)),
+            } )
+
+    for (name, src, dest) in [ ('uncovered.image', (255, 255, 0, 1.0), (0, 255, 255, 0.5)) ]:
+        for op, FA_code, FB_code in ops:
+            if op not in ops_trans: continue
+            expected0 = calc_output((0,0,0,0.0), dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'desc': 'drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.',
+                'testing': [ '2d.composite.%s' % op ],
+                'images': [ 'yellow.png' ],
+                'code': """
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.drawImage(document.getElementById('yellow.png'), 40, 40, 10, 10, 40, 50, 10, 10);
+    @assert pixel 15,15 ==~ %s +/- 5;
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, to_test(expected0), to_test(expected0)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % (to_cairo(expected0)),
+            } )
+
+    for (name, src, dest) in [ ('uncovered.nocontext', (255, 255, 0, 1.0), (0, 255, 255, 0.5)) ]:
+        for op, FA_code, FB_code in ops:
+            if op not in ops_trans: continue
+            expected0 = calc_output((0,0,0,0.0), dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'desc': 'drawImage() of a canvas with no context draws pixels as (0,0,0,0), and does not leave the pixels unchanged.',
+                'testing': [ '2d.composite.%s' % op ],
+                'code': """
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    var canvas2 = document.createElement('canvas');
+    ctx.drawImage(canvas2, 0, 0);
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, to_test(expected0)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % (to_cairo(expected0)),
+            } )
+
+    for (name, src, dest) in [ ('uncovered.pattern', (255, 255, 0, 1.0), (0, 255, 255, 0.5)) ]:
+        for op, FA_code, FB_code in ops:
+            if op not in ops_trans: continue
+            expected0 = calc_output((0,0,0,0.0), dest, FA_code, FB_code)
+            tests.append( {
+                'name': '2d.composite.%s.%s' % (name, op),
+                'desc': 'Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.',
+                'testing': [ '2d.composite.%s' % op ],
+                'images': [ 'yellow.png' ],
+                'code': """
+    ctx.fillStyle = 'rgba%s';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.fillStyle = ctx.createPattern(document.getElementById('yellow.png'), 'no-repeat');
+    ctx.fillRect(0, 50, 100, 50);
+    @assert pixel 50,25 ==~ %s +/- 5;
+    """ % (dest, op, to_test(expected0)),
+                'expected': """size 100 50
+    cr.set_source_rgba(%s)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % (to_cairo(expected0)),
+            } )
+
+    for op, FA_code, FB_code in ops:
+        tests.append( {
+            'name': '2d.composite.clip.%s' % (op),
+            'desc': 'fill() does not affect pixels outside the clip region.',
+            'testing': [ '2d.composite.%s' % op ],
+            'code': """
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = '%s';
+    ctx.rect(-20, -20, 10, 10);
+    ctx.clip();
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 50, 50);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+    """ % (op),
+                'expected': 'green'
+        } )
+
+- meta: |
+    # Color parsing tests
+
+    # Try most of the CSS3 Color <color> values - http://www.w3.org/TR/css3-color/#colorunits
+    big_float = '1' + ('0' * 39)
+    big_double = '1' + ('0' * 310)
+    for name, string, r,g,b,a, notes in [
+        ('html4', 'limE', 0,255,0,255, ""),
+        ('hex3', '#0f0', 0,255,0,255, ""),
+        ('hex4', '#0f0f', 0,255,0,255, ""),
+        ('hex6', '#00fF00', 0,255,0,255, ""),
+        ('hex8', '#00ff00ff', 0,255,0,255, ""),
+        ('rgb-num', 'rgb(0,255,0)', 0,255,0,255, ""),
+        ('rgb-clamp-1', 'rgb(-1000, 1000, -1000)', 0,255,0,255, 'Assumes colors are clamped to [0,255].'),
+        ('rgb-clamp-2', 'rgb(-200%, 200%, -200%)', 0,255,0,255, 'Assumes colors are clamped to [0,255].'),
+        ('rgb-clamp-3', 'rgb(-2147483649, 4294967298, -18446744073709551619)', 0,255,0,255, 'Assumes colors are clamped to [0,255].'),
+        ('rgb-clamp-4', 'rgb(-'+big_float+', '+big_float+', -'+big_float+')', 0,255,0,255, 'Assumes colors are clamped to [0,255].'),
+        ('rgb-clamp-5', 'rgb(-'+big_double+', '+big_double+', -'+big_double+')', 0,255,0,255, 'Assumes colors are clamped to [0,255].'),
+        ('rgb-percent', 'rgb(0% ,100% ,0%)', 0,255,0,255, 'CSS3 Color says "The integer value 255 corresponds to 100%". (In particular, it is not 254...)'),
+        ('rgb-eof', 'rgb(0, 255, 0', 0,255,0,255, ""), # see CSS2.1 4.2 "Unexpected end of style sheet"
+        ('rgba-solid-1', 'rgba(  0  ,  255  ,  0  ,  1  )', 0,255,0,255, ""),
+        ('rgba-solid-2', 'rgba(  0  ,  255  ,  0  ,  1.0  )', 0,255,0,255, ""),
+        ('rgba-solid-3', 'rgba(  0  ,  255  ,  0  , +1  )', 0,255,0,255, ""),
+        ('rgba-solid-4', 'rgba( -0  ,  255  , +0  ,  1  )', 0,255,0,255, ""),
+        ('rgba-num-1', 'rgba(  0  ,  255  ,  0  ,  .499  )', 0,255,0,127, ""),
+        ('rgba-num-2', 'rgba(  0  ,  255  ,  0  ,  0.499  )', 0,255,0,127, ""),
+        ('rgba-percent', 'rgba(0%,100%,0%,0.499)', 0,255,0,127, ""), # 0.499*255 rounds to 127, both down and nearest, so it should be safe
+        ('rgba-clamp-1', 'rgba(0, 255, 0, -2)', 0,0,0,0, ""),
+        ('rgba-clamp-2', 'rgba(0, 255, 0, 2)', 0,255,0,255, ""),
+        ('rgba-eof', 'rgba(0, 255, 0, 1', 0,255,0,255, ""),
+        ('transparent-1', 'transparent', 0,0,0,0, ""),
+        ('transparent-2', 'TrAnSpArEnT', 0,0,0,0, ""),
+        ('hsl-1', 'hsl(120, 100%, 50%)', 0,255,0,255, ""),
+        ('hsl-2', 'hsl( -240 , 100% , 50% )', 0,255,0,255, ""),
+        ('hsl-3', 'hsl(360120, 100%, 50%)', 0,255,0,255, ""),
+        ('hsl-4', 'hsl(-360240, 100%, 50%)', 0,255,0,255, ""),
+        ('hsl-5', 'hsl(120.0, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('hsl-6', 'hsl(+120, +100%, +50%)', 0,255,0,255, ""),
+        ('hsl-clamp-1', 'hsl(120, 200%, 50%)', 0,255,0,255, ""),
+        ('hsl-clamp-2', 'hsl(120, -200%, 49.9%)', 127,127,127,255, ""),
+        ('hsl-clamp-3', 'hsl(120, 100%, 200%)', 255,255,255,255, ""),
+        ('hsl-clamp-4', 'hsl(120, 100%, -200%)', 0,0,0,255, ""),
+        ('hsla-1', 'hsla(120, 100%, 50%, 0.499)', 0,255,0,127, ""),
+        ('hsla-2', 'hsla( 120.0 , 100.0% , 50.0% , 1 )', 0,255,0,255, ""),
+        ('hsla-clamp-1', 'hsla(120, 200%, 50%, 1)', 0,255,0,255, ""),
+        ('hsla-clamp-2', 'hsla(120, -200%, 49.9%, 1)', 127,127,127,255, ""),
+        ('hsla-clamp-3', 'hsla(120, 100%, 200%, 1)', 255,255,255,255, ""),
+        ('hsla-clamp-4', 'hsla(120, 100%, -200%, 1)', 0,0,0,255, ""),
+        ('hsla-clamp-5', 'hsla(120, 100%, 50%, 2)', 0,255,0,255, ""),
+        ('hsla-clamp-6', 'hsla(120, 100%, 0%, -2)', 0,0,0,0, ""),
+        ('svg-1', 'gray', 128,128,128,255, ""),
+        ('svg-2', 'grey', 128,128,128,255, ""),
+        # css-color-4 rgb() color function
+        #   https://drafts.csswg.org/css-color/#numeric-rgb
+        ('css-color-4-rgb-1', 'rgb(0, 255.0, 0)', 0,255,0,255, ""),
+        ('css-color-4-rgb-2', 'rgb(0, 255, 0, 0.2)', 0,255,0,51, ""),
+        ('css-color-4-rgb-3', 'rgb(0, 255, 0, 20%)', 0,255,0,51, ""),
+        ('css-color-4-rgb-4', 'rgb(0 255 0)', 0,255,0,255, ""),
+        ('css-color-4-rgb-5', 'rgb(0 255 0 / 0.2)', 0,255,0,51, ""),
+        ('css-color-4-rgb-6', 'rgb(0 255 0 / 20%)', 0,255,0,51, ""),
+        ('css-color-4-rgba-1', 'rgba(0, 255.0, 0)', 0,255,0,255, ""),
+        ('css-color-4-rgba-2', 'rgba(0, 255, 0, 0.2)', 0,255,0,51, ""),
+        ('css-color-4-rgba-3', 'rgba(0, 255, 0, 20%)', 0,255,0,51, ""),
+        ('css-color-4-rgba-4', 'rgba(0 255 0)', 0,255,0,255, ""),
+        ('css-color-4-rgba-5', 'rgba(0 255 0 / 0.2)', 0,255,0,51, ""),
+        ('css-color-4-rgba-6', 'rgba(0 255 0 / 20%)', 0,255,0,51, ""),
+        # css-color-4 hsl() color function
+        #   https://drafts.csswg.org/css-color/#the-hsl-notation
+        ('css-color-4-hsl-1', 'hsl(120 100.0% 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsl-2', 'hsl(120 100.0% 50.0% / 0.2)', 0,255,0,51, ""),
+        ('css-color-4-hsl-3', 'hsl(120.0, 100.0%, 50.0%, 0.2)', 0,255,0,51, ""),
+        ('css-color-4-hsl-4', 'hsl(120.0, 100.0%, 50.0%, 20%)', 0,255,0,51, ""),
+        ('css-color-4-hsl-5', 'hsl(120deg, 100.0%, 50.0%, 0.2)', 0,255,0,51, ""),
+        ('css-color-4-hsl-6', 'hsl(120deg, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsl-7', 'hsl(133.33333333grad, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsl-8', 'hsl(2.0943951024rad, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsl-9', 'hsl(0.3333333333turn, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsla-1', 'hsl(120 100.0% 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsla-2', 'hsl(120 100.0% 50.0% / 0.2)', 0,255,0,51, ""),
+        ('css-color-4-hsla-3', 'hsl(120.0, 100.0%, 50.0%, 0.2)', 0,255,0,51, ""),
+        ('css-color-4-hsla-4', 'hsl(120.0, 100.0%, 50.0%, 20%)', 0,255,0,51, ""),
+        ('css-color-4-hsla-5', 'hsl(120deg, 100.0%, 50.0%, 0.2)', 0,255,0,51, ""),
+        ('css-color-4-hsla-6', 'hsl(120deg, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsla-7', 'hsl(133.33333333grad, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsla-8', 'hsl(2.0943951024rad, 100.0%, 50.0%)', 0,255,0,255, ""),
+        ('css-color-4-hsla-9', 'hsl(0.3333333333turn, 100.0%, 50.0%)', 0,255,0,255, ""),
+        # currentColor is handled later
+    ]:
+        # TODO: test by retrieving fillStyle, instead of actually drawing?
+        # TODO: test strokeStyle, shadowColor in the same way
+        test = {
+            'name': '2d.fillStyle.parse.%s' % name,
+            'testing': [ '2d.colors.parse' ],
+            'notes': notes,
+            'code': """
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = '%s';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == %d,%d,%d,%d;
+    """ % (string, r,g,b,a),
+            'expected': """size 100 50
+    cr.set_source_rgba(%f, %f, %f, %f)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    """ % (r/255., g/255., b/255., a/255.),
+        }
+        tests.append(test)
+
+    # Also test that invalid colors are ignored
+    for name, string in [
+        ('hex1', '#f'),
+        ('hex2', '#f0'),
+        ('hex3', '#g00'),
+        ('hex4', '#fg00'),
+        ('hex5', '#ff000'),
+        ('hex6', '#fg0000'),
+        ('hex7', '#ff0000f'),
+        ('hex8', '#fg0000ff'),
+        ('rgb-1', 'rgb(255.0, 0, 0,)'),
+        ('rgb-2', 'rgb(100%, 0, 0)'),
+        ('rgb-3', 'rgb(255, - 1, 0)'),
+        ('rgba-1', 'rgba(100%, 0, 0, 1)'),
+        ('rgba-2', 'rgba(255, 0, 0, 1. 0)'),
+        ('rgba-3', 'rgba(255, 0, 0, 1.)'),
+        ('rgba-4', 'rgba(255, 0, 0, '),
+        ('rgba-5', 'rgba(255, 0, 0, 1,)'),
+        ('hsl-1', 'hsl(0%, 100%, 50%)'),
+        ('hsl-2', 'hsl(z, 100%, 50%)'),
+        ('hsl-3', 'hsl(0, 0, 50%)'),
+        ('hsl-4', 'hsl(0, 100%, 0)'),
+        ('hsl-5', 'hsl(0, 100.%, 50%)'),
+        ('hsl-6', 'hsl(0, 100%, 50%,)'),
+        ('hsla-1', 'hsla(0%, 100%, 50%, 1)'),
+        ('hsla-2', 'hsla(0, 0, 50%, 1)'),
+        ('hsla-3', 'hsla(0, 0, 50%, 1,)'),
+        ('name-1', 'darkbrown'),
+        ('name-2', 'firebrick1'),
+        ('name-3', 'red blue'),
+        ('name-4', '"red"'),
+        ('name-5', '"red'),
+        # css-color-4 color function
+        #   comma and comma-less expressions should not mix together.
+        ('css-color-4-rgb-1', 'rgb(255, 0, 0 / 1)'),
+        ('css-color-4-rgb-2', 'rgb(255 0 0, 1)'),
+        ('css-color-4-rgb-3', 'rgb(255, 0 0)'),
+        ('css-color-4-rgba-1', 'rgba(255, 0, 0 / 1)'),
+        ('css-color-4-rgba-2', 'rgba(255 0 0, 1)'),
+        ('css-color-4-rgba-3', 'rgba(255, 0 0)'),
+        ('css-color-4-hsl-1', 'hsl(0, 100%, 50% / 1)'),
+        ('css-color-4-hsl-2', 'hsl(0 100% 50%, 1)'),
+        ('css-color-4-hsl-3', 'hsl(0, 100% 50%)'),
+        ('css-color-4-hsla-1', 'hsla(0, 100%, 50% / 1)'),
+        ('css-color-4-hsla-2', 'hsla(0 100% 50%, 1)'),
+        ('css-color-4-hsla-3', 'hsla(0, 100% 50%)'),
+        #  trailing slash
+        ('css-color-4-rgb-4', 'rgb(0 0 0 /)'),
+        ('css-color-4-rgb-5', 'rgb(0, 0, 0 /)'),
+        ('css-color-4-hsl-4', 'hsl(0 100% 50% /)'),
+        ('css-color-4-hsl-5', 'hsl(0, 100%, 50% /)'),
+    ]:
+        test = {
+            'name': '2d.fillStyle.parse.invalid.%s' % name,
+            'testing': [ '2d.colors.parse' ],
+            'code': """
+    ctx.fillStyle = '#0f0';
+    try { ctx.fillStyle = '%s'; } catch (e) { } // this shouldn't throw, but it shouldn't matter here if it does
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+    """ % string,
+            'expected': 'green'
+        }
+        tests.append(test)
+
+    # Some can't have positive tests, only negative tests, because we don't know what color they're meant to be
+    for name, string in [
+        ('system', 'ThreeDDarkShadow'),
+        #('flavor', 'flavor'), # removed from latest CSS3 Color drafts
+    ]:
+        test = {
+            'name': '2d.fillStyle.parse.%s' % name,
+            'testing': [ '2d.colors.parse' ],
+            'code': """
+    ctx.fillStyle = '#f00';
+    ctx.fillStyle = '%s';
+    @assert ctx.fillStyle =~ /^#(?!(FF0000|ff0000|f00)$)/; // test that it's not red
+    """ % (string,),
+        }
+        tests.append(test)

--- a/test/wpt/path-objects.yaml
+++ b/test/wpt/path-objects.yaml
@@ -1,0 +1,3646 @@
+- name: 2d.path.initial
+  testing:
+  - 2d.path.initial
+  #mozilla: { bug: TODO }
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.closePath();
+    ctx.fillStyle = '#f00';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.beginPath
+  testing:
+  - 2d.path.beginPath
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.rect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.fillStyle = '#f00';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.moveTo.basic
+  testing:
+  - 2d.path.moveTo
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.rect(0, 0, 10, 50);
+    ctx.moveTo(100, 0);
+    ctx.lineTo(10, 0);
+    ctx.lineTo(10, 50);
+    ctx.lineTo(100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 90,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.moveTo.newsubpath
+  testing:
+  - 2d.path.moveTo
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.moveTo(100, 0);
+    ctx.moveTo(100, 50);
+    ctx.moveTo(0, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.moveTo.multiple
+  testing:
+  - 2d.path.moveTo
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.moveTo(0, 25);
+    ctx.moveTo(100, 25);
+    ctx.moveTo(0, 25);
+    ctx.lineTo(100, 25);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.moveTo.nonfinite
+  desc: moveTo() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.moveTo(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.closePath.empty
+  testing:
+  - 2d.path.closePath.empty
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.closePath();
+    ctx.fillStyle = '#f00';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.closePath.newline
+  testing:
+  - 2d.path.closePath.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.moveTo(-100, 25);
+    ctx.lineTo(-100, -100);
+    ctx.lineTo(200, -100);
+    ctx.lineTo(200, 25);
+    ctx.closePath();
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.closePath.nextpoint
+  testing:
+  - 2d.path.closePath.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.moveTo(-100, 25);
+    ctx.lineTo(-100, -1000);
+    ctx.closePath();
+    ctx.lineTo(1000, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.lineTo.ensuresubpath.1
+  desc: If there is no subpath, the point is added and nothing is drawn
+  testing:
+  - 2d.path.lineTo.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.lineTo(100, 50);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.lineTo.ensuresubpath.2
+  desc: If there is no subpath, the point is added and used for subsequent drawing
+  testing:
+  - 2d.path.lineTo.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.lineTo(0, 25);
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.lineTo.basic
+  testing:
+  - 2d.path.lineTo.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.lineTo.nextpoint
+  testing:
+  - 2d.path.lineTo.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.moveTo(-100, -100);
+    ctx.lineTo(0, 25);
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.lineTo.nonfinite
+  desc: lineTo() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.lineTo(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.lineTo.nonfinite.details
+  desc: lineTo() with Infinity/NaN for first arg still converts the second arg
+  testing:
+  - 2d.nonfinite
+  code: |
+    for (var arg1 of [Infinity, -Infinity, NaN]) {
+      var converted = false;
+      ctx.lineTo(arg1, { valueOf: function() { converted = true; return 0; } });
+      @assert converted;
+    }
+  expected: clear
+
+- name: 2d.path.quadraticCurveTo.ensuresubpath.1
+  desc: If there is no subpath, the first control point is added (and nothing is drawn
+    up to it)
+  testing:
+  - 2d.path.quadratic.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.quadraticCurveTo(100, 50, 200, 50);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 95,45 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.quadraticCurveTo.ensuresubpath.2
+  desc: If there is no subpath, the first control point is added
+  testing:
+  - 2d.path.quadratic.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.quadraticCurveTo(0, 25, 100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 5,45 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.quadraticCurveTo.basic
+  testing:
+  - 2d.path.quadratic.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.quadraticCurveTo(100, 25, 100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.quadraticCurveTo.shape
+  testing:
+  - 2d.path.quadratic.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 55;
+    ctx.beginPath();
+    ctx.moveTo(-1000, 1050);
+    ctx.quadraticCurveTo(0, -1000, 1200, 1050);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.quadraticCurveTo.scaled
+  testing:
+  - 2d.path.quadratic.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.scale(1000, 1000);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 0.055;
+    ctx.beginPath();
+    ctx.moveTo(-1, 1.05);
+    ctx.quadraticCurveTo(0, -1, 1.2, 1.05);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.quadraticCurveTo.nonfinite
+  desc: quadraticCurveTo() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.quadraticCurveTo(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.bezierCurveTo.ensuresubpath.1
+  desc: If there is no subpath, the first control point is added (and nothing is drawn
+    up to it)
+  testing:
+  - 2d.path.bezier.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.bezierCurveTo(100, 50, 200, 50, 200, 50);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 95,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.bezierCurveTo.ensuresubpath.2
+  desc: If there is no subpath, the first control point is added
+  testing:
+  - 2d.path.bezier.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.bezierCurveTo(0, 25, 100, 25, 100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 5,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.bezierCurveTo.basic
+  testing:
+  - 2d.path.bezier.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.bezierCurveTo(100, 25, 100, 25, 100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.bezierCurveTo.shape
+  testing:
+  - 2d.path.bezier.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 55;
+    ctx.beginPath();
+    ctx.moveTo(-2000, 3100);
+    ctx.bezierCurveTo(-2000, -1000, 2100, -1000, 2100, 3100);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.bezierCurveTo.scaled
+  testing:
+  - 2d.path.bezier.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.scale(1000, 1000);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 0.055;
+    ctx.beginPath();
+    ctx.moveTo(-2, 3.1);
+    ctx.bezierCurveTo(-2, -1, 2.1, -1, 2.1, 3.1);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.bezierCurveTo.nonfinite
+  desc: bezierCurveTo() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.bezierCurveTo(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.ensuresubpath.1
+  desc: If there is no subpath, the first control point is added (and nothing is drawn
+    up to it)
+  testing:
+  - 2d.path.arcTo.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.arcTo(100, 50, 200, 50, 0.1);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.ensuresubpath.2
+  desc: If there is no subpath, the first control point is added
+  testing:
+  - 2d.path.arcTo.empty
+  - 2d.path.ensure
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.arcTo(0, 25, 50, 250, 0.1); // adds (x1,y1), draws nothing
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.coincide.1
+  desc: arcTo() has no effect if P0 = P1
+  testing:
+  - 2d.path.arcTo.coincide.01
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(0, 25, 50, 1000, 1);
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.arcTo(50, 25, 100, 25, 1);
+    ctx.stroke();
+
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.coincide.2
+  desc: arcTo() draws a straight line to P1 if P1 = P2
+  testing:
+  - 2d.path.arcTo.coincide.12
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(100, 25, 100, 25, 1);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.collinear.1
+  desc: arcTo() with all points on a line, and P1 between P0/P2, draws a straight
+    line to P1
+  testing:
+  - 2d.path.arcTo.collinear
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(100, 25, 200, 25, 1);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(-100, 25);
+    ctx.arcTo(0, 25, 100, 25, 1);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.collinear.2
+  desc: arcTo() with all points on a line, and P2 between P0/P1, draws a straight
+    line to P1
+  testing:
+  - 2d.path.arcTo.collinear
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(100, 25, 10, 25, 1);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 25);
+    ctx.arcTo(200, 25, 110, 25, 1);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.collinear.3
+  desc: arcTo() with all points on a line, and P0 between P1/P2, draws a straight
+    line to P1
+  testing:
+  - 2d.path.arcTo.collinear
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(100, 25, -100, 25, 1);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 25);
+    ctx.arcTo(200, 25, 0, 25, 1);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(-100, 25);
+    ctx.arcTo(0, 25, -200, 25, 1);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.shape.curve1
+  desc: arcTo() curves in the right kind of shape
+  testing:
+  - 2d.path.arcTo.shape
+  code: |
+    var tol = 1.5; // tolerance to avoid antialiasing artifacts
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 10;
+    ctx.beginPath();
+    ctx.moveTo(10, 25);
+    ctx.arcTo(75, 25, 75, 60, 20);
+    ctx.stroke();
+
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.rect(10, 20, 45, 10);
+    ctx.moveTo(80, 45);
+    ctx.arc(55, 45, 25+tol, 0, -Math.PI/2, true);
+    ctx.arc(55, 45, 15-tol, -Math.PI/2, 0, false);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 55,19 == 0,255,0,255;
+    @assert pixel 55,20 == 0,255,0,255;
+    @assert pixel 55,21 == 0,255,0,255;
+    @assert pixel 64,22 == 0,255,0,255;
+    @assert pixel 65,21 == 0,255,0,255;
+    @assert pixel 72,28 == 0,255,0,255;
+    @assert pixel 73,27 == 0,255,0,255;
+    @assert pixel 78,36 == 0,255,0,255;
+    @assert pixel 79,35 == 0,255,0,255;
+    @assert pixel 80,44 == 0,255,0,255;
+    @assert pixel 80,45 == 0,255,0,255;
+    @assert pixel 80,46 == 0,255,0,255;
+    @assert pixel 65,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.shape.curve2
+  desc: arcTo() curves in the right kind of shape
+  testing:
+  - 2d.path.arcTo.shape
+  code: |
+    var tol = 1.5; // tolerance to avoid antialiasing artifacts
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.rect(10, 20, 45, 10);
+    ctx.moveTo(80, 45);
+    ctx.arc(55, 45, 25-tol, 0, -Math.PI/2, true);
+    ctx.arc(55, 45, 15+tol, -Math.PI/2, 0, false);
+    ctx.fill();
+
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 10;
+    ctx.beginPath();
+    ctx.moveTo(10, 25);
+    ctx.arcTo(75, 25, 75, 60, 20);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 55,19 == 0,255,0,255;
+    @assert pixel 55,20 == 0,255,0,255;
+    @assert pixel 55,21 == 0,255,0,255;
+    @assert pixel 64,22 == 0,255,0,255;
+    @assert pixel 65,21 == 0,255,0,255;
+    @assert pixel 72,28 == 0,255,0,255;
+    @assert pixel 73,27 == 0,255,0,255;
+    @assert pixel 78,36 == 0,255,0,255;
+    @assert pixel 79,35 == 0,255,0,255;
+    @assert pixel 80,44 == 0,255,0,255;
+    @assert pixel 80,45 == 0,255,0,255;
+    @assert pixel 80,46 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.shape.start
+  desc: arcTo() draws a straight line from P0 to P1
+  testing:
+  - 2d.path.arcTo.shape
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(200, 25, 200, 50, 10);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.shape.end
+  desc: arcTo() does not draw anything from P1 to P2
+  testing:
+  - 2d.path.arcTo.shape
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.beginPath();
+    ctx.moveTo(-100, -100);
+    ctx.arcTo(-100, 25, 200, 25, 10);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.negative
+  desc: arcTo() with negative radius throws an exception
+  testing:
+  - 2d.path.arcTo.negative
+  code: |
+    @assert throws INDEX_SIZE_ERR ctx.arcTo(0, 0, 0, 0, -1);
+    var path = new Path2D();
+    @assert throws INDEX_SIZE_ERR path.arcTo(10, 10, 20, 20, -5);
+
+- name: 2d.path.arcTo.zero.1
+  desc: arcTo() with zero radius draws a straight line from P0 to P1
+  testing:
+  - 2d.path.arcTo.zeroradius
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(100, 25, 100, 100, 0);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(0, -25);
+    ctx.arcTo(50, -25, 50, 50, 0);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.zero.2
+  desc: arcTo() with zero radius draws a straight line from P0 to P1, even when all
+    points are collinear
+  testing:
+  - 2d.path.arcTo.zeroradius
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arcTo(100, 25, -100, 25, 0);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 25);
+    ctx.arcTo(200, 25, 50, 25, 0);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.transformation
+  desc: arcTo joins up to the last subpath point correctly
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 50);
+    ctx.translate(100, 0);
+    ctx.arcTo(50, 50, 50, 0, 50);
+    ctx.lineTo(-100, 0);
+    ctx.fill();
+
+    @assert pixel 0,0 == 0,255,0,255;
+    @assert pixel 50,0 == 0,255,0,255;
+    @assert pixel 99,0 == 0,255,0,255;
+    @assert pixel 0,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 99,25 == 0,255,0,255;
+    @assert pixel 0,49 == 0,255,0,255;
+    @assert pixel 50,49 == 0,255,0,255;
+    @assert pixel 99,49 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.scale
+  desc: arcTo scales the curve, not just the control points
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 50);
+    ctx.translate(100, 0);
+    ctx.scale(0.1, 1);
+    ctx.arcTo(50, 50, 50, 0, 50);
+    ctx.lineTo(-1000, 0);
+    ctx.fill();
+
+    @assert pixel 0,0 == 0,255,0,255;
+    @assert pixel 50,0 == 0,255,0,255;
+    @assert pixel 99,0 == 0,255,0,255;
+    @assert pixel 0,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 99,25 == 0,255,0,255;
+    @assert pixel 0,49 == 0,255,0,255;
+    @assert pixel 50,49 == 0,255,0,255;
+    @assert pixel 99,49 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arcTo.nonfinite
+  desc: arcTo() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.arcTo(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.path.arc.empty
+  desc: arc() with an empty path does not draw a straight line to the start point
+  testing:
+  - 2d.path.arc.nonempty
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.arc(200, 25, 5, 0, 2*Math.PI, true);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.nonempty
+  desc: arc() with a non-empty path does draw a straight line to the start point
+  testing:
+  - 2d.path.arc.nonempty
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arc(200, 25, 5, 0, 2*Math.PI, true);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.end
+  desc: arc() adds the end point of the arc to the subpath
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(-100, 0);
+    ctx.arc(-100, 0, 25, -Math.PI/2, Math.PI/2, true);
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.default
+  desc: arc() with missing last argument defaults to clockwise
+  testing:
+  - 2d.path.arc.omitted
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 0);
+    ctx.arc(100, 0, 150, -Math.PI, Math.PI/2);
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.angle.1
+  desc: arc() draws pi/2 .. -pi anticlockwise correctly
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 0);
+    ctx.arc(100, 0, 150, Math.PI/2, -Math.PI, true);
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.angle.2
+  desc: arc() draws -3pi/2 .. -pi anticlockwise correctly
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 0);
+    ctx.arc(100, 0, 150, -3*Math.PI/2, -Math.PI, true);
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.angle.3
+  desc: arc() wraps angles mod 2pi when anticlockwise and end > start+2pi
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 0);
+    ctx.arc(100, 0, 150, (512+1/2)*Math.PI, (1024-1)*Math.PI, true);
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.angle.4
+  desc: arc() draws a full circle when clockwise and end > start+2pi
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.arc(50, 25, 60, (512+1/2)*Math.PI, (1024-1)*Math.PI, false);
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.angle.5
+  desc: arc() wraps angles mod 2pi when clockwise and start > end+2pi
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(100, 0);
+    ctx.arc(100, 0, 150, (1024-1)*Math.PI, (512+1/2)*Math.PI, false);
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.angle.6
+  desc: arc() draws a full circle when anticlockwise and start > end+2pi
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.arc(50, 25, 60, (1024-1)*Math.PI, (512+1/2)*Math.PI, true);
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.zero.1
+  desc: arc() draws nothing when startAngle = endAngle and anticlockwise
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.arc(50, 25, 50, 0, 0, true);
+    ctx.stroke();
+    @assert pixel 50,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.zero.2
+  desc: arc() draws nothing when startAngle = endAngle and clockwise
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.arc(50, 25, 50, 0, 0, false);
+    ctx.stroke();
+    @assert pixel 50,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.twopie.1
+  desc: arc() draws nothing when end = start + 2pi-e and anticlockwise
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.arc(50, 25, 50, 0, 2*Math.PI - 1e-4, true);
+    ctx.stroke();
+    @assert pixel 50,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.twopie.2
+  desc: arc() draws a full circle when end = start + 2pi-e and clockwise
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.arc(50, 25, 50, 0, 2*Math.PI - 1e-4, false);
+    ctx.stroke();
+    @assert pixel 50,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.twopie.3
+  desc: arc() draws a full circle when end = start + 2pi+e and anticlockwise
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.arc(50, 25, 50, 0, 2*Math.PI + 1e-4, true);
+    ctx.stroke();
+    @assert pixel 50,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.twopie.4
+  desc: arc() draws nothing when end = start + 2pi+e and clockwise
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.arc(50, 25, 50, 0, 2*Math.PI + 1e-4, false);
+    ctx.stroke();
+    @assert pixel 50,20 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.shape.1
+  desc: arc() from 0 to pi does not draw anything in the wrong half
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.arc(50, 50, 50, 0, Math.PI, false);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 20,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.shape.2
+  desc: arc() from 0 to pi draws stuff in the right half
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 100;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.arc(50, 50, 50, 0, Math.PI, true);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 20,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.shape.3
+  desc: arc() from 0 to -pi/2 does not draw anything in the wrong quadrant
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 100;
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.arc(0, 50, 50, 0, -Math.PI/2, false);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255; @moz-todo
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.shape.4
+  desc: arc() from 0 to -pi/2 draws stuff in the right quadrant
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 150;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.arc(-50, 50, 100, 0, -Math.PI/2, true);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.shape.5
+  desc: arc() from 0 to 5pi does not draw crazy things
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 200;
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.arc(300, 0, 100, 0, 5*Math.PI, false);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.selfintersect.1
+  desc: arc() with lineWidth > 2*radius is drawn sensibly
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 200;
+    ctx.strokeStyle = '#f00';
+    ctx.beginPath();
+    ctx.arc(100, 50, 25, 0, -Math.PI/2, true);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(0, 0, 25, 0, -Math.PI/2, true);
+    ctx.stroke();
+    @assert pixel 1,1 == 0,255,0,255; @moz-todo
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.selfintersect.2
+  desc: arc() with lineWidth > 2*radius is drawn sensibly
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 180;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.arc(-50, 50, 25, 0, -Math.PI/2, true);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(100, 0, 25, 0, -Math.PI/2, true);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,10 == 0,255,0,255;
+    @assert pixel 97,1 == 0,255,0,255;
+    @assert pixel 97,2 == 0,255,0,255;
+    @assert pixel 97,3 == 0,255,0,255;
+    @assert pixel 2,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.negative
+  desc: arc() with negative radius throws INDEX_SIZE_ERR
+  testing:
+  - 2d.path.arc.negative
+  code: |
+    @assert throws INDEX_SIZE_ERR ctx.arc(0, 0, -1, 0, 0, true);
+    var path = new Path2D();
+    @assert throws INDEX_SIZE_ERR path.arc(10, 10, -5, 0, 1, false);
+
+- name: 2d.path.arc.zeroradius
+  desc: arc() with zero radius draws a line to the start point
+  testing:
+  - 2d.path.arc.zero
+  code: |
+    ctx.fillStyle = '#f00'
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.lineWidth = 50;
+    ctx.strokeStyle = '#0f0';
+    ctx.beginPath();
+    ctx.moveTo(0, 25);
+    ctx.arc(200, 25, 0, 0, Math.PI, true);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.scale.1
+  desc: Non-uniformly scaled arcs are the right shape
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.scale(2, 0.5);
+    ctx.fillStyle = '#0f0';
+    ctx.beginPath();
+    ctx.arc(25, 50, 56, 0, 2*Math.PI, false);
+    ctx.fill();
+    ctx.fillStyle = '#f00';
+    ctx.beginPath();
+    ctx.moveTo(-25, 50);
+    ctx.arc(-25, 50, 24, 0, 2*Math.PI, false);
+    ctx.moveTo(75, 50);
+    ctx.arc(75, 50, 24, 0, 2*Math.PI, false);
+    ctx.moveTo(25, -25);
+    ctx.arc(25, -25, 24, 0, 2*Math.PI, false);
+    ctx.moveTo(25, 125);
+    ctx.arc(25, 125, 24, 0, 2*Math.PI, false);
+    ctx.fill();
+
+    @assert pixel 0,0 == 0,255,0,255;
+    @assert pixel 50,0 == 0,255,0,255;
+    @assert pixel 99,0 == 0,255,0,255;
+    @assert pixel 0,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 99,25 == 0,255,0,255;
+    @assert pixel 0,49 == 0,255,0,255;
+    @assert pixel 50,49 == 0,255,0,255;
+    @assert pixel 99,49 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.scale.2
+  desc: Highly scaled arcs are the right shape
+  testing:
+  - 2d.path.arc.draw
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.scale(100, 100);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    ctx.arc(0, 0, 0.6, 0, Math.PI/2, false);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.arc.nonfinite
+  desc: arc() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.arc(<0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <2*Math.PI Infinity -Infinity NaN>, <true>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.path.rect.basic
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.rect(0, 0, 100, 50);
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.newsubpath
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.moveTo(-100, 25);
+    ctx.lineTo(-50, 25);
+    ctx.rect(200, 25, 1, 1);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.closed
+  testing:
+  - 2d.path.rect.closed
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'miter';
+    ctx.rect(100, 50, 100, 100);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.end.1
+  testing:
+  - 2d.path.rect.newsubpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.rect(200, 100, 400, 1000);
+    ctx.lineTo(-2000, -1000);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.end.2
+  testing:
+  - 2d.path.rect.newsubpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 450;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'bevel';
+    ctx.rect(150, 150, 2000, 2000);
+    ctx.lineTo(160, 160);
+    ctx.stroke();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.zero.1
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.rect(0, 50, 100, 0);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.zero.2
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.rect(50, -100, 0, 250);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.zero.3
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.rect(50, 25, 0, 0);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.zero.4
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.rect(100, 25, 0, 0);
+    ctx.lineTo(0, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.zero.5
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.moveTo(0, 0);
+    ctx.rect(100, 25, 0, 0);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.rect.zero.6
+  testing:
+  - 2d.path.rect.subpath
+  #mozilla: { bug: TODO }
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineJoin = 'miter';
+    ctx.miterLimit = 1.5;
+    ctx.lineWidth = 200;
+    ctx.beginPath();
+    ctx.rect(100, 25, 1000, 0);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.rect.negative
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.fillStyle = '#0f0';
+    ctx.rect(0, 0, 50, 25);
+    ctx.rect(100, 0, -50, 25);
+    ctx.rect(0, 50, 50, -25);
+    ctx.rect(100, 50, -50, -25);
+    ctx.fill();
+    @assert pixel 25,12 == 0,255,0,255;
+    @assert pixel 75,12 == 0,255,0,255;
+    @assert pixel 25,37 == 0,255,0,255;
+    @assert pixel 75,37 == 0,255,0,255;
+
+- name: 2d.path.rect.winding
+  testing:
+  - 2d.path.rect.subpath
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.fillStyle = '#f00';
+    ctx.rect(0, 0, 50, 50);
+    ctx.rect(100, 50, -50, -50);
+    ctx.rect(0, 25, 100, -25);
+    ctx.rect(100, 25, -100, 25);
+    ctx.fill();
+    @assert pixel 25,12 == 0,255,0,255;
+    @assert pixel 75,12 == 0,255,0,255;
+    @assert pixel 25,37 == 0,255,0,255;
+    @assert pixel 75,37 == 0,255,0,255;
+
+- name: 2d.path.rect.selfintersect
+  #mozilla: { bug: TODO }
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 90;
+    ctx.beginPath();
+    ctx.rect(45, 20, 10, 10);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.rect.nonfinite
+  desc: rect() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.rect(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.newsubpath
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.moveTo(-100, 25);
+    ctx.lineTo(-50, 25);
+    ctx.roundRect(200, 25, 1, 1, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.closed
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'miter';
+    ctx.roundRect(100, 50, 100, 100, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.end.1
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.roundRect(200, 100, 400, 1000, [0]);
+    ctx.lineTo(-2000, -1000);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.end.2
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 450;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'bevel';
+    ctx.roundRect(150, 150, 2000, 2000, [0]);
+    ctx.lineTo(160, 160);
+    ctx.stroke();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.end.3
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.roundRect(101, 51, 2000, 2000, [500, 500, 500, 500]);
+    ctx.lineTo(-1, -1);
+    ctx.stroke();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.end.4
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 10;
+    ctx.roundRect(-1, -1, 2000, 2000, [1000, 1000, 1000, 1000]);
+    ctx.lineTo(-150, -150);
+    ctx.stroke();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.zero.1
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.roundRect(0, 50, 100, 0, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.zero.2
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.roundRect(50, -100, 0, 250, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.zero.3
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.beginPath();
+    ctx.roundRect(50, 25, 0, 0, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.zero.4
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 50;
+    ctx.roundRect(100, 25, 0, 0, [0]);
+    ctx.lineTo(0, 25);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.zero.5
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.moveTo(0, 0);
+    ctx.roundRect(100, 25, 0, 0, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.zero.6
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.lineJoin = 'miter';
+    ctx.miterLimit = 1.5;
+    ctx.lineWidth = 200;
+    ctx.beginPath();
+    ctx.roundRect(100, 25, 1000, 0, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.negative
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.fillStyle = '#0f0';
+    ctx.roundRect(0, 0, 50, 25, [10, 0, 0, 0]);
+    ctx.roundRect(100, 0, -50, 25, [10, 0, 0, 0]);
+    ctx.roundRect(0, 50, 50, -25, [10, 0, 0, 0]);
+    ctx.roundRect(100, 50, -50, -25, [10, 0, 0, 0]);
+    ctx.fill();
+    // All rects drawn
+    @assert pixel 25,12 == 0,255,0,255;
+    @assert pixel 75,12 == 0,255,0,255;
+    @assert pixel 25,37 == 0,255,0,255;
+    @assert pixel 75,37 == 0,255,0,255;
+    // Correct corners are rounded.
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.winding
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.beginPath();
+    ctx.fillStyle = '#f00';
+    ctx.roundRect(0, 0, 50, 50, [0]);
+    ctx.roundRect(100, 50, -50, -50, [0]);
+    ctx.roundRect(0, 25, 100, -25, [0]);
+    ctx.roundRect(100, 25, -100, 25, [0]);
+    ctx.fill();
+    @assert pixel 25,12 == 0,255,0,255;
+    @assert pixel 75,12 == 0,255,0,255;
+    @assert pixel 25,37 == 0,255,0,255;
+    @assert pixel 75,37 == 0,255,0,255;
+
+- name: 2d.path.roundrect.selfintersect
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.roundRect(0, 0, 100, 50, [0]);
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 90;
+    ctx.beginPath();
+    ctx.roundRect(45, 20, 10, 10, [0]);
+    ctx.stroke();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.nonfinite
+  desc: roundRect() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    @nonfinite ctx.roundRect(<0 Infinity -Infinity NaN>, <50 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>, <1 Infinity -Infinity NaN>, <[0] [Infinity] [-Infinity] [NaN] [Infinity,0] [-Infinity,0] [NaN,0] [0,Infinity] [0,-Infinity] [0,NaN] [Infinity,0,0] [-Infinity,0,0] [NaN,0,0] [0,Infinity,0] [0,-Infinity,0] [0,NaN,0] [0,0,Infinity] [0,0,-Infinity] [0,0,NaN] [Infinity,0,0,0] [-Infinity,0,0,0] [NaN,0,0,0] [0,Infinity,0,0] [0,-Infinity,0,0] [0,NaN,0,0] [0,0,Infinity,0] [0,0,-Infinity,0] [0,0,NaN,0] [0,0,0,Infinity] [0,0,0,-Infinity] [0,0,0,NaN]>);
+    ctx.roundRect(0, 0, 100, 100, [new DOMPoint(10, Infinity)]);
+    ctx.roundRect(0, 0, 100, 100, [new DOMPoint(10, -Infinity)]);
+    ctx.roundRect(0, 0, 100, 100, [new DOMPoint(10, NaN)]);
+    ctx.roundRect(0, 0, 100, 100, [new DOMPoint(Infinity, 10)]);
+    ctx.roundRect(0, 0, 100, 100, [new DOMPoint(-Infinity, 10)]);
+    ctx.roundRect(0, 0, 100, 100, [new DOMPoint(NaN, 10)]);
+    ctx.roundRect(0, 0, 100, 100, [{x: 10, y: Infinity}]);
+    ctx.roundRect(0, 0, 100, 100, [{x: 10, y: -Infinity}]);
+    ctx.roundRect(0, 0, 100, 100, [{x: 10, y: NaN}]);
+    ctx.roundRect(0, 0, 100, 100, [{x: Infinity, y: 10}]);
+    ctx.roundRect(0, 0, 100, 100, [{x: -Infinity, y: 10}]);
+    ctx.roundRect(0, 0, 100, 100, [{x: NaN, y: 10}]);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 90,45 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.roundrect.4.radii.1.double
+  desc: Verify that when four radii are given to roundRect(), the first radius, specified as a double, applies to the top-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [20, 0, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.1.dompoint
+  desc: Verify that when four radii are given to roundRect(), the first radius, specified as a DOMPoint, applies to the top-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20), 0, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.1.dompointinit
+  desc: Verify that when four radii are given to roundRect(), the first radius, specified as a DOMPointInit, applies to the top-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}, 0, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.2.double
+  desc: Verify that when four radii are given to roundRect(), the second radius, specified as a double, applies to the top-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 20, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.2.dompoint
+  desc: Verify that when four radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, new DOMPoint(40, 20), 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.2.dompointinit
+  desc: Verify that when four radii are given to roundRect(), the second radius, specified as a DOMPointInit, applies to the top-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, {x: 40, y: 20}, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.3.double
+  desc: Verify that when four radii are given to roundRect(), the third radius, specified as a double, applies to the bottom-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, 20, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.3.dompoint
+  desc: Verify that when four radii are given to roundRect(), the third radius, specified as a DOMPoint, applies to the bottom-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, new DOMPoint(40, 20), 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.3.dompointinit
+  desc: Verify that when four radii are given to roundRect(), the third radius, specified as a DOMPointInit, applies to the bottom-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, {x: 40, y: 20}, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.4.double
+  desc: Verify that when four radii are given to roundRect(), the fourth radius, specified as a double, applies to the bottom-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, 0, 20]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.4.radii.4.dompoint
+  desc: Verify that when four radii are given to roundRect(), the fourth radius, specified as a DOMPoint, applies to the bottom-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, 0, new DOMPoint(40, 20)]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.4.radii.4.dompointinit
+  desc: Verify that when four radii are given to roundRect(), the fourth radius, specified as a DOMPointInit, applies to the bottom-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, 0, {x: 40, y: 20}]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.1.double
+  desc: Verify that when three radii are given to roundRect(), the first radius, specified as a double, applies to the top-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [20, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.1.dompoint
+  desc: Verify that when three radii are given to roundRect(), the first radius, specified as a DOMPoint, applies to the top-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20), 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.1.dompointinit
+  desc: Verify that when three radii are given to roundRect(), the first radius, specified as a DOMPointInit, applies to the top-left corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}, 0, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.2.double
+  desc: Verify that when three radii are given to roundRect(), the second radius, specified as a double, applies to the top-right and bottom-left corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 20, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.3.radii.2.dompoint
+  desc: Verify that when three radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right and bottom-left corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, new DOMPoint(40, 20), 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.2.dompointinit
+  desc: Verify that when three radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right and bottom-left corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, {x: 40, y: 20}, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.3.double
+  desc: Verify that when three radii are given to roundRect(), the third radius, specified as a double, applies to the bottom-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, 20]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.3.dompoint
+  desc: Verify that when three radii are given to roundRect(), the third radius, specified as a DOMPoint, applies to the bottom-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, new DOMPoint(40, 20)]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.3.radii.3.dompointinit
+  desc: Verify that when three radii are given to roundRect(), the third radius, specified as a DOMPointInit, applies to the bottom-right corner.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 0, {x: 40, y: 20}]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.2.radii.1.double
+  desc: Verify that when two radii are given to roundRect(), the first radius, specified as a double, applies to the top-left and bottom-right corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [20, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.2.radii.1.dompoint
+  desc: Verify that when two radii are given to roundRect(), the first radius, specified as a DOMPoint, applies to the top-left and bottom-right corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20), 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.2.radii.1.dompointinit
+  desc: Verify that when two radii are given to roundRect(), the first radius, specified as a DOMPointInit, applies to the top-left and bottom-right corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}, 0]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 98,1 == 0,255,0,255;
+    @assert pixel 1,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.2.radii.2.double
+  desc: Verify that when two radii are given to roundRect(), the second radius, specified as a double, applies to the top-right and bottom-left corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, 20]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.2.radii.2.dompoint
+  desc: Verify that when two radii are given to roundRect(), the second radius, specified as a DOMPoint, applies to the top-right and bottom-left corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, new DOMPoint(40, 20)]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.2.radii.2.dompointinit
+  desc: Verify that when two radii are given to roundRect(), the second radius, specified as a DOMPointInit, applies to the top-right and bottom-left corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [0, {x: 40, y: 20}]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+    // other corners
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+
+- name: 2d.path.roundrect.1.radius.double
+  desc: Verify that when one radius is given to roundRect(), specified as a double, it applies to all corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [20]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.1.radius.double.single.argument
+  desc: Verify that when one radius is given to roundRect() as a non-array argument, specified as a double, it applies to all corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, 20);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.1.radius.dompoint
+  desc: Verify that when one radius is given to roundRect(), specified as a DOMPoint, it applies to all corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [new DOMPoint(40, 20)]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+- name: 2d.path.roundrect.1.radius.dompoint.single argument
+  desc: Verify that when one radius is given to roundRect() as a non-array argument, specified as a DOMPoint, it applies to all corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, new DOMPoint(40, 20));
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+- name: 2d.path.roundrect.1.radius.dompointinit
+  desc: Verify that when one radius is given to roundRect(), specified as a DOMPointInit, applies to all corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [{x: 40, y: 20}]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+- name: 2d.path.roundrect.1.radius.dompointinit.single.argument
+  desc: Verify that when one radius is given to roundRect() as a non-array argument, specified as a DOMPointInit, applies to all corners.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, {x: 40, y: 20});
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    // top-left corner
+    @assert pixel 20,1 == 255,0,0,255;
+    @assert pixel 41,1 == 0,255,0,255;
+    @assert pixel 1,10 == 255,0,0,255;
+    @assert pixel 1,21 == 0,255,0,255;
+
+    // top-right corner
+    @assert pixel 79,1 == 255,0,0,255;
+    @assert pixel 58,1 == 0,255,0,255;
+    @assert pixel 98,10 == 255,0,0,255;
+    @assert pixel 98,21 == 0,255,0,255;
+
+    // bottom-right corner
+    @assert pixel 79,48 == 255,0,0,255;
+    @assert pixel 58,48 == 0,255,0,255;
+    @assert pixel 98,39 == 255,0,0,255;
+    @assert pixel 98,28 == 0,255,0,255;
+
+    // bottom-left corner
+    @assert pixel 20,48 == 255,0,0,255;
+    @assert pixel 41,48 == 0,255,0,255;
+    @assert pixel 1,39 == 255,0,0,255;
+    @assert pixel 1,28 == 0,255,0,255;
+
+- name: 2d.path.roundrect.radius.intersecting.1
+  desc: Check that roundRects with intersecting corner arcs are rendered correctly.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [40, 40, 40, 40]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 2,25 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 97,25 == 0,255,0,255;
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.radius.intersecting.2
+  desc: Check that roundRects with intersecting corner arcs are rendered correctly.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(0, 0, 100, 50, [1000, 1000, 1000, 1000]);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 2,25 == 0,255,0,255;
+    @assert pixel 50,1 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 50,48 == 0,255,0,255;
+    @assert pixel 97,25 == 0,255,0,255;
+    @assert pixel 1,1 == 255,0,0,255;
+    @assert pixel 98,1 == 255,0,0,255;
+    @assert pixel 1,48 == 255,0,0,255;
+    @assert pixel 98,48 == 255,0,0,255;
+
+- name: 2d.path.roundrect.radius.none
+  desc: Check that roundRect throws an RangeError if radii is an empty array.
+  code: |
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 100, 50, [])});
+
+- name: 2d.path.roundrect.radius.noargument
+  desc: Check that roundRect draws a rectangle when no radii are provided.
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.roundRect(10, 10, 80, 30);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    // upper left corner (10, 10)
+    @assert pixel 10,9 == 255,0,0,255;
+    @assert pixel 9,10 == 255,0,0,255;
+    @assert pixel 10,10 == 0,255,0,255;
+
+    // upper right corner (89, 10)
+    @assert pixel 90,10 == 255,0,0,255;
+    @assert pixel 89,9 == 255,0,0,255;
+    @assert pixel 89,10 == 0,255,0,255;
+
+    // lower right corner (89, 39)
+    @assert pixel 89,40 == 255,0,0,255;
+    @assert pixel 90,39 == 255,0,0,255;
+    @assert pixel 89,39 == 0,255,0,255;
+
+    // lower left corner (10, 30)
+    @assert pixel 9,39 == 255,0,0,255;
+    @assert pixel 10,40 == 255,0,0,255;
+    @assert pixel 10,39 == 0,255,0,255;
+
+- name: 2d.path.roundrect.radius.toomany
+  desc: Check that roundRect throws an IndeSizeError if radii has more than four items.
+  code: |
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 100, 50, [0, 0, 0, 0, 0])});
+
+- name: 2d.path.roundrect.radius.negative
+  desc: roundRect() with negative radius throws an exception
+  code: |
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [-1])});
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [1, -1])});
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [new DOMPoint(-1, 1), 1])});
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [new DOMPoint(1, -1)])});
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [{x: -1, y: 1}, 1])});
+    assert_throws_js(RangeError, () => { ctx.roundRect(0, 0, 0, 0, [{x: 1, y: -1}])});
+
+- name: 2d.path.ellipse.basics
+  desc: Verify canvas throws error when drawing ellipse with negative radii.
+  testing:
+  - 2d.ellipse.basics
+  code: |
+    ctx.ellipse(10, 10, 10, 5, 0, 0, 1, false);
+    ctx.ellipse(10, 10, 10, 0, 0, 0, 1, false);
+    ctx.ellipse(10, 10, -0, 5, 0, 0, 1, false);
+    @assert throws INDEX_SIZE_ERR ctx.ellipse(10, 10, -2, 5, 0, 0, 1, false);
+    @assert throws INDEX_SIZE_ERR ctx.ellipse(10, 10, 0, -1.5, 0, 0, 1, false);
+    @assert throws INDEX_SIZE_ERR ctx.ellipse(10, 10, -2, -5, 0, 0, 1, false);
+    ctx.ellipse(80, 0, 10, 4294967277, Math.PI / -84, -Math.PI / 2147483436, false);
+
+- name: 2d.path.fill.overlap
+  testing:
+  - 2d.path.fill.basic
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = 'rgba(0, 255, 0, 0.5)';
+    ctx.rect(0, 0, 100, 50);
+    ctx.closePath();
+    ctx.rect(10, 10, 80, 30);
+    ctx.fill();
+
+    @assert pixel 50,25 ==~ 0,127,0,255 +/- 1;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0, 0.5, 0)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.path.fill.winding.add
+  testing:
+  - 2d.path.fill.basic
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.moveTo(-10, -10);
+    ctx.lineTo(110, -10);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(-10, 60);
+    ctx.lineTo(-10, -10);
+    ctx.lineTo(0, 0);
+    ctx.lineTo(100, 0);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.fill.winding.subtract.1
+  testing:
+  - 2d.path.fill.basic
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.moveTo(-10, -10);
+    ctx.lineTo(110, -10);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(-10, 60);
+    ctx.lineTo(-10, -10);
+    ctx.lineTo(0, 0);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(100, 0);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.fill.winding.subtract.2
+  testing:
+  - 2d.path.fill.basic
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.moveTo(-10, -10);
+    ctx.lineTo(110, -10);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(-10, 60);
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(100, 0);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.fill.winding.subtract.3
+  testing:
+  - 2d.path.fill.basic
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.moveTo(-10, -10);
+    ctx.lineTo(110, -10);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(-10, 60);
+    ctx.lineTo(-10, -10);
+    ctx.lineTo(-20, -20);
+    ctx.lineTo(120, -20);
+    ctx.lineTo(120, 70);
+    ctx.lineTo(-20, 70);
+    ctx.lineTo(-20, -20);
+    ctx.lineTo(0, 0);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(100, 0);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.fill.closed.basic
+  testing:
+  - 2d.path.fill.closed
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(0, 50);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.fill.closed.unaffected
+  testing:
+  - 2d.path.fill.closed
+  code: |
+    ctx.fillStyle = '#00f';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.moveTo(0, 0);
+    ctx.lineTo(100, 0);
+    ctx.lineTo(100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fill();
+    ctx.lineTo(0, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    @assert pixel 90,10 == 0,255,0,255;
+    @assert pixel 10,40 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.overlap
+  desc: Stroked subpaths are combined before being drawn
+  testing:
+  - 2d.path.stroke.basic
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = 'rgba(0, 255, 0, 0.5)';
+    ctx.lineWidth = 50;
+    ctx.moveTo(0, 20);
+    ctx.lineTo(100, 20);
+    ctx.moveTo(0, 30);
+    ctx.lineTo(100, 30);
+    ctx.stroke();
+
+    @assert pixel 50,25 ==~ 0,127,0,255 +/- 1;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0, 0.5, 0)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.path.stroke.union
+  desc: Strokes in opposite directions are unioned, not subtracted
+  testing:
+  - 2d.path.stroke.basic
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 40;
+    ctx.moveTo(0, 10);
+    ctx.lineTo(100, 10);
+    ctx.moveTo(100, 40);
+    ctx.lineTo(0, 40);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.unaffected
+  desc: Stroking does not start a new path or subpath
+  testing:
+  - 2d.path.stroke.basic
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.lineWidth = 50;
+    ctx.moveTo(-100, 25);
+    ctx.lineTo(-100, -100);
+    ctx.lineTo(200, -100);
+    ctx.lineTo(200, 25);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+
+    ctx.closePath();
+    ctx.strokeStyle = '#0f0';
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.scale1
+  desc: Stroke line widths are scaled by the current transformation matrix
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.rect(25, 12.5, 50, 25);
+    ctx.save();
+    ctx.scale(50, 25);
+    ctx.strokeStyle = '#0f0';
+    ctx.stroke();
+    ctx.restore();
+
+    ctx.beginPath();
+    ctx.rect(-25, -12.5, 150, 75);
+    ctx.save();
+    ctx.scale(50, 25);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+    ctx.restore();
+
+    @assert pixel 0,0 == 0,255,0,255;
+    @assert pixel 50,0 == 0,255,0,255;
+    @assert pixel 99,0 == 0,255,0,255;
+    @assert pixel 0,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 99,25 == 0,255,0,255;
+    @assert pixel 0,49 == 0,255,0,255;
+    @assert pixel 50,49 == 0,255,0,255;
+    @assert pixel 99,49 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.scale2
+  desc: Stroke line widths are scaled by the current transformation matrix
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.rect(25, 12.5, 50, 25);
+    ctx.save();
+    ctx.rotate(Math.PI/2);
+    ctx.scale(25, 50);
+    ctx.strokeStyle = '#0f0';
+    ctx.stroke();
+    ctx.restore();
+
+    ctx.beginPath();
+    ctx.rect(-25, -12.5, 150, 75);
+    ctx.save();
+    ctx.rotate(Math.PI/2);
+    ctx.scale(25, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+    ctx.restore();
+
+    @assert pixel 0,0 == 0,255,0,255;
+    @assert pixel 50,0 == 0,255,0,255;
+    @assert pixel 99,0 == 0,255,0,255;
+    @assert pixel 0,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 99,25 == 0,255,0,255;
+    @assert pixel 0,49 == 0,255,0,255;
+    @assert pixel 50,49 == 0,255,0,255;
+    @assert pixel 99,49 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.skew
+  desc: Strokes lines are skewed by the current transformation matrix
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(49, -50);
+    ctx.lineTo(201, -50);
+    ctx.rotate(Math.PI/4);
+    ctx.scale(1, 283);
+    ctx.strokeStyle = '#0f0';
+    ctx.stroke();
+    ctx.restore();
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.translate(-150, 0);
+    ctx.moveTo(49, -50);
+    ctx.lineTo(199, -50);
+    ctx.rotate(Math.PI/4);
+    ctx.scale(1, 142);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+    ctx.restore();
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.translate(-150, 0);
+    ctx.moveTo(49, -50);
+    ctx.lineTo(199, -50);
+    ctx.rotate(Math.PI/4);
+    ctx.scale(1, 142);
+    ctx.strokeStyle = '#f00';
+    ctx.stroke();
+    ctx.restore();
+
+    @assert pixel 0,0 == 0,255,0,255;
+    @assert pixel 50,0 == 0,255,0,255;
+    @assert pixel 99,0 == 0,255,0,255;
+    @assert pixel 0,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 99,25 == 0,255,0,255;
+    @assert pixel 0,49 == 0,255,0,255;
+    @assert pixel 50,49 == 0,255,0,255;
+    @assert pixel 99,49 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.empty
+  desc: Empty subpaths are not stroked
+  testing:
+  - 2d.path.stroke.empty
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.moveTo(40, 25);
+    ctx.moveTo(60, 25);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.stroke.prune.line
+  desc: Zero-length line segments from lineTo are removed before stroking
+  testing:
+  - 2d.path.stroke.prune
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.lineTo(50, 25);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.stroke.prune.closed
+  desc: Zero-length line segments from closed paths are removed before stroking
+  testing:
+  - 2d.path.stroke.prune
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.lineTo(50, 25);
+    ctx.closePath();
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.stroke.prune.curve
+  desc: Zero-length line segments from quadraticCurveTo and bezierCurveTo are removed
+    before stroking
+  testing:
+  - 2d.path.stroke.prune
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.quadraticCurveTo(50, 25, 50, 25);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.bezierCurveTo(50, 25, 50, 25, 50, 25);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.stroke.prune.arc
+  desc: Zero-length line segments from arcTo and arc are removed before stroking
+  testing:
+  - 2d.path.stroke.prune
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.moveTo(50, 25);
+    ctx.arcTo(50, 25, 150, 25, 10);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(60, 25);
+    ctx.arc(50, 25, 10, 0, 0, false);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.stroke.prune.rect
+  desc: Zero-length line segments from rect and strokeRect are removed before stroking
+  testing:
+  - 2d.path.stroke.prune
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 100;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.rect(50, 25, 0, 0);
+    ctx.stroke();
+
+    ctx.strokeRect(50, 25, 0, 0);
+
+    @assert pixel 50,25 == 0,255,0,255; @moz-todo
+  expected: green
+
+- name: 2d.path.stroke.prune.corner
+  desc: Zero-length line segments are removed before stroking with miters
+  testing:
+  - 2d.path.stroke.prune
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 400;
+    ctx.lineJoin = 'miter';
+    ctx.miterLimit = 1.4;
+
+    ctx.beginPath();
+    ctx.moveTo(-1000, 200);
+    ctx.lineTo(-100, 200);
+    ctx.lineTo(-100, 200);
+    ctx.lineTo(-100, 200);
+    ctx.lineTo(-100, 1000);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.path.transformation.basic
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(-100, 0);
+    ctx.rect(100, 0, 100, 50);
+    ctx.translate(0, -100);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.transformation.multiple
+  # TODO: change this name
+  desc: Transformations are applied while building paths, not when drawing
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.translate(-100, 0);
+    ctx.rect(0, 0, 100, 50);
+    ctx.fill();
+    ctx.translate(100, 0);
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.strokeStyle = '#f00';
+    ctx.lineWidth = 50;
+    ctx.translate(0, -50);
+    ctx.moveTo(0, 25);
+    ctx.lineTo(100, 25);
+    ctx.stroke();
+    ctx.translate(0, 50);
+    ctx.stroke();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.transformation.changing
+  desc: Transformations are applied while building paths, not when drawing
+  testing:
+  - 2d.path.transformation
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.moveTo(0, 0);
+    ctx.translate(100, 0);
+    ctx.lineTo(0, 0);
+    ctx.translate(0, 50);
+    ctx.lineTo(0, 0);
+    ctx.translate(-100, 0);
+    ctx.lineTo(0, 0);
+    ctx.translate(1000, 1000);
+    ctx.rotate(Math.PI/2);
+    ctx.scale(0.1, 0.1);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.path.clip.empty
+  testing:
+  - 2d.path.clip.basic
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.clip();
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.clip.basic.1
+  testing:
+  - 2d.path.clip.basic
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.rect(0, 0, 100, 50);
+    ctx.clip();
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.clip.basic.2
+  testing:
+  - 2d.path.clip.basic
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.rect(-100, 0, 100, 50);
+    ctx.clip();
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.clip.intersect
+  testing:
+  - 2d.path.clip.basic
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.rect(0, 0, 50, 50);
+    ctx.clip();
+    ctx.beginPath();
+    ctx.rect(50, 0, 50, 50)
+    ctx.clip();
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.clip.winding.1
+  testing:
+  - 2d.path.clip.basic
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.moveTo(-10, -10);
+    ctx.lineTo(110, -10);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(-10, 60);
+    ctx.lineTo(-10, -10);
+    ctx.lineTo(0, 0);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(100, 0);
+    ctx.clip();
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.clip.winding.2
+  testing:
+  - 2d.path.clip.basic
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.beginPath();
+    ctx.moveTo(-10, -10);
+    ctx.lineTo(110, -10);
+    ctx.lineTo(110, 60);
+    ctx.lineTo(-10, 60);
+    ctx.lineTo(-10, -10);
+    ctx.clip();
+
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(100, 0);
+    ctx.lineTo(0, 0);
+    ctx.clip();
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.path.clip.unaffected
+  testing:
+  - 2d.path.clip.closed
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(100, 50);
+    ctx.lineTo(100, 0);
+    ctx.clip();
+
+    ctx.lineTo(0, 0);
+    ctx.fill();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+
+
+- name: 2d.path.isPointInPath.basic.1
+  desc: isPointInPath() detects whether the point is inside the path
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.rect(0, 0, 20, 20);
+    @assert ctx.isPointInPath(10, 10) === true;
+    @assert ctx.isPointInPath(30, 10) === false;
+
+- name: 2d.path.isPointInPath.basic.2
+  desc: isPointInPath() detects whether the point is inside the path
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.rect(20, 0, 20, 20);
+    @assert ctx.isPointInPath(10, 10) === false;
+    @assert ctx.isPointInPath(30, 10) === true;
+
+- name: 2d.path.isPointInPath.edge
+  desc: isPointInPath() counts points on the path as being inside
+  testing:
+  - 2d.path.isPointInPath.edge
+  code: |
+    ctx.rect(0, 0, 20, 20);
+    @assert ctx.isPointInPath(0, 0) === true;
+    @assert ctx.isPointInPath(10, 0) === true;
+    @assert ctx.isPointInPath(20, 0) === true;
+    @assert ctx.isPointInPath(20, 10) === true;
+    @assert ctx.isPointInPath(20, 20) === true;
+    @assert ctx.isPointInPath(10, 20) === true;
+    @assert ctx.isPointInPath(0, 20) === true;
+    @assert ctx.isPointInPath(0, 10) === true;
+    @assert ctx.isPointInPath(10, -0.01) === false;
+    @assert ctx.isPointInPath(10, 20.01) === false;
+    @assert ctx.isPointInPath(-0.01, 10) === false;
+    @assert ctx.isPointInPath(20.01, 10) === false;
+
+- name: 2d.path.isPointInPath.empty
+  desc: isPointInPath() works when there is no path
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    @assert ctx.isPointInPath(0, 0) === false;
+
+- name: 2d.path.isPointInPath.subpath
+  desc: isPointInPath() uses the current path, not just the subpath
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.rect(0, 0, 20, 20);
+    ctx.beginPath();
+    ctx.rect(20, 0, 20, 20);
+    ctx.closePath();
+    ctx.rect(40, 0, 20, 20);
+    @assert ctx.isPointInPath(10, 10) === false;
+    @assert ctx.isPointInPath(30, 10) === true;
+    @assert ctx.isPointInPath(50, 10) === true;
+
+- name: 2d.path.isPointInPath.outside
+  desc: isPointInPath() works on paths outside the canvas
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.rect(0, -100, 20, 20);
+    ctx.rect(20, -10, 20, 20);
+    @assert ctx.isPointInPath(10, -110) === false;
+    @assert ctx.isPointInPath(10, -90) === true;
+    @assert ctx.isPointInPath(10, -70) === false;
+    @assert ctx.isPointInPath(30, -20) === false;
+    @assert ctx.isPointInPath(30, 0) === true;
+    @assert ctx.isPointInPath(30, 20) === false;
+
+- name: 2d.path.isPointInPath.unclosed
+  desc: isPointInPath() works on unclosed subpaths
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.moveTo(0, 0);
+    ctx.lineTo(20, 0);
+    ctx.lineTo(20, 20);
+    ctx.lineTo(0, 20);
+    @assert ctx.isPointInPath(10, 10) === true;
+    @assert ctx.isPointInPath(30, 10) === false;
+
+- name: 2d.path.isPointInPath.arc
+  desc: isPointInPath() works on arcs
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.arc(50, 25, 10, 0, Math.PI, false);
+    @assert ctx.isPointInPath(50, 10) === false;
+    @assert ctx.isPointInPath(50, 20) === false;
+    @assert ctx.isPointInPath(50, 30) === true;
+    @assert ctx.isPointInPath(50, 40) === false;
+    @assert ctx.isPointInPath(30, 20) === false;
+    @assert ctx.isPointInPath(70, 20) === false;
+    @assert ctx.isPointInPath(30, 30) === false;
+    @assert ctx.isPointInPath(70, 30) === false;
+
+- name: 2d.path.isPointInPath.bigarc
+  desc: isPointInPath() works on unclosed arcs larger than 2pi
+  opera: {bug: 320937}
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.arc(50, 25, 10, 0, 7, false);
+    @assert ctx.isPointInPath(50, 10) === false;
+    @assert ctx.isPointInPath(50, 20) === true;
+    @assert ctx.isPointInPath(50, 30) === true;
+    @assert ctx.isPointInPath(50, 40) === false;
+    @assert ctx.isPointInPath(30, 20) === false;
+    @assert ctx.isPointInPath(70, 20) === false;
+    @assert ctx.isPointInPath(30, 30) === false;
+    @assert ctx.isPointInPath(70, 30) === false;
+
+- name: 2d.path.isPointInPath.bezier
+  desc: isPointInPath() works on Bezier curves
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.moveTo(25, 25);
+    ctx.bezierCurveTo(50, -50, 50, 100, 75, 25);
+    @assert ctx.isPointInPath(25, 20) === false;
+    @assert ctx.isPointInPath(25, 30) === false;
+    @assert ctx.isPointInPath(30, 20) === true;
+    @assert ctx.isPointInPath(30, 30) === false;
+    @assert ctx.isPointInPath(40, 2) === false;
+    @assert ctx.isPointInPath(40, 20) === true;
+    @assert ctx.isPointInPath(40, 30) === false;
+    @assert ctx.isPointInPath(40, 47) === false;
+    @assert ctx.isPointInPath(45, 20) === true;
+    @assert ctx.isPointInPath(45, 30) === false;
+    @assert ctx.isPointInPath(55, 20) === false;
+    @assert ctx.isPointInPath(55, 30) === true;
+    @assert ctx.isPointInPath(60, 2) === false;
+    @assert ctx.isPointInPath(60, 20) === false;
+    @assert ctx.isPointInPath(60, 30) === true;
+    @assert ctx.isPointInPath(60, 47) === false;
+    @assert ctx.isPointInPath(70, 20) === false;
+    @assert ctx.isPointInPath(70, 30) === true;
+    @assert ctx.isPointInPath(75, 20) === false;
+    @assert ctx.isPointInPath(75, 30) === false;
+
+- name: 2d.path.isPointInPath.winding
+  desc: isPointInPath() uses the non-zero winding number rule
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    // Create a square ring, using opposite windings to make a hole in the centre
+    ctx.moveTo(0, 0);
+    ctx.lineTo(50, 0);
+    ctx.lineTo(50, 50);
+    ctx.lineTo(0, 50);
+    ctx.lineTo(0, 0);
+    ctx.lineTo(10, 10);
+    ctx.lineTo(10, 40);
+    ctx.lineTo(40, 40);
+    ctx.lineTo(40, 10);
+    ctx.lineTo(10, 10);
+
+    @assert ctx.isPointInPath(5, 5) === true;
+    @assert ctx.isPointInPath(25, 5) === true;
+    @assert ctx.isPointInPath(45, 5) === true;
+    @assert ctx.isPointInPath(5, 25) === true;
+    @assert ctx.isPointInPath(25, 25) === false;
+    @assert ctx.isPointInPath(45, 25) === true;
+    @assert ctx.isPointInPath(5, 45) === true;
+    @assert ctx.isPointInPath(25, 45) === true;
+    @assert ctx.isPointInPath(45, 45) === true;
+
+- name: 2d.path.isPointInPath.transform.1
+  desc: isPointInPath() handles transformations correctly
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.translate(50, 0);
+    ctx.rect(0, 0, 20, 20);
+    @assert ctx.isPointInPath(-40, 10) === false;
+    @assert ctx.isPointInPath(10, 10) === false;
+    @assert ctx.isPointInPath(49, 10) === false;
+    @assert ctx.isPointInPath(51, 10) === true;
+    @assert ctx.isPointInPath(69, 10) === true;
+    @assert ctx.isPointInPath(71, 10) === false;
+
+- name: 2d.path.isPointInPath.transform.2
+  desc: isPointInPath() handles transformations correctly
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.rect(50, 0, 20, 20);
+    ctx.translate(50, 0);
+    @assert ctx.isPointInPath(-40, 10) === false;
+    @assert ctx.isPointInPath(10, 10) === false;
+    @assert ctx.isPointInPath(49, 10) === false;
+    @assert ctx.isPointInPath(51, 10) === true;
+    @assert ctx.isPointInPath(69, 10) === true;
+    @assert ctx.isPointInPath(71, 10) === false;
+
+- name: 2d.path.isPointInPath.transform.3
+  desc: isPointInPath() handles transformations correctly
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.scale(-1, 1);
+    ctx.rect(-70, 0, 20, 20);
+    @assert ctx.isPointInPath(-40, 10) === false;
+    @assert ctx.isPointInPath(10, 10) === false;
+    @assert ctx.isPointInPath(49, 10) === false;
+    @assert ctx.isPointInPath(51, 10) === true;
+    @assert ctx.isPointInPath(69, 10) === true;
+    @assert ctx.isPointInPath(71, 10) === false;
+
+- name: 2d.path.isPointInPath.transform.4
+  desc: isPointInPath() handles transformations correctly
+  testing:
+  - 2d.path.isPointInPath
+  code: |
+    ctx.translate(50, 0);
+    ctx.rect(50, 0, 20, 20);
+    ctx.translate(0, 50);
+    @assert ctx.isPointInPath(60, 10) === false;
+    @assert ctx.isPointInPath(110, 10) === true;
+    @assert ctx.isPointInPath(110, 60) === false;
+
+- name: 2d.path.isPointInPath.nonfinite
+  desc: isPointInPath() returns false for non-finite arguments
+  testing:
+  - 2d.path.isPointInPath.nonfinite
+  code: |
+    ctx.rect(-100, -50, 200, 100);
+    @assert ctx.isPointInPath(Infinity, 0) === false;
+    @assert ctx.isPointInPath(-Infinity, 0) === false;
+    @assert ctx.isPointInPath(NaN, 0) === false;
+    @assert ctx.isPointInPath(0, Infinity) === false;
+    @assert ctx.isPointInPath(0, -Infinity) === false;
+    @assert ctx.isPointInPath(0, NaN) === false;
+    @assert ctx.isPointInPath(NaN, NaN) === false;
+
+
+- name: 2d.path.isPointInStroke.scaleddashes
+  desc: isPointInStroke() should return correct results on dashed paths at high scale
+    factors
+  testing:
+  - 2d.path.isPointInStroke
+  code: |
+    var scale = 20;
+    ctx.setLineDash([10, 21.4159]); // dash from t=0 to t=10 along the circle
+    ctx.scale(scale, scale);
+    ctx.ellipse(6, 10, 5, 5, 0, 2*Math.PI, false);
+    ctx.stroke();
+
+    // hit-test the beginning of the dash (t=0)
+    @assert ctx.isPointInStroke(11*scale, 10*scale) === true;
+    // hit-test the middle of the dash (t=5)
+    @assert ctx.isPointInStroke(8.70*scale, 14.21*scale) === true;
+    // hit-test the end of the dash (t=9.8)
+    @assert ctx.isPointInStroke(4.10*scale, 14.63*scale) === true;
+    // hit-test past the end of the dash (t=10.2)
+    @assert ctx.isPointInStroke(3.74*scale, 14.46*scale) === false;
+
+- name: 2d.path.isPointInPath.basic
+  desc: Verify the winding rule in isPointInPath works for for rect path.
+  testing:
+  - 2d.isPointInPath.basic
+  code: |
+    canvas.width = 200;
+    canvas.height = 200;
+
+    // Testing default isPointInPath
+    ctx.beginPath();
+    ctx.rect(0, 0, 100, 100);
+    ctx.rect(25, 25, 50, 50);
+    @assert ctx.isPointInPath(50, 50) === true;
+    @assert ctx.isPointInPath(NaN, 50) === false;
+    @assert ctx.isPointInPath(50, NaN) === false;
+
+    // Testing nonzero isPointInPath
+    ctx.beginPath();
+    ctx.rect(0, 0, 100, 100);
+    ctx.rect(25, 25, 50, 50);
+    @assert ctx.isPointInPath(50, 50, 'nonzero') === true;
+
+    // Testing evenodd isPointInPath
+    ctx.beginPath();
+    ctx.rect(0, 0, 100, 100);
+    ctx.rect(25, 25, 50, 50);
+    @assert ctx.isPointInPath(50, 50, 'evenodd') === false;
+
+    // Testing extremely large scale
+    ctx.save();
+    ctx.scale(Number.MAX_VALUE, Number.MAX_VALUE);
+    ctx.beginPath();
+    ctx.rect(-10, -10, 20, 20);
+    @assert ctx.isPointInPath(0, 0, 'nonzero') === true;
+    @assert ctx.isPointInPath(0, 0, 'evenodd') === true;
+    ctx.restore();
+
+    // Check with non-invertible ctm.
+    ctx.save();
+    ctx.scale(0, 0);
+    ctx.beginPath();
+    ctx.rect(-10, -10, 20, 20);
+    @assert ctx.isPointInPath(0, 0, 'nonzero') === false;
+    @assert ctx.isPointInPath(0, 0, 'evenodd') === false;
+    ctx.restore();
+
+- name: 2d.path.isPointInpath.multi.path
+  desc: Verify the winding rule in isPointInPath works for path object.
+  testing:
+  - 2d.isPointInPath.basic
+  code: |
+    canvas.width = 200;
+    canvas.height = 200;
+
+    // Testing default isPointInPath with Path object');
+    path = new Path2D();
+    path.rect(0, 0, 100, 100);
+    path.rect(25, 25, 50, 50);
+    @assert ctx.isPointInPath(path, 50, 50) === true;
+    @assert ctx.isPointInPath(path, 50, 50, undefined) === true;
+    @assert ctx.isPointInPath(path, NaN, 50) === false;
+    @assert ctx.isPointInPath(path, 50, NaN) === false;
+
+    // Testing nonzero isPointInPath with Path object');
+    path = new Path2D();
+    path.rect(0, 0, 100, 100);
+    path.rect(25, 25, 50, 50);
+    @assert ctx.isPointInPath(path, 50, 50, 'nonzero') === true;
+
+    // Testing evenodd isPointInPath with Path object');
+    path = new Path2D();
+    path.rect(0, 0, 100, 100);
+    path.rect(25, 25, 50, 50);
+    assert_false(ctx.isPointInPath(path, 50, 50, 'evenodd'));
+
+- name: 2d.path.isPointInpath.invalid
+  desc: Verify isPointInPath throws exceptions with invalid inputs.
+  testing:
+  - 2d.isPointInPath.basic
+  code: |
+    canvas.width = 200;
+    canvas.height = 200;
+    path = new Path2D();
+    path.rect(0, 0, 100, 100);
+    path.rect(25, 25, 50, 50);
+    // Testing invalid enumeration isPointInPath (w/ and w/o Path object');
+    @assert throws TypeError ctx.isPointInPath(path, 50, 50, 'gazonk');
+    @assert throws TypeError ctx.isPointInPath(50, 50, 'gazonk');
+
+    // Testing invalid type isPointInPath with Path object');
+    @assert throws TypeError ctx.isPointInPath(null, 50, 50);
+    @assert throws TypeError ctx.isPointInPath(null, 50, 50, 'nonzero');
+    @assert throws TypeError ctx.isPointInPath(null, 50, 50, 'evenodd');
+    @assert throws TypeError ctx.isPointInPath(null, 50, 50, null);
+    @assert throws TypeError ctx.isPointInPath(path, 50, 50, null);
+    @assert throws TypeError ctx.isPointInPath(undefined, 50, 50);
+    @assert throws TypeError ctx.isPointInPath(undefined, 50, 50, 'nonzero');
+    @assert throws TypeError ctx.isPointInPath(undefined, 50, 50, 'evenodd');
+    @assert throws TypeError ctx.isPointInPath(undefined, 50, 50, undefined);
+    @assert throws TypeError ctx.isPointInPath([], 50, 50);
+    @assert throws TypeError ctx.isPointInPath([], 50, 50, 'nonzero');
+    @assert throws TypeError ctx.isPointInPath([], 50, 50, 'evenodd');
+    @assert throws TypeError ctx.isPointInPath({}, 50, 50);
+    @assert throws TypeError ctx.isPointInPath({}, 50, 50, 'nonzero');
+    @assert throws TypeError ctx.isPointInPath({}, 50, 50, 'evenodd');

--- a/test/wpt/pixel-manipulation.yaml
+++ b/test/wpt/pixel-manipulation.yaml
@@ -1,0 +1,1145 @@
+- name: 2d.imageData.create2.basic
+  desc: createImageData(sw, sh) exists and returns something
+  testing:
+  - 2d.imageData.create2.object
+  code: |
+    @assert ctx.createImageData(1, 1) !== null;
+
+- name: 2d.imageData.create1.basic
+  desc: createImageData(imgdata) exists and returns something
+  testing:
+  - 2d.imageData.create1.object
+  code: |
+    @assert ctx.createImageData(ctx.createImageData(1, 1)) !== null;
+
+- name: 2d.imageData.create2.type
+  desc: createImageData(sw, sh) returns an ImageData object containing a Uint8ClampedArray
+    object
+  testing:
+  - 2d.imageData.create2.object
+  code: |
+    @assert window.ImageData !== undefined;
+    @assert window.Uint8ClampedArray !== undefined;
+    window.ImageData.prototype.thisImplementsImageData = true;
+    window.Uint8ClampedArray.prototype.thisImplementsUint8ClampedArray = true;
+    var imgdata = ctx.createImageData(1, 1);
+    @assert imgdata.thisImplementsImageData;
+    @assert imgdata.data.thisImplementsUint8ClampedArray;
+
+- name: 2d.imageData.create1.type
+  desc: createImageData(imgdata) returns an ImageData object containing a Uint8ClampedArray
+    object
+  testing:
+  - 2d.imageData.create1.object
+  code: |
+    @assert window.ImageData !== undefined;
+    @assert window.Uint8ClampedArray !== undefined;
+    window.ImageData.prototype.thisImplementsImageData = true;
+    window.Uint8ClampedArray.prototype.thisImplementsUint8ClampedArray = true;
+    var imgdata = ctx.createImageData(ctx.createImageData(1, 1));
+    @assert imgdata.thisImplementsImageData;
+    @assert imgdata.data.thisImplementsUint8ClampedArray;
+
+- name: 2d.imageData.create2.this
+  desc: createImageData(sw, sh) should throw when called with the wrong |this|
+  notes: &bindings Defined in "Web IDL" (draft)
+  testing:
+  - 2d.imageData.create2.object
+  code: |
+    @assert throws TypeError CanvasRenderingContext2D.prototype.createImageData.call(null, 1, 1); @moz-todo
+    @assert throws TypeError CanvasRenderingContext2D.prototype.createImageData.call(undefined, 1, 1); @moz-todo
+    @assert throws TypeError CanvasRenderingContext2D.prototype.createImageData.call({}, 1, 1); @moz-todo
+
+- name: 2d.imageData.create1.this
+  desc: createImageData(imgdata) should throw when called with the wrong |this|
+  notes: *bindings
+  testing:
+  - 2d.imageData.create2.object
+  code: |
+    var imgdata = ctx.createImageData(1, 1);
+    @assert throws TypeError CanvasRenderingContext2D.prototype.createImageData.call(null, imgdata); @moz-todo
+    @assert throws TypeError CanvasRenderingContext2D.prototype.createImageData.call(undefined, imgdata); @moz-todo
+    @assert throws TypeError CanvasRenderingContext2D.prototype.createImageData.call({}, imgdata); @moz-todo
+
+- name: 2d.imageData.create2.initial
+  desc: createImageData(sw, sh) returns transparent black data of the right size
+  testing:
+  - 2d.imageData.create2.size
+  - 2d.imageData.create.initial
+  - 2d.imageData.initial
+  code: |
+    var imgdata = ctx.createImageData(10, 20);
+    @assert imgdata.data.length === imgdata.width*imgdata.height*4;
+    @assert imgdata.width < imgdata.height;
+    @assert imgdata.width > 0;
+    var isTransparentBlack = true;
+    for (var i = 0; i < imgdata.data.length; ++i)
+        if (imgdata.data[i] !== 0)
+            isTransparentBlack = false;
+    @assert isTransparentBlack;
+
+- name: 2d.imageData.create1.initial
+  desc: createImageData(imgdata) returns transparent black data of the right size
+  testing:
+  - 2d.imageData.create1.size
+  - 2d.imageData.create.initial
+  - 2d.imageData.initial
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    var imgdata1 = ctx.getImageData(0, 0, 10, 20);
+    var imgdata2 = ctx.createImageData(imgdata1);
+    @assert imgdata2.data.length === imgdata1.data.length;
+    @assert imgdata2.width === imgdata1.width;
+    @assert imgdata2.height === imgdata1.height;
+    var isTransparentBlack = true;
+    for (var i = 0; i < imgdata2.data.length; ++i)
+        if (imgdata2.data[i] !== 0)
+            isTransparentBlack = false;
+    @assert isTransparentBlack;
+
+- name: 2d.imageData.create2.large
+  desc: createImageData(sw, sh) works for sizes much larger than the canvas
+  testing:
+  - 2d.imageData.create2.size
+  code: |
+    var imgdata = ctx.createImageData(1000, 2000);
+    @assert imgdata.data.length === imgdata.width*imgdata.height*4;
+    @assert imgdata.width < imgdata.height;
+    @assert imgdata.width > 0;
+    var isTransparentBlack = true;
+    for (var i = 0; i < imgdata.data.length; i += 7813) // check ~1024 points (assuming normal scaling)
+        if (imgdata.data[i] !== 0)
+            isTransparentBlack = false;
+    @assert isTransparentBlack;
+
+- name: 2d.imageData.create2.negative
+  desc: createImageData(sw, sh) takes the absolute magnitude of the size arguments
+  testing:
+  - 2d.imageData.create2.size
+  code: |
+    var imgdata1 = ctx.createImageData(10, 20);
+    var imgdata2 = ctx.createImageData(-10, 20);
+    var imgdata3 = ctx.createImageData(10, -20);
+    var imgdata4 = ctx.createImageData(-10, -20);
+    @assert imgdata1.data.length === imgdata2.data.length;
+    @assert imgdata2.data.length === imgdata3.data.length;
+    @assert imgdata3.data.length === imgdata4.data.length;
+
+- name: 2d.imageData.create2.zero
+  desc: createImageData(sw, sh) throws INDEX_SIZE_ERR if size is zero
+  testing:
+  - 2d.imageData.getcreate.zero
+  code: |
+    @assert throws INDEX_SIZE_ERR ctx.createImageData(10, 0);
+    @assert throws INDEX_SIZE_ERR ctx.createImageData(0, 10);
+    @assert throws INDEX_SIZE_ERR ctx.createImageData(0, 0);
+    @assert throws INDEX_SIZE_ERR ctx.createImageData(0.99, 10);
+    @assert throws INDEX_SIZE_ERR ctx.createImageData(10, 0.1);
+
+- name: 2d.imageData.create2.nonfinite
+  desc: createImageData() throws TypeError if arguments are not finite
+  notes: *bindings
+  testing:
+  - 2d.imageData.getcreate.nonfinite
+  code: |
+    @nonfinite @assert throws TypeError ctx.createImageData(<10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>);
+    var posinfobj = { valueOf: function() { return Infinity; } },
+        neginfobj = { valueOf: function() { return -Infinity; } },
+        nanobj = { valueOf: function() { return -Infinity; } };
+    @nonfinite @assert throws TypeError ctx.createImageData(<10 posinfobj neginfobj nanobj>, <10 posinfobj neginfobj nanobj>);
+
+- name: 2d.imageData.create1.zero
+  desc: createImageData(null) throws TypeError
+  testing:
+  - 2d.imageData.create.null
+  code: |
+    @assert throws TypeError ctx.createImageData(null);
+
+- name: 2d.imageData.create2.double
+  desc: createImageData(w, h) double is converted to long
+  testing:
+  - 2d.imageData.create2.size
+  code: |
+    var imgdata1 = ctx.createImageData(10.01, 10.99);
+    var imgdata2 = ctx.createImageData(-10.01, -10.99);
+    @assert imgdata1.width === 10;
+    @assert imgdata1.height === 10;
+    @assert imgdata2.width === 10;
+    @assert imgdata2.height === 10;
+
+- name: 2d.imageData.create.and.resize
+  desc: Verify no crash when resizing an image bitmap to zero.
+  testing:
+  - 2d.imageData.resize
+  images:
+  - red.png
+  code: |
+    var image = new Image();
+    image.onload = t.step_func(function() {
+      var options = { resizeHeight: 0 };
+      var p1 = createImageBitmap(image, options);
+      p1.catch(function(error){});
+      t.done();
+    });
+    image.src = 'red.png';
+
+- name: 2d.imageData.get.basic
+  desc: getImageData() exists and returns something
+  testing:
+  - 2d.imageData.get.basic
+  code: |
+    @assert ctx.getImageData(0, 0, 100, 50) !== null;
+
+- name: 2d.imageData.get.type
+  desc: getImageData() returns an ImageData object containing a Uint8ClampedArray
+    object
+  testing:
+  - 2d.imageData.get.object
+  code: |
+    @assert window.ImageData !== undefined;
+    @assert window.Uint8ClampedArray !== undefined;
+    window.ImageData.prototype.thisImplementsImageData = true;
+    window.Uint8ClampedArray.prototype.thisImplementsUint8ClampedArray = true;
+    var imgdata = ctx.getImageData(0, 0, 1, 1);
+    @assert imgdata.thisImplementsImageData;
+    @assert imgdata.data.thisImplementsUint8ClampedArray;
+
+- name: 2d.imageData.get.zero
+  desc: getImageData() throws INDEX_SIZE_ERR if size is zero
+  testing:
+  - 2d.imageData.getcreate.zero
+  code: |
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, 10, 0);
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, 0, 10);
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, 0, 0);
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, 0.1, 10);
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, 10, 0.99);
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, -0.1, 10);
+    @assert throws INDEX_SIZE_ERR ctx.getImageData(1, 1, 10, -0.99);
+
+- name: 2d.imageData.get.nonfinite
+  desc: getImageData() throws TypeError if arguments are not finite
+  notes: *bindings
+  testing:
+  - 2d.imageData.getcreate.nonfinite
+  code: |
+    @nonfinite @assert throws TypeError ctx.getImageData(<10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>);
+    var posinfobj = { valueOf: function() { return Infinity; } },
+        neginfobj = { valueOf: function() { return -Infinity; } },
+        nanobj = { valueOf: function() { return -Infinity; } };
+    @nonfinite @assert throws TypeError ctx.getImageData(<10 posinfobj neginfobj nanobj>, <10 posinfobj neginfobj nanobj>, <10 posinfobj neginfobj nanobj>, <10 posinfobj neginfobj nanobj>);
+
+- name: 2d.imageData.get.source.outside
+  desc: getImageData() returns transparent black outside the canvas
+  testing:
+  - 2d.imageData.get.basic
+  - 2d.imageData.get.outside
+  code: |
+    ctx.fillStyle = '#08f';
+    ctx.fillRect(0, 0, 100, 50);
+
+    var imgdata1 = ctx.getImageData(-10, 5, 1, 1);
+    @assert imgdata1.data[0] === 0;
+    @assert imgdata1.data[1] === 0;
+    @assert imgdata1.data[2] === 0;
+    @assert imgdata1.data[3] === 0;
+
+    var imgdata2 = ctx.getImageData(10, -5, 1, 1);
+    @assert imgdata2.data[0] === 0;
+    @assert imgdata2.data[1] === 0;
+    @assert imgdata2.data[2] === 0;
+    @assert imgdata2.data[3] === 0;
+
+    var imgdata3 = ctx.getImageData(200, 5, 1, 1);
+    @assert imgdata3.data[0] === 0;
+    @assert imgdata3.data[1] === 0;
+    @assert imgdata3.data[2] === 0;
+    @assert imgdata3.data[3] === 0;
+
+    var imgdata4 = ctx.getImageData(10, 60, 1, 1);
+    @assert imgdata4.data[0] === 0;
+    @assert imgdata4.data[1] === 0;
+    @assert imgdata4.data[2] === 0;
+    @assert imgdata4.data[3] === 0;
+
+    var imgdata5 = ctx.getImageData(100, 10, 1, 1);
+    @assert imgdata5.data[0] === 0;
+    @assert imgdata5.data[1] === 0;
+    @assert imgdata5.data[2] === 0;
+    @assert imgdata5.data[3] === 0;
+
+    var imgdata6 = ctx.getImageData(0, 10, 1, 1);
+    @assert imgdata6.data[0] === 0;
+    @assert imgdata6.data[1] === 136;
+    @assert imgdata6.data[2] === 255;
+    @assert imgdata6.data[3] === 255;
+
+    var imgdata7 = ctx.getImageData(-10, 10, 20, 20);
+    @assert imgdata7.data[ 0*4+0] === 0;
+    @assert imgdata7.data[ 0*4+1] === 0;
+    @assert imgdata7.data[ 0*4+2] === 0;
+    @assert imgdata7.data[ 0*4+3] === 0;
+    @assert imgdata7.data[ 9*4+0] === 0;
+    @assert imgdata7.data[ 9*4+1] === 0;
+    @assert imgdata7.data[ 9*4+2] === 0;
+    @assert imgdata7.data[ 9*4+3] === 0;
+    @assert imgdata7.data[10*4+0] === 0;
+    @assert imgdata7.data[10*4+1] === 136;
+    @assert imgdata7.data[10*4+2] === 255;
+    @assert imgdata7.data[10*4+3] === 255;
+    @assert imgdata7.data[19*4+0] === 0;
+    @assert imgdata7.data[19*4+1] === 136;
+    @assert imgdata7.data[19*4+2] === 255;
+    @assert imgdata7.data[19*4+3] === 255;
+    @assert imgdata7.data[20*4+0] === 0;
+    @assert imgdata7.data[20*4+1] === 0;
+    @assert imgdata7.data[20*4+2] === 0;
+    @assert imgdata7.data[20*4+3] === 0;
+
+- name: 2d.imageData.get.source.negative
+  desc: getImageData() works with negative width and height, and returns top-to-bottom
+    left-to-right
+  testing:
+  - 2d.imageData.get.basic
+  - 2d.pixelarray.order
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(20, 10, 60, 10);
+
+    var imgdata1 = ctx.getImageData(85, 25, -10, -10);
+    @assert imgdata1.data[0] === 255;
+    @assert imgdata1.data[1] === 255;
+    @assert imgdata1.data[2] === 255;
+    @assert imgdata1.data[3] === 255;
+    @assert imgdata1.data[imgdata1.data.length-4+0] === 0;
+    @assert imgdata1.data[imgdata1.data.length-4+1] === 0;
+    @assert imgdata1.data[imgdata1.data.length-4+2] === 0;
+    @assert imgdata1.data[imgdata1.data.length-4+3] === 255;
+
+    var imgdata2 = ctx.getImageData(0, 0, -1, -1);
+    @assert imgdata2.data[0] === 0;
+    @assert imgdata2.data[1] === 0;
+    @assert imgdata2.data[2] === 0;
+    @assert imgdata2.data[3] === 0;
+
+- name: 2d.imageData.get.source.size
+  desc: getImageData() returns bigger ImageData for bigger source rectangle
+  testing:
+  - 2d.imageData.get.basic
+  code: |
+    var imgdata1 = ctx.getImageData(0, 0, 10, 10);
+    var imgdata2 = ctx.getImageData(0, 0, 20, 20);
+    @assert imgdata2.width > imgdata1.width;
+    @assert imgdata2.height > imgdata1.height;
+
+- name: 2d.imageData.get.double
+  desc: createImageData(w, h) double is converted to long
+  testing:
+  - 2d.imageData.get.basic
+  code: |
+    var imgdata1 = ctx.getImageData(0, 0, 10.01, 10.99);
+    var imgdata2 = ctx.getImageData(0, 0, -10.01, -10.99);
+    @assert imgdata1.width === 10;
+    @assert imgdata1.height === 10;
+    @assert imgdata2.width === 10;
+    @assert imgdata2.height === 10;
+
+- name: 2d.imageData.get.nonpremul
+  desc: getImageData() returns non-premultiplied colors
+  testing:
+  - 2d.imageData.get.premul
+  code: |
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+    ctx.fillRect(0, 0, 100, 50);
+    var imgdata = ctx.getImageData(10, 10, 10, 10);
+    @assert imgdata.data[0] > 200;
+    @assert imgdata.data[1] > 200;
+    @assert imgdata.data[2] > 200;
+    @assert imgdata.data[3] > 100;
+    @assert imgdata.data[3] < 200;
+
+- name: 2d.imageData.get.range
+  desc: getImageData() returns values in the range [0, 255]
+  testing:
+  - 2d.pixelarray.range
+  - 2d.pixelarray.retrieve
+  code: |
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(20, 10, 60, 10);
+    var imgdata1 = ctx.getImageData(10, 5, 1, 1);
+    @assert imgdata1.data[0] === 0;
+    var imgdata2 = ctx.getImageData(30, 15, 1, 1);
+    @assert imgdata2.data[0] === 255;
+
+- name: 2d.imageData.get.clamp
+  desc: getImageData() clamps colors to the range [0, 255]
+  testing:
+  - 2d.pixelarray.range
+  code: |
+    ctx.fillStyle = 'rgb(-100, -200, -300)';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = 'rgb(256, 300, 400)';
+    ctx.fillRect(20, 10, 60, 10);
+    var imgdata1 = ctx.getImageData(10, 5, 1, 1);
+    @assert imgdata1.data[0] === 0;
+    @assert imgdata1.data[1] === 0;
+    @assert imgdata1.data[2] === 0;
+    var imgdata2 = ctx.getImageData(30, 15, 1, 1);
+    @assert imgdata2.data[0] === 255;
+    @assert imgdata2.data[1] === 255;
+    @assert imgdata2.data[2] === 255;
+
+- name: 2d.imageData.get.length
+  desc: getImageData() returns a correctly-sized Uint8ClampedArray
+  testing:
+  - 2d.pixelarray.length
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @assert imgdata.data.length === imgdata.width*imgdata.height*4;
+
+- name: 2d.imageData.get.order.cols
+  desc: getImageData() returns leftmost columns first
+  testing:
+  - 2d.pixelarray.order
+  code: |
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 2, 50);
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @assert imgdata.data[0] === 0;
+    @assert imgdata.data[Math.round(imgdata.width/2*4)] === 255;
+    @assert imgdata.data[Math.round((imgdata.height/2)*imgdata.width*4)] === 0;
+
+- name: 2d.imageData.get.order.rows
+  desc: getImageData() returns topmost rows first
+  testing:
+  - 2d.pixelarray.order
+  code: |
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 100, 2);
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @assert imgdata.data[0] === 0;
+    @assert imgdata.data[Math.floor(imgdata.width/2*4)] === 0;
+    @assert imgdata.data[(imgdata.height/2)*imgdata.width*4] === 255;
+
+- name: 2d.imageData.get.order.rgb
+  desc: getImageData() returns R then G then B
+  testing:
+  - 2d.pixelarray.order
+  - 2d.pixelarray.indexes
+  code: |
+    ctx.fillStyle = '#48c';
+    ctx.fillRect(0, 0, 100, 50);
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @assert imgdata.data[0] === 0x44;
+    @assert imgdata.data[1] === 0x88;
+    @assert imgdata.data[2] === 0xCC;
+    @assert imgdata.data[3] === 255;
+    @assert imgdata.data[4] === 0x44;
+    @assert imgdata.data[5] === 0x88;
+    @assert imgdata.data[6] === 0xCC;
+    @assert imgdata.data[7] === 255;
+
+- name: 2d.imageData.get.order.alpha
+  desc: getImageData() returns A in the fourth component
+  testing:
+  - 2d.pixelarray.order
+  code: |
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    ctx.fillRect(0, 0, 100, 50);
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @assert imgdata.data[3] < 200;
+    @assert imgdata.data[3] > 100;
+
+- name: 2d.imageData.get.unaffected
+  desc: getImageData() is not affected by context state
+  testing:
+  - 2d.imageData.unaffected
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 50)
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(50, 0, 50, 50)
+    ctx.save();
+    ctx.translate(50, 0);
+    ctx.globalAlpha = 0.1;
+    ctx.globalCompositeOperation = 'destination-atop';
+    ctx.shadowColor = '#f00';
+    ctx.rect(0, 0, 5, 5);
+    ctx.clip();
+    var imgdata = ctx.getImageData(0, 0, 50, 50);
+    ctx.restore();
+    ctx.putImageData(imgdata, 50, 0);
+    @assert pixel 25,25 ==~ 0,255,0,255;
+    @assert pixel 75,25 ==~ 0,255,0,255;
+  expected: green
+
+
+- name: 2d.imageData.get.large.crash
+  desc: Test that canvas crash when image data cannot be allocated.
+  testing:
+  - 2d.getImageData
+  code: |
+    @assert throws TypeError ctx.getImageData(10, 0xffffffff, 2147483647, 10);
+
+- name: 2d.imageData.get.rounding
+  desc: Test the handling of non-integer source coordinates in getImageData().
+  testing:
+  - 2d.getImageData
+  code: |
+    function testDimensions(sx, sy, sw, sh, width, height)
+    {
+        imageData = ctx.getImageData(sx, sy, sw, sh);
+        @assert imageData.width == width;
+        @assert imageData.height == height;
+    }
+
+    testDimensions(0, 0, 20, 10, 20, 10);
+
+    testDimensions(.1, .2, 20, 10, 20, 10);
+    testDimensions(.9, .8, 20, 10, 20, 10);
+
+    testDimensions(0, 0, 20.9, 10.9, 20, 10);
+    testDimensions(0, 0, 20.1, 10.1, 20, 10);
+
+    testDimensions(-1, -1, 20, 10, 20, 10);
+
+    testDimensions(-1.1, 0, 20, 10, 20, 10);
+    testDimensions(-1.9,  0, 20, 10, 20, 10);
+
+- name: 2d.imageData.get.invalid
+  desc: Verify getImageData() behavior in invalid cases.
+  testing:
+  - 2d.imageData.get.invalid
+  code: |
+    imageData = ctx.getImageData(0,0,2,2);
+    var testValues = [NaN, true, false, "\"garbage\"", "-1",
+                      "0", "1", "2", Infinity, -Infinity,
+                      -5, -0.5, 0, 0.5, 5,
+                      5.4, 255, 256, null, undefined];
+    var testResults = [0, 1, 0, 0, 0,
+                       0, 1, 2, 255, 0,
+                       0, 0, 0, 0, 5,
+                       5, 255, 255, 0, 0];
+    for (var i = 0; i < testValues.length; i++) {
+        imageData.data[0] = testValues[i];
+        @assert imageData.data[0] == testResults[i];
+    }
+    imageData.data['foo']='garbage';
+    @assert imageData.data['foo'] == 'garbage';
+    imageData.data[-1]='garbage';
+    @assert imageData.data[-1] == undefined;
+    imageData.data[17]='garbage';
+    @assert imageData.data[17] == undefined;
+
+- name: 2d.imageData.object.properties
+  desc: ImageData objects have the right properties
+  testing:
+  - 2d.imageData.type
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @assert typeof(imgdata.width) === 'number';
+    @assert typeof(imgdata.height) === 'number';
+    @assert typeof(imgdata.data) === 'object';
+
+- name: 2d.imageData.object.readonly
+  desc: ImageData objects properties are read-only
+  testing:
+  - 2d.imageData.type
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    var w = imgdata.width;
+    var h = imgdata.height;
+    var d = imgdata.data;
+    imgdata.width = 123;
+    imgdata.height = 123;
+    imgdata.data = [100,100,100,100];
+    @assert imgdata.width === w;
+    @assert imgdata.height === h;
+    @assert imgdata.data === d;
+    @assert imgdata.data[0] === 0;
+    @assert imgdata.data[1] === 0;
+    @assert imgdata.data[2] === 0;
+    @assert imgdata.data[3] === 0;
+
+- name: 2d.imageData.object.ctor.size
+  desc: ImageData has a usable constructor
+  testing:
+  - 2d.imageData.type
+  code: |
+    @assert window.ImageData !== undefined;
+
+    var imgdata = new window.ImageData(2, 3);
+    @assert imgdata.width === 2;
+    @assert imgdata.height === 3;
+    @assert imgdata.data.length === 2 * 3 * 4;
+    for (var i = 0; i < imgdata.data.length; ++i) {
+      @assert imgdata.data[i] === 0;
+    }
+
+- name: 2d.imageData.object.ctor.basics
+  desc: Testing different type of ImageData constructor
+  testing:
+  - 2d.imageData.type
+  code: |
+    function setRGBA(imageData, i, rgba)
+    {
+        var s = i * 4;
+        imageData[s] = rgba[0];
+        imageData[s + 1] = rgba[1];
+        imageData[s + 2] = rgba[2];
+        imageData[s + 3] = rgba[3];
+    }
+
+    function getRGBA(imageData, i)
+    {
+        var result = [];
+        var s = i * 4;
+        for (var j = 0; j < 4; j++) {
+            result[j] = imageData[s + j];
+        }
+        return result;
+    }
+
+    function assertArrayEquals(actual, expected)
+    {
+        @assert typeof actual === "object";
+        @assert actual !== null;
+        @assert "length" in actual === true;
+        @assert actual.length === expected.length;
+        for (var i = 0; i < actual.length; i++) {
+            @assert actual.hasOwnProperty(i) === expected.hasOwnProperty(i);
+            @assert actual[i] === expected[i];
+        }
+    }
+
+    @assert ImageData !== undefined;
+    imageData = new ImageData(100, 50);
+
+    @assert imageData !== null;
+    @assert imageData.data !== null;
+    @assert imageData.width === 100;
+    @assert imageData.height === 50;
+    assertArrayEquals(getRGBA(imageData.data, 4), [0, 0, 0, 0]);
+
+    var testColor = [0, 255, 255, 128];
+    setRGBA(imageData.data, 4, testColor);
+    assertArrayEquals(getRGBA(imageData.data, 4), testColor);
+
+    @assert throws TypeError new ImageData(10);
+    @assert throws INDEX_SIZE_ERR new ImageData(0, 10);
+    @assert throws INDEX_SIZE_ERR new ImageData(10, 0);
+    @assert throws INDEX_SIZE_ERR new ImageData('width', 'height');
+    @assert throws INDEX_SIZE_ERR new ImageData(1 << 31, 1 << 31);
+    @assert throws TypeError new ImageData(new Uint8ClampedArray(0));
+    @assert throws INDEX_SIZE_ERR new ImageData(new Uint8Array(100), 25);
+    @assert throws INVALID_STATE_ERR new ImageData(new Uint8ClampedArray(27), 2);
+    @assert throws INDEX_SIZE_ERR new ImageData(new Uint8ClampedArray(28), 7, 0);
+    @assert throws INDEX_SIZE_ERR new ImageData(new Uint8ClampedArray(104), 14);
+    @assert throws INDEX_SIZE_ERR new ImageData(new Uint8ClampedArray([12, 34, 168, 65328]), 1, 151);
+    @assert throws TypeError new ImageData(self, 4, 4);
+    @assert throws TypeError new ImageData(null, 4, 4);
+    @assert throws INDEX_SIZE_ERR new ImageData(imageData.data, 0);
+    @assert throws INDEX_SIZE_ERR new ImageData(imageData.data, 13);
+    @assert throws INDEX_SIZE_ERR new ImageData(imageData.data, 1 << 31);
+    @assert throws INDEX_SIZE_ERR new ImageData(imageData.data, 'biggish');
+    @assert throws INDEX_SIZE_ERR new ImageData(imageData.data, 1 << 24, 1 << 31);
+    @assert new ImageData(new Uint8ClampedArray(28), 7).height === 1;
+
+    imageDataFromData = new ImageData(imageData.data, 100);
+    @assert imageDataFromData.width === 100;
+    @assert imageDataFromData.height === 50;
+    @assert imageDataFromData.data === imageData.data;
+    assertArrayEquals(getRGBA(imageDataFromData.data, 10), getRGBA(imageData.data, 10));
+    setRGBA(imageData.data, 10, testColor);
+    assertArrayEquals(getRGBA(imageDataFromData.data, 10), getRGBA(imageData.data, 10));
+
+    var data = new Uint8ClampedArray(400);
+    data[22] = 129;
+    imageDataFromData = new ImageData(data, 20, 5);
+    @assert imageDataFromData.width === 20;
+    @assert imageDataFromData.height === 5;
+    @assert imageDataFromData.data === data;
+    assertArrayEquals(getRGBA(imageDataFromData.data, 2), getRGBA(data, 2));
+    setRGBA(imageDataFromData.data, 2, testColor);
+    assertArrayEquals(getRGBA(imageDataFromData.data, 2), getRGBA(data, 2));
+
+    if (window.SharedArrayBuffer) {
+        @assert throws TypeError new ImageData(new Uint16Array(new SharedArrayBuffer(32)), 4, 2);
+    }
+
+- name: 2d.imageData.object.ctor.array
+  desc: ImageData has a usable constructor
+  testing:
+  - 2d.imageData.type
+  code: |
+    @assert window.ImageData !== undefined;
+
+    var array = new Uint8ClampedArray(8);
+    var imgdata = new window.ImageData(array, 1, 2);
+    @assert imgdata.width === 1;
+    @assert imgdata.height === 2;
+    @assert imgdata.data === array;
+
+- name: 2d.imageData.object.ctor.array.bounds
+  desc: ImageData has a usable constructor
+  testing:
+  - 2d.imageData.type
+  code: |
+    @assert window.ImageData !== undefined;
+
+    @assert throws INVALID_STATE_ERR new ImageData(new Uint8ClampedArray(0), 1);
+    @assert throws INVALID_STATE_ERR new ImageData(new Uint8ClampedArray(3), 1);
+    @assert throws INDEX_SIZE_ERR new ImageData(new Uint8ClampedArray(4), 0);
+    @assert throws INDEX_SIZE_ERR new ImageData(new Uint8ClampedArray(4), 1, 2);
+    @assert throws TypeError new ImageData(new Uint8Array(8), 1, 2);
+    @assert throws TypeError new ImageData(new Int8Array(8), 1, 2);
+
+- name: 2d.imageData.object.set
+  desc: ImageData.data can be modified
+  testing:
+  - 2d.pixelarray.modify
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    imgdata.data[0] = 100;
+    @assert imgdata.data[0] === 100;
+    imgdata.data[0] = 200;
+    @assert imgdata.data[0] === 200;
+
+- name: 2d.imageData.object.undefined
+  desc: ImageData.data converts undefined to 0
+  testing:
+  - 2d.pixelarray.modify
+  webidl:
+  - es-octet
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    imgdata.data[0] = 100;
+    imgdata.data[0] = undefined;
+    @assert imgdata.data[0] === 0;
+
+- name: 2d.imageData.object.nan
+  desc: ImageData.data converts NaN to 0
+  testing:
+  - 2d.pixelarray.modify
+  webidl:
+  - es-octet
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    imgdata.data[0] = 100;
+    imgdata.data[0] = NaN;
+    @assert imgdata.data[0] === 0;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = "cheese";
+    @assert imgdata.data[0] === 0;
+
+- name: 2d.imageData.object.string
+  desc: ImageData.data converts strings to numbers with ToNumber
+  testing:
+  - 2d.pixelarray.modify
+  webidl:
+  - es-octet
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    imgdata.data[0] = 100;
+    imgdata.data[0] = "110";
+    @assert imgdata.data[0] === 110;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = "0x78";
+    @assert imgdata.data[0] === 120;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = " +130e0 ";
+    @assert imgdata.data[0] === 130;
+
+- name: 2d.imageData.object.clamp
+  desc: ImageData.data clamps numbers to [0, 255]
+  testing:
+  - 2d.pixelarray.modify
+  webidl:
+  - es-octet
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+
+    imgdata.data[0] = 100;
+    imgdata.data[0] = 300;
+    @assert imgdata.data[0] === 255;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = -100;
+    @assert imgdata.data[0] === 0;
+
+    imgdata.data[0] = 100;
+    imgdata.data[0] = 200+Math.pow(2, 32);
+    @assert imgdata.data[0] === 255;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = -200-Math.pow(2, 32);
+    @assert imgdata.data[0] === 0;
+
+    imgdata.data[0] = 100;
+    imgdata.data[0] = Math.pow(10, 39);
+    @assert imgdata.data[0] === 255;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = -Math.pow(10, 39);
+    @assert imgdata.data[0] === 0;
+
+    imgdata.data[0] = 100;
+    imgdata.data[0] = -Infinity;
+    @assert imgdata.data[0] === 0;
+    imgdata.data[0] = 100;
+    imgdata.data[0] = Infinity;
+    @assert imgdata.data[0] === 255;
+
+- name: 2d.imageData.object.round
+  desc: ImageData.data rounds numbers with round-to-zero
+  testing:
+  - 2d.pixelarray.modify
+  webidl:
+  - es-octet
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    imgdata.data[0] = 0.499;
+    @assert imgdata.data[0] === 0;
+    imgdata.data[0] = 0.5;
+    @assert imgdata.data[0] === 0;
+    imgdata.data[0] = 0.501;
+    @assert imgdata.data[0] === 1;
+    imgdata.data[0] = 1.499;
+    @assert imgdata.data[0] === 1;
+    imgdata.data[0] = 1.5;
+    @assert imgdata.data[0] === 2;
+    imgdata.data[0] = 1.501;
+    @assert imgdata.data[0] === 2;
+    imgdata.data[0] = 2.5;
+    @assert imgdata.data[0] === 2;
+    imgdata.data[0] = 3.5;
+    @assert imgdata.data[0] === 4;
+    imgdata.data[0] = 252.5;
+    @assert imgdata.data[0] === 252;
+    imgdata.data[0] = 253.5;
+    @assert imgdata.data[0] === 254;
+    imgdata.data[0] = 254.5;
+    @assert imgdata.data[0] === 254;
+    imgdata.data[0] = 256.5;
+    @assert imgdata.data[0] === 255;
+    imgdata.data[0] = -0.5;
+    @assert imgdata.data[0] === 0;
+    imgdata.data[0] = -1.5;
+    @assert imgdata.data[0] === 0;
+
+
+
+- name: 2d.imageData.put.null
+  desc: putImageData() with null imagedata throws TypeError
+  testing:
+  - 2d.imageData.put.wrongtype
+  code: |
+    @assert throws TypeError ctx.putImageData(null, 0, 0);
+
+- name: 2d.imageData.put.nonfinite
+  desc: putImageData() throws TypeError if arguments are not finite
+  notes: *bindings
+  testing:
+  - 2d.imageData.put.nonfinite
+  code: |
+    var imgdata = ctx.getImageData(0, 0, 10, 10);
+    @nonfinite @assert throws TypeError ctx.putImageData(<imgdata>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>);
+    @nonfinite @assert throws TypeError ctx.putImageData(<imgdata>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>, <10 Infinity -Infinity NaN>);
+
+- name: 2d.imageData.put.basic
+  desc: putImageData() puts image data from getImageData() onto the canvas
+  testing:
+  - 2d.imageData.put.normal
+  - 2d.imageData.put.3arg
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.putImageData(imgdata, 0, 0);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.created
+  desc: putImageData() puts image data from createImageData() onto the canvas
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    var imgdata = ctx.createImageData(100, 50);
+    for (var i = 0; i < imgdata.data.length; i += 4) {
+        imgdata.data[i] = 0;
+        imgdata.data[i+1] = 255;
+        imgdata.data[i+2] = 0;
+        imgdata.data[i+3] = 255;
+    }
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.putImageData(imgdata, 0, 0);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.wrongtype
+  desc: putImageData() does not accept non-ImageData objects
+  testing:
+  - 2d.imageData.put.wrongtype
+  code: |
+    var imgdata = { width: 1, height: 1, data: [255, 0, 0, 255] };
+    @assert throws TypeError ctx.putImageData(imgdata, 0, 0);
+    @assert throws TypeError ctx.putImageData("cheese", 0, 0);
+    @assert throws TypeError ctx.putImageData(42, 0, 0);
+  expected: green
+
+- name: 2d.imageData.put.cross
+  desc: putImageData() accepts image data got from a different canvas
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    var canvas2 = document.createElement('canvas');
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#0f0';
+    ctx2.fillRect(0, 0, 100, 50)
+    var imgdata = ctx2.getImageData(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.putImageData(imgdata, 0, 0);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.alpha
+  desc: putImageData() puts non-solid image data correctly
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = 'rgba(0, 255, 0, 0.25)';
+    ctx.fillRect(0, 0, 100, 50)
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.putImageData(imgdata, 0, 0);
+    @assert pixel 50,25 ==~ 0,255,0,64;
+  expected: |
+    size 100 50
+    cr.set_source_rgba(0, 1, 0, 0.25)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.imageData.put.modified
+  desc: putImageData() puts modified image data correctly
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(45, 20, 10, 10)
+    var imgdata = ctx.getImageData(45, 20, 10, 10);
+    for (var i = 0, len = imgdata.width*imgdata.height*4; i < len; i += 4)
+    {
+        imgdata.data[i] = 0;
+        imgdata.data[i+1] = 255;
+    }
+    ctx.putImageData(imgdata, 45, 20);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.dirty.zero
+  desc: putImageData() with zero-sized dirty rectangle puts nothing
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.putImageData(imgdata, 0, 0, 0, 0, 0, 0);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.dirty.rect1
+  desc: putImageData() only modifies areas inside the dirty rectangle, using width
+    and height
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 20, 20)
+
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(40, 20, 20, 20)
+    ctx.putImageData(imgdata, 40, 20, 0, 0, 20, 20);
+
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 35,25 ==~ 0,255,0,255;
+    @assert pixel 65,25 ==~ 0,255,0,255;
+    @assert pixel 50,15 ==~ 0,255,0,255;
+    @assert pixel 50,45 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.dirty.rect2
+  desc: putImageData() only modifies areas inside the dirty rectangle, using x and
+    y
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(60, 30, 20, 20)
+
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(40, 20, 20, 20)
+    ctx.putImageData(imgdata, -20, -10, 60, 30, 20, 20);
+
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 35,25 ==~ 0,255,0,255;
+    @assert pixel 65,25 ==~ 0,255,0,255;
+    @assert pixel 50,15 ==~ 0,255,0,255;
+    @assert pixel 50,45 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.dirty.negative
+  desc: putImageData() handles negative-sized dirty rectangles correctly
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 20, 20)
+
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(40, 20, 20, 20)
+    ctx.putImageData(imgdata, 40, 20, 20, 20, -20, -20);
+
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 35,25 ==~ 0,255,0,255;
+    @assert pixel 65,25 ==~ 0,255,0,255;
+    @assert pixel 50,15 ==~ 0,255,0,255;
+    @assert pixel 50,45 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.dirty.outside
+  desc: putImageData() handles dirty rectangles outside the canvas correctly
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+
+    ctx.putImageData(imgdata, 100, 20, 20, 20, -20, -20);
+    ctx.putImageData(imgdata, 200, 200, 0, 0, 100, 50);
+    ctx.putImageData(imgdata, 40, 20, -30, -20, 30, 20);
+    ctx.putImageData(imgdata, -30, 20, 0, 0, 30, 20);
+
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 98,15 ==~ 0,255,0,255;
+    @assert pixel 98,25 ==~ 0,255,0,255;
+    @assert pixel 98,45 ==~ 0,255,0,255;
+    @assert pixel 1,5 ==~ 0,255,0,255;
+    @assert pixel 1,25 ==~ 0,255,0,255;
+    @assert pixel 1,45 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.unchanged
+  desc: putImageData(getImageData(...), ...) has no effect
+  testing:
+  - 2d.imageData.unchanged
+  code: |
+    var i = 0;
+    for (var y = 0; y < 16; ++y) {
+        for (var x = 0; x < 16; ++x, ++i) {
+            ctx.fillStyle = 'rgba(' + i + ',' + (Math.floor(i*1.5) % 256) + ',' + (Math.floor(i*23.3) % 256) + ',' + (i/256) + ')';
+            ctx.fillRect(x, y, 1, 1);
+        }
+    }
+    var imgdata1 = ctx.getImageData(0.1, 0.2, 15.8, 15.9);
+    var olddata = [];
+    for (var i = 0; i < imgdata1.data.length; ++i)
+        olddata[i] = imgdata1.data[i];
+
+    ctx.putImageData(imgdata1, 0.1, 0.2);
+
+    var imgdata2 = ctx.getImageData(0.1, 0.2, 15.8, 15.9);
+    for (var i = 0; i < imgdata2.data.length; ++i) {
+        @assert olddata[i] === imgdata2.data[i];
+    }
+
+- name: 2d.imageData.put.unaffected
+  desc: putImageData() is not affected by context state
+  testing:
+  - 2d.imageData.unaffected
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.globalAlpha = 0.1;
+    ctx.globalCompositeOperation = 'destination-atop';
+    ctx.shadowColor = '#f00';
+    ctx.shadowBlur = 1;
+    ctx.translate(100, 50);
+    ctx.scale(0.1, 0.1);
+    ctx.putImageData(imgdata, 0, 0);
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.clip
+  desc: putImageData() is not affected by clipping regions
+  testing:
+  - 2d.imageData.unaffected
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50)
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.beginPath();
+    ctx.rect(0, 0, 50, 50);
+    ctx.clip();
+    ctx.putImageData(imgdata, 0, 0);
+    @assert pixel 25,25 ==~ 0,255,0,255;
+    @assert pixel 75,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.imageData.put.path
+  desc: putImageData() does not affect the current path
+  testing:
+  - 2d.imageData.put.normal
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50)
+    ctx.rect(0, 0, 100, 50);
+    var imgdata = ctx.getImageData(0, 0, 100, 50);
+    ctx.putImageData(imgdata, 0, 0);
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green

--- a/test/wpt/shadows.yaml
+++ b/test/wpt/shadows.yaml
@@ -1,0 +1,1150 @@
+- name: 2d.shadow.attributes.shadowBlur.initial
+  testing:
+  - 2d.shadow.blur.get
+  - 2d.shadow.blur.initial
+  code: |
+    @assert ctx.shadowBlur === 0;
+
+- name: 2d.shadow.attributes.shadowBlur.valid
+  testing:
+  - 2d.shadow.blur.get
+  - 2d.shadow.blur.set
+  code: |
+    ctx.shadowBlur = 1;
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 0.5;
+    @assert ctx.shadowBlur === 0.5;
+
+    ctx.shadowBlur = 1e6;
+    @assert ctx.shadowBlur === 1e6;
+
+    ctx.shadowBlur = 0;
+    @assert ctx.shadowBlur === 0;
+
+- name: 2d.shadow.attributes.shadowBlur.invalid
+  testing:
+  - 2d.shadow.blur.invalid
+  code: |
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = -2;
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = Infinity;
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = -Infinity;
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = NaN;
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = 'string';
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = true;
+    @assert ctx.shadowBlur === 1;
+
+    ctx.shadowBlur = 1;
+    ctx.shadowBlur = false;
+    @assert ctx.shadowBlur === 0;
+
+- name: 2d.shadow.attributes.shadowOffset.initial
+  testing:
+  - 2d.shadow.offset.initial
+  code: |
+    @assert ctx.shadowOffsetX === 0;
+    @assert ctx.shadowOffsetY === 0;
+
+- name: 2d.shadow.attributes.shadowOffset.valid
+  testing:
+  - 2d.shadow.offset.get
+  - 2d.shadow.offset.set
+  code: |
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    @assert ctx.shadowOffsetX === 1;
+    @assert ctx.shadowOffsetY === 2;
+
+    ctx.shadowOffsetX = 0.5;
+    ctx.shadowOffsetY = 0.25;
+    @assert ctx.shadowOffsetX === 0.5;
+    @assert ctx.shadowOffsetY === 0.25;
+
+    ctx.shadowOffsetX = -0.5;
+    ctx.shadowOffsetY = -0.25;
+    @assert ctx.shadowOffsetX === -0.5;
+    @assert ctx.shadowOffsetY === -0.25;
+
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+    @assert ctx.shadowOffsetX === 0;
+    @assert ctx.shadowOffsetY === 0;
+
+    ctx.shadowOffsetX = 1e6;
+    ctx.shadowOffsetY = 1e6;
+    @assert ctx.shadowOffsetX === 1e6;
+    @assert ctx.shadowOffsetY === 1e6;
+
+- name: 2d.shadow.attributes.shadowOffset.invalid
+  testing:
+  - 2d.shadow.offset.invalid
+  code: |
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    ctx.shadowOffsetX = Infinity;
+    ctx.shadowOffsetY = Infinity;
+    @assert ctx.shadowOffsetX === 1;
+    @assert ctx.shadowOffsetY === 2;
+
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    ctx.shadowOffsetX = -Infinity;
+    ctx.shadowOffsetY = -Infinity;
+    @assert ctx.shadowOffsetX === 1;
+    @assert ctx.shadowOffsetY === 2;
+
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    ctx.shadowOffsetX = NaN;
+    ctx.shadowOffsetY = NaN;
+    @assert ctx.shadowOffsetX === 1;
+    @assert ctx.shadowOffsetY === 2;
+
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    ctx.shadowOffsetX = 'string';
+    ctx.shadowOffsetY = 'string';
+    @assert ctx.shadowOffsetX === 1;
+    @assert ctx.shadowOffsetY === 2;
+
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    ctx.shadowOffsetX = true;
+    ctx.shadowOffsetY = true;
+    @assert ctx.shadowOffsetX === 1;
+    @assert ctx.shadowOffsetY === 1;
+
+    ctx.shadowOffsetX = 1;
+    ctx.shadowOffsetY = 2;
+    ctx.shadowOffsetX = false;
+    ctx.shadowOffsetY = false;
+    @assert ctx.shadowOffsetX === 0;
+    @assert ctx.shadowOffsetY === 0;
+
+- name: 2d.shadow.attributes.shadowColor.initial
+  testing:
+  - 2d.shadow.color.initial
+  code: |
+    @assert ctx.shadowColor === 'rgba(0, 0, 0, 0)';
+
+- name: 2d.shadow.attributes.shadowColor.valid
+  testing:
+  - 2d.shadow.color.get
+  - 2d.shadow.color.set
+  code: |
+    ctx.shadowColor = 'lime';
+    @assert ctx.shadowColor === '#00ff00';
+
+    ctx.shadowColor = 'RGBA(0,255, 0,0)';
+    @assert ctx.shadowColor === 'rgba(0, 255, 0, 0)';
+
+- name: 2d.shadow.attributes.shadowColor.invalid
+  testing:
+  - 2d.shadow.color.invalid
+  code: |
+    ctx.shadowColor = '#00ff00';
+    ctx.shadowColor = 'bogus';
+    @assert ctx.shadowColor === '#00ff00';
+
+    ctx.shadowColor = '#00ff00';
+    ctx.shadowColor = 'red bogus';
+    @assert ctx.shadowColor === '#00ff00';
+
+    ctx.shadowColor = '#00ff00';
+    ctx.shadowColor = ctx;
+    @assert ctx.shadowColor === '#00ff00';
+
+    ctx.shadowColor = '#00ff00';
+    ctx.shadowColor = undefined;
+    @assert ctx.shadowColor === '#00ff00';
+
+- name: 2d.shadow.enable.off.1
+  desc: Shadows are not drawn when only shadowColor is set
+  testing:
+  - 2d.shadow.enable
+  - 2d.shadow.render
+  code: |
+    ctx.shadowColor = '#f00';
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.enable.off.2
+  desc: Shadows are not drawn when only shadowColor is set
+  testing:
+  - 2d.shadow.enable
+  - 2d.shadow.render
+  code: |
+    ctx.globalCompositeOperation = 'destination-atop';
+    ctx.shadowColor = '#f00';
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.enable.blur
+  desc: Shadows are drawn if shadowBlur is set
+  testing:
+  - 2d.shadow.enable
+  - 2d.shadow.render
+  code: |
+    ctx.globalCompositeOperation = 'destination-atop';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowBlur = 0.1;
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.enable.x
+  desc: Shadows are drawn if shadowOffsetX is set
+  testing:
+  - 2d.shadow.enable
+  - 2d.shadow.render
+  code: |
+    ctx.globalCompositeOperation = 'destination-atop';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = 0.1;
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.enable.y
+  desc: Shadows are drawn if shadowOffsetY is set
+  testing:
+  - 2d.shadow.enable
+  - 2d.shadow.render
+  code: |
+    ctx.globalCompositeOperation = 'destination-atop';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 0.1;
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.offset.positiveX
+  desc: Shadows can be offset with positive x
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = 50;
+    ctx.fillRect(0, 0, 50, 50);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.offset.negativeX
+  desc: Shadows can be offset with negative x
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = -50;
+    ctx.fillRect(50, 0, 50, 50);
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.offset.positiveY
+  desc: Shadows can be offset with positive y
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 25;
+    ctx.fillRect(0, 0, 100, 25);
+    @assert pixel 50,12 == 0,255,0,255;
+    @assert pixel 50,37 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.offset.negativeY
+  desc: Shadows can be offset with negative y
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = -25;
+    ctx.fillRect(0, 25, 100, 25);
+    @assert pixel 50,12 == 0,255,0,255;
+    @assert pixel 50,37 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.outside
+  desc: Shadows of shapes outside the visible area can be offset onto the visible
+    area
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = 100;
+    ctx.fillRect(-100, 0, 25, 50);
+    ctx.shadowOffsetX = -100;
+    ctx.fillRect(175, 0, 25, 50);
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 100;
+    ctx.fillRect(25, -100, 50, 25);
+    ctx.shadowOffsetY = -100;
+    ctx.fillRect(25, 125, 50, 25);
+    @assert pixel 12,25 == 0,255,0,255;
+    @assert pixel 87,25 == 0,255,0,255;
+    @assert pixel 50,12 == 0,255,0,255;
+    @assert pixel 50,37 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.clip.1
+  desc: Shadows of clipped shapes are still drawn within the clipping region
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(50, 0, 50, 50);
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(50, 0, 50, 50);
+    ctx.clip();
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = 50;
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.restore();
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.clip.2
+  desc: Shadows are not drawn outside the clipping region
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(50, 0, 50, 50);
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, 50, 50);
+    ctx.clip();
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetX = 50;
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.restore();
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.clip.3
+  desc: Shadows of clipped shapes are still drawn within the clipping region
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(50, 0, 50, 50);
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, 50, 50);
+    ctx.clip();
+    ctx.fillStyle = '#f00';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = 50;
+    ctx.fillRect(-50, 0, 50, 50);
+    ctx.restore();
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.stroke.basic
+  desc: Shadows are drawn for strokes
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 50;
+    ctx.beginPath();
+    ctx.lineWidth = 50;
+    ctx.moveTo(0, -25);
+    ctx.lineTo(100, -25);
+    ctx.stroke();
+
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.stroke.cap.1
+  desc: Shadows are not drawn for areas outside stroke caps
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetY = 50;
+    ctx.beginPath();
+    ctx.lineWidth = 50;
+    ctx.lineCap = 'butt';
+    ctx.moveTo(-50, -25);
+    ctx.lineTo(0, -25);
+    ctx.moveTo(100, -25);
+    ctx.lineTo(150, -25);
+    ctx.stroke();
+
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.stroke.cap.2
+  desc: Shadows are drawn for stroke caps
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 50;
+    ctx.beginPath();
+    ctx.lineWidth = 50;
+    ctx.lineCap = 'square';
+    ctx.moveTo(25, -25);
+    ctx.lineTo(75, -25);
+    ctx.stroke();
+
+    @assert pixel 1,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.stroke.join.1
+  desc: Shadows are not drawn for areas outside stroke joins
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetX = 100;
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'bevel';
+    ctx.beginPath();
+    ctx.moveTo(-200, -50);
+    ctx.lineTo(-150, -50);
+    ctx.lineTo(-151, -100);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.stroke.join.2
+  desc: Shadows are drawn for stroke joins
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(50, 0, 50, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetX = 100;
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'miter';
+    ctx.beginPath();
+    ctx.moveTo(-200, -50);
+    ctx.lineTo(-150, -50);
+    ctx.lineTo(-151, -100);
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.stroke.join.3
+  desc: Shadows are drawn for stroke joins respecting miter limit
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.strokeStyle = '#f00';
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetX = 100;
+    ctx.lineWidth = 200;
+    ctx.lineJoin = 'miter';
+    ctx.miterLimit = 0.1;
+    ctx.beginPath();
+    ctx.moveTo(-200, -50);
+    ctx.lineTo(-150, -50);
+    ctx.lineTo(-151, -100); // (not an exact right angle, to avoid some other bug in Firefox 3)
+    ctx.stroke();
+
+    @assert pixel 1,1 == 0,255,0,255;
+    @assert pixel 48,48 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,48 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.image.basic
+  desc: Shadows are drawn for images
+  testing:
+  - 2d.shadow.render
+  images:
+  - red.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 50;
+    ctx.drawImage(document.getElementById('red.png'), 0, -50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.image.transparent.1
+  desc: Shadows are not drawn for transparent images
+  testing:
+  - 2d.shadow.render
+  images:
+  - transparent.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetY = 50;
+    ctx.drawImage(document.getElementById('transparent.png'), 0, -50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.image.transparent.2
+  desc: Shadows are not drawn for transparent parts of images
+  testing:
+  - 2d.shadow.render
+  images:
+  - redtransparent.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(50, 0, 50, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.drawImage(document.getElementById('redtransparent.png'), 50, -50);
+    ctx.shadowColor = '#f00';
+    ctx.drawImage(document.getElementById('redtransparent.png'), -50, -50);
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.image.alpha
+  desc: Shadows are drawn correctly for partially-transparent images
+  testing:
+  - 2d.shadow.render
+  images:
+  - transparent50.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#00f';
+    ctx.drawImage(document.getElementById('transparent50.png'), 0, -50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.image.section
+  desc: Shadows are not drawn for areas outside image source rectangles
+  testing:
+  - 2d.shadow.render
+  images:
+  - redtransparent.png
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#f00';
+    ctx.drawImage(document.getElementById('redtransparent.png'), 50, 0, 50, 50, 0, -50, 50, 50);
+
+    @assert pixel 25,25 ==~ 0,255,0,255;
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 75,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.image.scale
+  desc: Shadows are drawn correctly for scaled images
+  testing:
+  - 2d.shadow.render
+  images:
+  - redtransparent.png
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.drawImage(document.getElementById('redtransparent.png'), 0, 0, 100, 50, -10, -50, 240, 50);
+
+    @assert pixel 25,25 ==~ 0,255,0,255;
+    @assert pixel 50,25 ==~ 0,255,0,255;
+    @assert pixel 75,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.canvas.basic
+  desc: Shadows are drawn for canvases
+  testing:
+  - 2d.shadow.render
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#f00';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 50;
+    ctx.drawImage(canvas2, 0, -50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.canvas.transparent.1
+  desc: Shadows are not drawn for transparent canvases
+  testing:
+  - 2d.shadow.render
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetY = 50;
+    ctx.drawImage(canvas2, 0, -50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.canvas.transparent.2
+  desc: Shadows are not drawn for transparent parts of canvases
+  testing:
+  - 2d.shadow.render
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = '#f00';
+    ctx2.fillRect(0, 0, 50, 50);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(50, 0, 50, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.drawImage(canvas2, 50, -50);
+    ctx.shadowColor = '#f00';
+    ctx.drawImage(canvas2, -50, -50);
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.canvas.alpha
+  desc: Shadows are drawn correctly for partially-transparent canvases
+  testing:
+  - 2d.shadow.render
+  images:
+  - transparent50.png
+  code: |
+    var canvas2 = document.createElement('canvas');
+    canvas2.width = 100;
+    canvas2.height = 50;
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.fillStyle = 'rgba(255, 0, 0, 0.5)';
+    ctx2.fillRect(0, 0, 100, 50);
+
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#00f';
+    ctx.drawImage(canvas2, 0, -50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.pattern.basic
+  desc: Shadows are drawn for fill patterns
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  images:
+  - red.png
+  code: |
+    var pattern = ctx.createPattern(document.getElementById('red.png'), 'repeat');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 50;
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.pattern.transparent.1
+  desc: Shadows are not drawn for transparent fill patterns
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  images:
+  - transparent.png
+  code: |
+    var pattern = ctx.createPattern(document.getElementById('transparent.png'), 'repeat');
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetY = 50;
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.pattern.transparent.2
+  desc: Shadows are not drawn for transparent parts of fill patterns
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  images:
+  - redtransparent.png
+  code: |
+    var pattern = ctx.createPattern(document.getElementById('redtransparent.png'), 'repeat');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(50, 0, 50, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.pattern.alpha
+  desc: Shadows are drawn correctly for partially-transparent fill patterns
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  images:
+  - transparent50.png
+  code: |
+    var pattern = ctx.createPattern(document.getElementById('transparent50.png'), 'repeat');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#00f';
+    ctx.fillStyle = pattern;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.gradient.basic
+  desc: Shadows are drawn for gradient fills
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  code: |
+    var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+    gradient.addColorStop(0, '#f00');
+    gradient.addColorStop(1, '#f00');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#0f0';
+    ctx.shadowOffsetY = 50;
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.gradient.transparent.1
+  desc: Shadows are not drawn for transparent gradient fills
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  code: |
+    var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+    gradient.addColorStop(0, 'rgba(0,0,0,0)');
+    gradient.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetY = 50;
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.gradient.transparent.2
+  desc: Shadows are not drawn for transparent parts of gradient fills
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  code: |
+    var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+    gradient.addColorStop(0, '#f00');
+    gradient.addColorStop(0.499, '#f00');
+    gradient.addColorStop(0.5, 'rgba(0,0,0,0)');
+    gradient.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 50, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(50, 0, 50, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.gradient.alpha
+  desc: Shadows are drawn correctly for partially-transparent gradient fills
+  testing:
+  - 2d.shadow.render
+  # http://bugs.webkit.org/show_bug.cgi?id=15266
+  code: |
+    var gradient = ctx.createLinearGradient(0, 0, 100, 0);
+    gradient.addColorStop(0, 'rgba(255,0,0,0.5)');
+    gradient.addColorStop(1, 'rgba(255,0,0,0.5)');
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#00f';
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.transform.1
+  desc: Shadows take account of transformations
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.translate(100, 100);
+    ctx.fillRect(-100, -150, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.transform.2
+  desc: Shadow offsets are not affected by transformations
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowOffsetY = 50;
+    ctx.shadowColor = '#0f0';
+    ctx.rotate(Math.PI)
+    ctx.fillRect(-100, 0, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.blur.low
+  desc: Shadows look correct for small blurs
+  manual:
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#ff0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#00f';
+    ctx.shadowOffsetY = 25;
+    for (var x = 0; x < 100; ++x) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(x, 0, 1, 50);
+        ctx.clip();
+        ctx.shadowBlur = x;
+        ctx.fillRect(-200, -200, 500, 200);
+        ctx.restore();
+    }
+  expected: |
+    size 100 50
+    import math
+    cr.set_source_rgb(0, 0, 1)
+    cr.rectangle(0, 0, 1, 25)
+    cr.fill()
+    cr.set_source_rgb(1, 1, 0)
+    cr.rectangle(0, 25, 1, 25)
+    cr.fill()
+    for x in range(1, 100):
+        sigma = x/2.0
+        filter = []
+        for i in range(-24, 26):
+            filter.append(math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma))
+        accum = [0]
+        for f in filter:
+            accum.append(accum[-1] + f)
+        for y in range(0, 50):
+            cr.set_source_rgb(accum[y], accum[y], 1-accum[y])
+            cr.rectangle(x, y, 1, 1)
+            cr.fill()
+
+- name: 2d.shadow.blur.high
+  desc: Shadows look correct for large blurs
+  manual:
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#ff0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = '#00f';
+    ctx.shadowOffsetY = 0;
+    ctx.shadowBlur = 100;
+    ctx.fillRect(-200, -200, 200, 400);
+  expected: |
+    size 100 50
+    import math
+    sigma = 100.0/2
+    filter = []
+    for i in range(-200, 100):
+        filter.append(math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma))
+    accum = [0]
+    for f in filter:
+        accum.append(accum[-1] + f)
+    for x in range(0, 100):
+        cr.set_source_rgb(accum[x+200], accum[x+200], 1-accum[x+200])
+        cr.rectangle(x, 0, 1, 50)
+        cr.fill()
+
+- name: 2d.shadow.alpha.1
+  desc: Shadow color alpha components are used
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = 'rgba(255, 0, 0, 0.01)';
+    ctx.shadowOffsetY = 50;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 0,255,0,255 +/- 4;
+  expected: green
+
+- name: 2d.shadow.alpha.2
+  desc: Shadow color alpha components are used
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.shadowColor = 'rgba(0, 0, 255, 0.5)';
+    ctx.shadowOffsetY = 50;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.alpha.3
+  desc: Shadows are affected by globalAlpha
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00'; // (work around broken Firefox globalAlpha caching)
+    ctx.shadowColor = '#00f';
+    ctx.shadowOffsetY = 50;
+    ctx.globalAlpha = 0.5;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.alpha.4
+  desc: Shadows with alpha components are correctly affected by globalAlpha
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00'; // (work around broken Firefox globalAlpha caching)
+    ctx.shadowColor = 'rgba(0, 0, 255, 0.707)';
+    ctx.shadowOffsetY = 50;
+    ctx.globalAlpha = 0.707;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.alpha.5
+  desc: Shadows of shapes with alpha components are drawn correctly
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = 'rgba(64, 0, 0, 0.5)';
+    ctx.shadowColor = '#00f';
+    ctx.shadowOffsetY = 50;
+    ctx.fillRect(0, -50, 100, 50);
+
+    @assert pixel 50,25 ==~ 127,0,127,255;
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0.5, 0, 0.5)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+
+- name: 2d.shadow.composite.1
+  desc: Shadows are drawn using globalCompositeOperation
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = 'xor';
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetX = 100;
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, 0, 200, 50);
+
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.composite.2
+  desc: Shadows are drawn using globalCompositeOperation
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = 'xor';
+    ctx.shadowColor = '#f00';
+    ctx.shadowBlur = 1;
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-10, -10, 120, 70);
+
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green
+
+- name: 2d.shadow.composite.3
+  desc: Areas outside shadows are drawn correctly with destination-out
+  testing:
+  - 2d.shadow.render
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.globalCompositeOperation = 'destination-out';
+    ctx.shadowColor = '#f00';
+    ctx.shadowBlur = 10;
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(200, 0, 100, 50);
+
+    @assert pixel 5,5 ==~ 0,255,0,255;
+    @assert pixel 50,25 ==~ 0,255,0,255;
+  expected: green

--- a/test/wpt/text-styles.yaml
+++ b/test/wpt/text-styles.yaml
@@ -1,0 +1,525 @@
+- name: 2d.text.font.parse.basic
+  testing:
+  - 2d.text.font.parse
+  - 2d.text.font.get
+  code: |
+    ctx.font = '20px serif';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20PX   SERIF';
+    @assert ctx.font === '20px serif'; @moz-todo
+
+- name: 2d.text.font.parse.tiny
+  testing:
+  - 2d.text.font.parse
+  - 2d.text.font.get
+  code: |
+    ctx.font = '1px sans-serif';
+    @assert ctx.font === '1px sans-serif';
+
+- name: 2d.text.font.parse.complex
+  testing:
+  - 2d.text.font.parse
+  - 2d.text.font.get
+  - 2d.text.font.lineheight
+  code: |
+    ctx.font = 'small-caps italic 400 12px/2 Unknown Font, sans-serif';
+    @assert ctx.font === 'italic small-caps 12px "Unknown Font", sans-serif'; @moz-todo
+
+- name: 2d.text.font.parse.family
+  testing:
+  - 2d.text.font.parse
+  - 2d.text.font.get
+  - 2d.text.font.lineheight
+  code: |
+    ctx.font = '20px cursive,fantasy,monospace,sans-serif,serif,UnquotedFont,"QuotedFont\\\\\\","';
+    @assert ctx.font === '20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\\\\","';
+
+  # TODO:
+  #   2d.text.font.parse.size.absolute
+  #     xx-small x-small small medium large x-large xx-large
+  #   2d.text.font.parse.size.relative
+  #     smaller larger
+  #   2d.text.font.parse.size.length.relative
+  #     em ex px
+  #   2d.text.font.parse.size.length.absolute
+  #     in cm mm pt pc
+
+- name: 2d.text.font.parse.size.percentage
+  testing:
+  - 2d.text.font.parse
+  - 2d.text.font.get
+  - 2d.text.font.fontsize
+  - 2d.text.font.size
+  canvas: 'style="font-size: 144px" width="100" height="50"'
+  code: |
+    ctx.font = '50% serif';
+    @assert ctx.font === '72px serif'; @moz-todo
+    canvas.setAttribute('style', 'font-size: 100px');
+    @assert ctx.font === '72px serif'; @moz-todo
+
+- name: 2d.text.font.parse.size.percentage.default
+  testing:
+  - 2d.text.font.undefined
+  code: |
+    var canvas2 = document.createElement('canvas');
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.font = '1000% serif';
+    @assert ctx2.font === '100px serif'; @moz-todo
+
+- name: 2d.text.font.parse.system
+  desc: System fonts must be computed to explicit values
+  testing:
+  - 2d.text.font.parse
+  - 2d.text.font.get
+  - 2d.text.font.systemfonts
+  code: |
+    ctx.font = 'message-box';
+    @assert ctx.font !== 'message-box';
+
+- name: 2d.text.font.parse.invalid
+  testing:
+  - 2d.text.font.invalid
+  code: |
+    ctx.font = '20px serif';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = '';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = 'bogus';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = 'inherit';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = '10px {bogus}';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = '10px initial';
+    @assert ctx.font === '20px serif'; @moz-todo
+
+    ctx.font = '20px serif';
+    ctx.font = '10px default';
+    @assert ctx.font === '20px serif'; @moz-todo
+
+    ctx.font = '20px serif';
+    ctx.font = '10px inherit';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = '10px revert';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = 'var(--x)';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = 'var(--x, 10px serif)';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
+    ctx.font = '1em serif; background: green; margin: 10px';
+    @assert ctx.font === '20px serif';
+
+- name: 2d.text.font.default
+  testing:
+  - 2d.text.font.default
+  code: |
+    @assert ctx.font === '10px sans-serif';
+
+- name: 2d.text.font.relative_size
+  testing:
+  - 2d.text.font.relative_size
+  code: |
+    var canvas2 = document.createElement('canvas');
+    var ctx2 = canvas2.getContext('2d');
+    ctx2.font = '1em sans-serif';
+    @assert ctx2.font === '10px sans-serif';
+
+- name: 2d.text.align.valid
+  testing:
+  - 2d.text.align.get
+  - 2d.text.align.set
+  code: |
+    ctx.textAlign = 'start';
+    @assert ctx.textAlign === 'start';
+
+    ctx.textAlign = 'end';
+    @assert ctx.textAlign === 'end';
+
+    ctx.textAlign = 'left';
+    @assert ctx.textAlign === 'left';
+
+    ctx.textAlign = 'right';
+    @assert ctx.textAlign === 'right';
+
+    ctx.textAlign = 'center';
+    @assert ctx.textAlign === 'center';
+
+- name: 2d.text.align.invalid
+  testing:
+  - 2d.text.align.invalid
+  code: |
+    ctx.textAlign = 'start';
+    ctx.textAlign = 'bogus';
+    @assert ctx.textAlign === 'start';
+
+    ctx.textAlign = 'start';
+    ctx.textAlign = 'END';
+    @assert ctx.textAlign === 'start';
+
+    ctx.textAlign = 'start';
+    ctx.textAlign = 'end ';
+    @assert ctx.textAlign === 'start';
+
+    ctx.textAlign = 'start';
+    ctx.textAlign = 'end\0';
+    @assert ctx.textAlign === 'start';
+
+- name: 2d.text.align.default
+  testing:
+  - 2d.text.align.default
+  code: |
+    @assert ctx.textAlign === 'start';
+
+
+- name: 2d.text.baseline.valid
+  testing:
+  - 2d.text.baseline.get
+  - 2d.text.baseline.set
+  code: |
+    ctx.textBaseline = 'top';
+    @assert ctx.textBaseline === 'top';
+
+    ctx.textBaseline = 'hanging';
+    @assert ctx.textBaseline === 'hanging';
+
+    ctx.textBaseline = 'middle';
+    @assert ctx.textBaseline === 'middle';
+
+    ctx.textBaseline = 'alphabetic';
+    @assert ctx.textBaseline === 'alphabetic';
+
+    ctx.textBaseline = 'ideographic';
+    @assert ctx.textBaseline === 'ideographic';
+
+    ctx.textBaseline = 'bottom';
+    @assert ctx.textBaseline === 'bottom';
+
+- name: 2d.text.baseline.invalid
+  testing:
+  - 2d.text.baseline.invalid
+  code: |
+    ctx.textBaseline = 'top';
+    ctx.textBaseline = 'bogus';
+    @assert ctx.textBaseline === 'top';
+
+    ctx.textBaseline = 'top';
+    ctx.textBaseline = 'MIDDLE';
+    @assert ctx.textBaseline === 'top';
+
+    ctx.textBaseline = 'top';
+    ctx.textBaseline = 'middle ';
+    @assert ctx.textBaseline === 'top';
+
+    ctx.textBaseline = 'top';
+    ctx.textBaseline = 'middle\0';
+    @assert ctx.textBaseline === 'top';
+
+- name: 2d.text.baseline.default
+  testing:
+  - 2d.text.baseline.default
+  code: |
+    @assert ctx.textBaseline === 'alphabetic';
+
+
+
+
+
+- name: 2d.text.draw.baseline.top
+  desc: textBaseline top is the top of the em square (not the bounding box)
+  testing:
+  - 2d.text.baseline.top
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textBaseline = 'top';
+        ctx.fillText('CC', 0, 0);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.baseline.bottom
+  desc: textBaseline bottom is the bottom of the em square (not the bounding box)
+  testing:
+  - 2d.text.baseline.bottom
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textBaseline = 'bottom';
+        ctx.fillText('CC', 0, 50);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.baseline.middle
+  desc: textBaseline middle is the middle of the em square (not the bounding box)
+  testing:
+  - 2d.text.baseline.middle
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('CC', 0, 25);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.baseline.alphabetic
+  testing:
+  - 2d.text.baseline.alphabetic
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textBaseline = 'alphabetic';
+        ctx.fillText('CC', 0, 37.5);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.baseline.ideographic
+  testing:
+  - 2d.text.baseline.ideographic
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textBaseline = 'ideographic';
+        ctx.fillText('CC', 0, 31.25);
+        @assert pixel 5,5 ==~ 0,255,0,255;
+        @assert pixel 95,5 ==~ 0,255,0,255;
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 95,45 ==~ 0,255,0,255; @moz-todo
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.baseline.hanging
+  testing:
+  - 2d.text.baseline.hanging
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textBaseline = 'hanging';
+        ctx.fillText('CC', 0, 12.5);
+        @assert pixel 5,5 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 95,5 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255;
+        @assert pixel 5,45 ==~ 0,255,0,255;
+        @assert pixel 95,45 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.space.collapse.space
+  desc: Space characters are converted to U+0020, and collapsed (per CSS)
+  testing:
+  - 2d.text.draw.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('E  EE', -100, 37.5);
+        @assert pixel 25,25 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.space.collapse.other
+  desc: Space characters are converted to U+0020, and collapsed (per CSS)
+  testing:
+  - 2d.text.draw.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText('E \x09\x0a\x0c\x0d  \x09\x0a\x0c\x0dEE', -100, 37.5);
+        @assert pixel 25,25 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 75,25 ==~ 0,255,0,255; @moz-todo
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.space.collapse.start
+  desc: Space characters at the start of a line are collapsed (per CSS)
+  testing:
+  - 2d.text.draw.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.fillText(' EE', 0, 37.5);
+        @assert pixel 25,25 ==~ 0,255,0,255; @moz-todo
+        @assert pixel 75,25 ==~ 0,255,0,255;
+    }), 500);
+  expected: green
+
+- name: 2d.text.draw.space.collapse.end
+  desc: Space characters at the end of a line are collapsed (per CSS)
+  testing:
+  - 2d.text.draw.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    ctx.font = '50px CanvasTest';
+    deferTest();
+    step_timeout(t.step_func_done(function () {
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 100, 50);
+        ctx.fillStyle = '#0f0';
+        ctx.textAlign = 'right';
+        ctx.fillText('EE ', 100, 37.5);
+        @assert pixel 25,25 ==~ 0,255,0,255;
+        @assert pixel 75,25 ==~ 0,255,0,255; @moz-todo
+    }), 500);
+  expected: green
+
+
+- name: 2d.text.measure.width.space
+  desc: Space characters are converted to U+0020 and collapsed (per CSS)
+  testing:
+  - 2d.text.measure.spaces
+  fonts:
+  - CanvasTest
+  code: |
+    deferTest();
+    var f = new FontFace("CanvasTest", "/fonts/CanvasTest.ttf");
+    document.fonts.add(f);
+    document.fonts.ready.then(() => {
+        step_timeout(t.step_func_done(function () {
+            ctx.font = '50px CanvasTest';
+            @assert ctx.measureText('A B').width === 150;
+            @assert ctx.measureText('A  B').width === 200;
+            @assert ctx.measureText('A \x09\x0a\x0c\x0d  \x09\x0a\x0c\x0dB').width === 150; @moz-todo
+            @assert ctx.measureText('A \x0b B').width >= 200;
+
+            @assert ctx.measureText(' AB').width === 100; @moz-todo
+            @assert ctx.measureText('AB ').width === 100; @moz-todo
+        }), 500);
+    });
+
+- name: 2d.text.measure.rtl.text
+  desc: Measurement should follow canvas direction instead text direction
+  testing:
+  - 2d.text.measure.rtl.text
+  fonts:
+  - CanvasTest
+  code: |
+    metrics = ctx.measureText('اَلْعَرَبِيَّةُ');
+    @assert metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight;
+
+    metrics = ctx.measureText('hello');
+    @assert metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight;
+
+- name: 2d.text.measure.boundingBox.textAlign
+  desc: Measurement should be related to textAlignment
+  testing:
+  - 2d.text.measure.boundingBox.textAlign
+  code: |
+    ctx.textAlign = "right";
+    metrics = ctx.measureText('hello');
+    @assert metrics.actualBoundingBoxLeft > metrics.actualBoundingBoxRight;
+
+    ctx.textAlign = "left"
+    metrics = ctx.measureText('hello');
+    @assert metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight;
+
+- name: 2d.text.measure.boundingBox.direction
+  desc: Measurement should follow text direction
+  testing:
+  - 2d.text.measure.boundingBox.direction
+  code: |
+    ctx.direction = "ltr";
+    metrics = ctx.measureText('hello');
+    @assert metrics.actualBoundingBoxLeft < metrics.actualBoundingBoxRight;
+
+    ctx.direction = "rtl";
+    metrics = ctx.measureText('hello');
+    @assert metrics.actualBoundingBoxLeft > metrics.actualBoundingBoxRight;

--- a/test/wpt/the-canvas-element.yaml
+++ b/test/wpt/the-canvas-element.yaml
@@ -1,0 +1,169 @@
+- name: 2d.getcontext.exists
+  desc: The 2D context is implemented
+  testing:
+  - context.2d
+  code: |
+    @assert canvas.getContext('2d') !== null;
+
+- name: 2d.getcontext.invalid.args
+  desc: Calling getContext with invalid arguments.
+  testing:
+  - context.2d
+  code: |
+    @assert canvas.getContext('') === null;
+    @assert canvas.getContext('2d#') === null;
+    @assert canvas.getContext('This is clearly not a valid context name.') === null;
+    @assert canvas.getContext('2d\0') === null;
+    @assert canvas.getContext('2\uFF44') === null;
+    @assert canvas.getContext('2D') === null;
+    @assert throws TypeError canvas.getContext();
+    @assert canvas.getContext('null') === null;
+    @assert canvas.getContext('undefined') === null;
+
+- name: 2d.getcontext.extraargs.create
+  desc: The 2D context doesn't throw with extra getContext arguments (new context)
+  testing:
+  - context.2d.extraargs
+  code: |
+    @assert document.createElement("canvas").getContext('2d', false, {}, [], 1, "2") !== null;
+    @assert document.createElement("canvas").getContext('2d', 123) !== null;
+    @assert document.createElement("canvas").getContext('2d', "test") !== null;
+    @assert document.createElement("canvas").getContext('2d', undefined) !== null;
+    @assert document.createElement("canvas").getContext('2d', null) !== null;
+    @assert document.createElement("canvas").getContext('2d', Symbol.hasInstance) !== null;
+
+- name: 2d.getcontext.extraargs.cache
+  desc: The 2D context doesn't throw with extra getContext arguments (cached)
+  testing:
+  - context.2d.extraargs
+  code: |
+    @assert canvas.getContext('2d', false, {}, [], 1, "2") !== null;
+    @assert canvas.getContext('2d', 123) !== null;
+    @assert canvas.getContext('2d', "test") !== null;
+    @assert canvas.getContext('2d', undefined) !== null;
+    @assert canvas.getContext('2d', null) !== null;
+    @assert canvas.getContext('2d', Symbol.hasInstance) !== null;
+
+- name: 2d.type.exists
+  desc: The 2D context interface is a property of 'window'
+  notes: &bindings Defined in "Web IDL" (draft)
+  testing:
+  - context.2d.type
+  code: |
+    @assert window.CanvasRenderingContext2D;
+
+- name: 2d.type.prototype
+  desc: window.CanvasRenderingContext2D.prototype are not [[Writable]] and not [[Configurable]],
+    and its methods are [[Configurable]].
+  notes: *bindings
+  testing:
+  - context.2d.type
+  code: |
+    @assert window.CanvasRenderingContext2D.prototype;
+    @assert window.CanvasRenderingContext2D.prototype.fill;
+    window.CanvasRenderingContext2D.prototype = null;
+    @assert window.CanvasRenderingContext2D.prototype;
+    delete window.CanvasRenderingContext2D.prototype;
+    @assert window.CanvasRenderingContext2D.prototype;
+    window.CanvasRenderingContext2D.prototype.fill = 1;
+    @assert window.CanvasRenderingContext2D.prototype.fill === 1;
+    delete window.CanvasRenderingContext2D.prototype.fill;
+    @assert window.CanvasRenderingContext2D.prototype.fill === undefined;
+
+- name: 2d.type.replace
+  desc: Interface methods can be overridden
+  notes: *bindings
+  testing:
+  - context.2d.type
+  code: |
+    var fillRect = window.CanvasRenderingContext2D.prototype.fillRect;
+    window.CanvasRenderingContext2D.prototype.fillRect = function (x, y, w, h)
+    {
+        this.fillStyle = '#0f0';
+        fillRect.call(this, x, y, w, h);
+    };
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.type.extend
+  desc: Interface methods can be added
+  notes: *bindings
+  testing:
+  - context.2d.type
+  code: |
+    window.CanvasRenderingContext2D.prototype.fillRectGreen = function (x, y, w, h)
+    {
+        this.fillStyle = '#0f0';
+        this.fillRect(x, y, w, h);
+    };
+    ctx.fillStyle = '#f00';
+    ctx.fillRectGreen(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.getcontext.unique
+  desc: getContext('2d') returns the same object
+  testing:
+  - context.unique
+  code: |
+    @assert canvas.getContext('2d') === canvas.getContext('2d');
+
+- name: 2d.getcontext.shared
+  desc: getContext('2d') returns objects which share canvas state
+  testing:
+  - context.unique
+  code: |
+    var ctx2 = canvas.getContext('2d');
+    ctx.fillStyle = '#f00';
+    ctx2.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.scaled
+  desc: CSS-scaled canvases get drawn correctly
+  canvas: 'width="50" height="25" style="width: 100px; height: 50px"'
+  manual:
+  code: |
+    ctx.fillStyle = '#00f';
+    ctx.fillRect(0, 0, 50, 25);
+    ctx.fillStyle = '#0ff';
+    ctx.fillRect(0, 0, 25, 10);
+  expected: |
+    size 100 50
+    cr.set_source_rgb(0, 0, 1)
+    cr.rectangle(0, 0, 100, 50)
+    cr.fill()
+    cr.set_source_rgb(0, 1, 1)
+    cr.rectangle(0, 0, 50, 20)
+    cr.fill()
+
+- name: 2d.canvas.reference
+  desc: CanvasRenderingContext2D.canvas refers back to its canvas
+  testing:
+  - 2d.canvas
+  code: |
+    @assert ctx.canvas === canvas;
+
+- name: 2d.canvas.readonly
+  desc: CanvasRenderingContext2D.canvas is readonly
+  testing:
+  - 2d.canvas.attribute
+  code: |
+    var c = document.createElement('canvas');
+    var d = ctx.canvas;
+    @assert c !== d;
+    ctx.canvas = c;
+    @assert ctx.canvas === d;
+
+- name: 2d.canvas.context
+  desc: checks CanvasRenderingContext2D prototype
+  testing:
+  - 2d.path.contexttypexxx.basic
+  code: |
+    @assert Object.getPrototypeOf(CanvasRenderingContext2D.prototype) === Object.prototype;
+    @assert Object.getPrototypeOf(ctx) === CanvasRenderingContext2D.prototype;
+    t.done();
+

--- a/test/wpt/the-canvas-state.yaml
+++ b/test/wpt/the-canvas-state.yaml
@@ -1,0 +1,107 @@
+- name: 2d.state.saverestore.transformation
+  desc: save()/restore() affects the current transformation matrix
+  testing:
+  - 2d.state.transformation
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.save();
+    ctx.translate(200, 0);
+    ctx.restore();
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(-200, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.state.saverestore.clip
+  desc: save()/restore() affects the clipping path
+  testing:
+  - 2d.state.clip
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.save();
+    ctx.rect(0, 0, 1, 1);
+    ctx.clip();
+    ctx.restore();
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.state.saverestore.path
+  desc: save()/restore() does not affect the current path
+  testing:
+  - 2d.state.path
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.save();
+    ctx.rect(0, 0, 100, 50);
+    ctx.restore();
+    ctx.fillStyle = '#0f0';
+    ctx.fill();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.state.saverestore.bitmap
+  desc: save()/restore() does not affect the current bitmap
+  testing:
+  - 2d.state.bitmap
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.save();
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.restore();
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.state.saverestore.stack
+  desc: save()/restore() can be nested as a stack
+  testing:
+  - 2d.state.save
+  - 2d.state.restore
+  code: |
+    ctx.lineWidth = 1;
+    ctx.save();
+    ctx.lineWidth = 2;
+    ctx.save();
+    ctx.lineWidth = 3;
+    @assert ctx.lineWidth === 3;
+    ctx.restore();
+    @assert ctx.lineWidth === 2;
+    ctx.restore();
+    @assert ctx.lineWidth === 1;
+
+- name: 2d.state.saverestore.stackdepth
+  desc: save()/restore() stack depth is not unreasonably limited
+  testing:
+  - 2d.state.save
+  - 2d.state.restore
+  code: |
+    var limit = 512;
+    for (var i = 1; i < limit; ++i)
+    {
+        ctx.save();
+        ctx.lineWidth = i;
+    }
+    for (var i = limit-1; i > 0; --i)
+    {
+        @assert ctx.lineWidth === i;
+        ctx.restore();
+    }
+
+- name: 2d.state.saverestore.underflow
+  desc: restore() with an empty stack has no effect
+  testing:
+  - 2d.state.restore.underflow
+  code: |
+    for (var i = 0; i < 16; ++i)
+        ctx.restore();
+    ctx.lineWidth = 0.5;
+    ctx.restore();
+    @assert ctx.lineWidth === 0.5;
+
+

--- a/test/wpt/transformations.yaml
+++ b/test/wpt/transformations.yaml
@@ -1,0 +1,402 @@
+- name: 2d.transformation.order
+  desc: Transformations are applied in the right order
+  testing:
+  - 2d.transformation.order
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.scale(2, 1);
+    ctx.rotate(Math.PI / 2);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, -50, 50, 50);
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.transformation.scale.basic
+  desc: scale() works
+  testing:
+  - 2d.transformation.scale
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.scale(2, 4);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 12.5);
+    @assert pixel 90,40 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.scale.zero
+  desc: scale() with a scale factor of zero works
+  testing:
+  - 2d.transformation.scale
+  code: |
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.save();
+    ctx.translate(50, 0);
+    ctx.scale(0, 1);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(0, 25);
+    ctx.scale(1, 0);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.restore();
+
+    canvas.toDataURL();
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.scale.negative
+  desc: scale() with negative scale factors works
+  testing:
+  - 2d.transformation.scale
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-50, 0, 50, 50);
+    ctx.restore();
+
+    ctx.save();
+    ctx.scale(1, -1);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(50, -50, 50, 50);
+    ctx.restore();
+    @assert pixel 25,25 == 0,255,0,255;
+    @assert pixel 75,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.scale.large
+  desc: scale() with large scale factors works
+  notes: Not really that large at all, but it hits the limits in Firefox.
+  testing:
+  - 2d.transformation.scale
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.scale(1e5, 1e5);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 1, 1);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.scale.nonfinite
+  desc: scale() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(100, 10);
+    @nonfinite ctx.scale(<0.1 Infinity -Infinity NaN>, <0.1 Infinity -Infinity NaN>);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -10, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.scale.multiple
+  desc: Multiple scale()s combine
+  testing:
+  - 2d.transformation.scale.multiple
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.scale(Math.sqrt(2), Math.sqrt(2));
+    ctx.scale(Math.sqrt(2), Math.sqrt(2));
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 25);
+    @assert pixel 90,40 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.transformation.rotate.zero
+  desc: rotate() by 0 does nothing
+  testing:
+  - 2d.transformation.rotate
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.rotate(0);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.rotate.radians
+  desc: rotate() uses radians
+  testing:
+  - 2d.transformation.rotate.radians
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.rotate(Math.PI); // should fail obviously if this is 3.1 degrees
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -50, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.rotate.direction
+  desc: rotate() is clockwise
+  testing:
+  - 2d.transformation.rotate.direction
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.rotate(Math.PI / 2);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, -100, 50, 100);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.rotate.wrap
+  desc: rotate() wraps large positive values correctly
+  testing:
+  - 2d.transformation.rotate
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.rotate(Math.PI * (1 + 4096)); // == pi (mod 2*pi)
+    // We need about pi +/- 0.001 in order to get correct-looking results
+    // 32-bit floats can store pi*4097 with precision 2^-10, so that should
+    // be safe enough on reasonable implementations
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -50, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,2 == 0,255,0,255;
+    @assert pixel 98,47 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.rotate.wrapnegative
+  desc: rotate() wraps large negative values correctly
+  testing:
+  - 2d.transformation.rotate
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.rotate(-Math.PI * (1 + 4096));
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -50, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+    @assert pixel 98,2 == 0,255,0,255;
+    @assert pixel 98,47 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.rotate.nonfinite
+  desc: rotate() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(100, 10);
+    @nonfinite ctx.rotate(<0.1 Infinity -Infinity NaN>);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -10, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.translate.basic
+  desc: translate() works
+  testing:
+  - 2d.transformation.translate
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(100, 50);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -50, 100, 50);
+    @assert pixel 90,40 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.translate.nonfinite
+  desc: translate() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(100, 10);
+    @nonfinite ctx.translate(<0.1 Infinity -Infinity NaN>, <0.1 Infinity -Infinity NaN>);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -10, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+
+- name: 2d.transformation.transform.identity
+  desc: transform() with the identity matrix does nothing
+  testing:
+  - 2d.transformation.transform
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.transform(1,0, 0,1, 0,0);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.transform.skewed
+  desc: transform() with skewy matrix transforms correctly
+  testing:
+  - 2d.transformation.transform
+  code: |
+    // Create green with a red square ring inside it
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(20, 10, 60, 30);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(40, 20, 20, 10);
+
+    // Draw a skewed shape to fill that gap, to make sure it is aligned correctly
+    ctx.transform(1,4, 2,3, 5,6);
+    // Post-transform coordinates:
+    //   [[20,10],[80,10],[80,40],[20,40],[20,10],[40,20],[40,30],[60,30],[60,20],[40,20],[20,10]];
+    // Hence pre-transform coordinates:
+    var pts=[[-7.4,11.2],[-43.4,59.2],[-31.4,53.2],[4.6,5.2],[-7.4,11.2],
+             [-15.4,25.2],[-11.4,23.2],[-23.4,39.2],[-27.4,41.2],[-15.4,25.2],
+             [-7.4,11.2]];
+    ctx.beginPath();
+    ctx.moveTo(pts[0][0], pts[0][1]);
+    for (var i = 0; i < pts.length; ++i)
+        ctx.lineTo(pts[i][0], pts[i][1]);
+    ctx.fill();
+    @assert pixel 21,11 == 0,255,0,255;
+    @assert pixel 79,11 == 0,255,0,255;
+    @assert pixel 21,39 == 0,255,0,255;
+    @assert pixel 79,39 == 0,255,0,255;
+    @assert pixel 39,19 == 0,255,0,255;
+    @assert pixel 61,19 == 0,255,0,255;
+    @assert pixel 39,31 == 0,255,0,255;
+    @assert pixel 61,31 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.transform.multiply
+  desc: transform() multiplies the CTM
+  testing:
+  - 2d.transformation.transform.multiply
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.transform(1,2, 3,4, 5,6);
+    ctx.transform(-2,1, 3/2,-1/2, 1,-2);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.transform.nonfinite
+  desc: transform() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(100, 10);
+    @nonfinite ctx.transform(<0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -10, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.setTransform.skewed
+  testing:
+  - 2d.transformation.setTransform
+  code: |
+    // Create green with a red square ring inside it
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 100, 50);
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(20, 10, 60, 30);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(40, 20, 20, 10);
+
+    // Draw a skewed shape to fill that gap, to make sure it is aligned correctly
+    ctx.setTransform(1,4, 2,3, 5,6);
+    // Post-transform coordinates:
+    //   [[20,10],[80,10],[80,40],[20,40],[20,10],[40,20],[40,30],[60,30],[60,20],[40,20],[20,10]];
+    // Hence pre-transform coordinates:
+    var pts=[[-7.4,11.2],[-43.4,59.2],[-31.4,53.2],[4.6,5.2],[-7.4,11.2],
+             [-15.4,25.2],[-11.4,23.2],[-23.4,39.2],[-27.4,41.2],[-15.4,25.2],
+             [-7.4,11.2]];
+    ctx.beginPath();
+    ctx.moveTo(pts[0][0], pts[0][1]);
+    for (var i = 0; i < pts.length; ++i)
+        ctx.lineTo(pts[i][0], pts[i][1]);
+    ctx.fill();
+    @assert pixel 21,11 == 0,255,0,255;
+    @assert pixel 79,11 == 0,255,0,255;
+    @assert pixel 21,39 == 0,255,0,255;
+    @assert pixel 79,39 == 0,255,0,255;
+    @assert pixel 39,19 == 0,255,0,255;
+    @assert pixel 61,19 == 0,255,0,255;
+    @assert pixel 39,31 == 0,255,0,255;
+    @assert pixel 61,31 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.setTransform.multiple
+  testing:
+  - 2d.transformation.setTransform.identity
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.setTransform(1/2,0, 0,1/2, 0,0);
+    ctx.setTransform();
+    ctx.setTransform(2,0, 0,2, 0,0);
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(0, 0, 50, 25);
+    @assert pixel 75,35 == 0,255,0,255;
+  expected: green
+
+- name: 2d.transformation.setTransform.nonfinite
+  desc: setTransform() with Infinity/NaN is ignored
+  testing:
+  - 2d.nonfinite
+  code: |
+    ctx.fillStyle = '#f00';
+    ctx.fillRect(0, 0, 100, 50);
+
+    ctx.translate(100, 10);
+    @nonfinite ctx.setTransform(<0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>, <0 Infinity -Infinity NaN>);
+
+    ctx.fillStyle = '#0f0';
+    ctx.fillRect(-100, -10, 100, 50);
+
+    @assert pixel 50,25 == 0,255,0,255;
+  expected: green


### PR DESCRIPTION
This adds a generator that converts the [WPT Canvas yaml test files](https://github.com/web-platform-tests/wpt/tree/master/html/canvas) to ones that can run against node-canvas, and the generated output.

```
  273 passing (1s)
  10 pending
  181 failing
```

The 9 of the 10 pending tests are V8/native crashes that should be a priority to fix.

The 181 failing ones are a mix of:
- No `Path2D` support
- No `ctx.roundRect()` support
- Lots of text issues
- Arc issues (#2055)
- Missing arg checks
- Shadow issues
- Incomplete porting of the test harness/framework.
- Others

I'm fine if folks don't want to merge this yet, but thought it would be helpful for others to see what tests are failing. A lot of these fixes would be good first issues.