### PR TITLE
Adds deregisterAllFonts to the typescript declaration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * `createPattern()` always used "repeat" mode; now supports "repeat-x" and "repeat-y". ([#2066](https://github.com/Automattic/node-canvas/issues/2066))
 * Crashes and hangs when using non-finite values in `context.arc()`. ([#2055](https://github.com/Automattic/node-canvas/issues/2055))
 * Incorrect `context.arc()` geometry logic for full ellipses. ([#1808](https://github.com/Automattic/node-canvas/issues/1808), ([#1736](https://github.com/Automattic/node-canvas/issues/1736)))
+* Added missing `deregisterAllFonts` to the Typescript declaration file ([#2096](https://github.com/Automattic/node-canvas/pull/2096))
 
 2.9.3
 ==================

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -300,6 +300,11 @@ export function loadImage(src: string|Buffer, options?: any): Promise<Image>
  */
 export function registerFont(path: string, fontFace: {family: string, weight?: string, style?: string}): void
 
+/**
+ * Unloads all fonts
+ */
+export function deregisterAllFonts(): void;
+
 /** This class must not be constructed directly; use `canvas.createPNGStream()`. */
 export class PNGStream extends Readable {}
 /** This class must not be constructed directly; use `canvas.createJPEGStream()`. */

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,7 @@
 import * as Canvas from 'canvas'
+import * as path from "path";
+
+Canvas.registerFont(path.join(__dirname, '../pfennigFont/Pfennig.ttf'), {family: 'pfennigFont'})
 
 Canvas.createCanvas(5, 10)
 Canvas.createCanvas(200, 200, 'pdf')
@@ -39,3 +42,5 @@ img.onload = null;
 const id2: Canvas.ImageData = Canvas.createImageData(new Uint16Array(4), 1)
 
 ctx.drawImage(canv, 0, 0)
+
+Canvas.deregisterAllFonts();


### PR DESCRIPTION
This is function is being exported but isn't listed in the TypeScript declaration file.

- [x] Have you updated CHANGELOG.md?
