### PR TITLE
Fix: missing type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * `createPattern()` always used "repeat" mode; now supports "repeat-x" and "repeat-y". ([#2066](https://github.com/Automattic/node-canvas/issues/2066))
 * Crashes and hangs when using non-finite values in `context.arc()`. ([#2055](https://github.com/Automattic/node-canvas/issues/2055))
 * Incorrect `context.arc()` geometry logic for full ellipses. ([#1808](https://github.com/Automattic/node-canvas/issues/1808), ([#1736](https://github.com/Automattic/node-canvas/issues/1736)))
+* Add type definition for `deregisterAllFonts()` in types.
 
 2.9.3
 ==================

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -300,6 +300,11 @@ export function loadImage(src: string|Buffer, options?: any): Promise<Image>
  */
 export function registerFont(path: string, fontFace: {family: string, weight?: string, style?: string}): void
 
+/**
+ * Deregisters all restered fonts to free up memory
+ */
+export function deregisterAllFonts(): void
+
 /** This class must not be constructed directly; use `canvas.createPNGStream()`. */
 export class PNGStream extends Readable {}
 /** This class must not be constructed directly; use `canvas.createJPEGStream()`. */


### PR DESCRIPTION
Add missing type definition for ```deregisterAllFonts()```

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
