### PR TITLE
Add roundRect() support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Export `pangoVersion`
 ### Added
+* [`ctx.roundRect()`](https://developer.chrome.com/blog/canvas2d/#round-rect)
 ### Fixed
 * `rgba(r,g,b)` with no alpha should parse as opaque, not transparent. ([#2029](https://github.com/Automattic/node-canvas/issues/2029))
 * Typo in `PngConfig.filters` types. ([#2072](https://github.com/Automattic/node-canvas/issues/2072))

--- a/binding.gyp
+++ b/binding.gyp
@@ -96,7 +96,8 @@
             '<(GTK_Root)/lib/glib-2.0/include'
           ],
           'defines': [
-            '_USE_MATH_DEFINES'  # for M_PI
+            '_USE_MATH_DEFINES',  # for M_PI
+            'NOMINMAX' # allow std::min/max to work
           ],
           'configurations': {
             'Debug': {

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -104,6 +104,7 @@ class Context2d: public Nan::ObjectWrap {
     static NAN_METHOD(StrokeRect);
     static NAN_METHOD(ClearRect);
     static NAN_METHOD(Rect);
+    static NAN_METHOD(RoundRect);
     static NAN_METHOD(Arc);
     static NAN_METHOD(ArcTo);
     static NAN_METHOD(Ellipse);

--- a/src/Point.h
+++ b/src/Point.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-template <class T>
+template <typename T>
 class Point {
   public:
     T x, y;
-    Point(T x, T y): x(x), y(y) {}
+    Point(T x=0, T y=0): x(x), y(y) {}
+    Point(const Point&) = default;
 };

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -95,6 +95,43 @@ tests['fillRect()'] = function (ctx) {
   render(1)
 }
 
+tests['roundRect()'] = function (ctx) {
+  if (!ctx.roundRect) {
+    ctx.textAlign = 'center'
+    ctx.fillText('roundRect() not supported', 100, 100, 190)
+    ctx.fillText('try Chrome instead', 100, 115, 190)
+    return
+  }
+  ctx.roundRect(5, 5, 60, 60, 20)
+  ctx.fillStyle = 'red'
+  ctx.fill()
+
+  ctx.beginPath()
+  ctx.roundRect(5, 70, 60, 60, [10, 15, 20, 25])
+  ctx.fillStyle = 'blue'
+  ctx.fill()
+
+  ctx.beginPath()
+  ctx.roundRect(70, 5, 60, 60, [10])
+  ctx.fillStyle = 'green'
+  ctx.fill()
+
+  ctx.beginPath()
+  ctx.roundRect(70, 70, 60, 60, [10, 15])
+  ctx.fillStyle = 'orange'
+  ctx.fill()
+
+  ctx.beginPath()
+  ctx.roundRect(135, 5, 60, 60, [10, 15, 20])
+  ctx.fillStyle = 'pink'
+  ctx.fill()
+
+  ctx.beginPath()
+  ctx.roundRect(135, 70, 60, 60, [{ x: 30, y: 10 }, { x: 5, y: 20 }])
+  ctx.fillStyle = 'darkseagreen'
+  ctx.fill()
+}
+
 tests['lineTo()'] = function (ctx) {
   // Filled triangle
   ctx.beginPath()


### PR DESCRIPTION
https://developer.chrome.com/blog/canvas2d/#round-rect

WPT tests:

    326 passing (1s)
    9 pending
    129 failing (down from 179)

There are two or three roundRect WPT tests still failing that I can't figure out, but they're edge cases.

- [x] Have you updated CHANGELOG.md?
