### PR TITLE
Parse rgba(r,g,b,0) correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ package-lock.json
 *.swp
 *.un~
 npm-debug.log
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Fixed
 * Fix `actualBoundingBoxLeft` and `actualBoundingBoxRight` when `textAlign='center'` or `'right'` ([#1909](https://github.com/Automattic/node-canvas/issues/1909))
+* Fix `rgba(r,g,b,0)` with alpha to 0 should parse as transparent, not opaque.
 
 2.10.0
 ==================

--- a/src/color.cc
+++ b/src/color.cc
@@ -228,7 +228,10 @@ parse_clipped_percentage(const char** pStr, float *pFraction) {
     if (*str >= '1' && *str <= '9') { \
       NAME = 1; \
     } else { \
-      if ('0' == *str) ++str; \
+      if ('0' == *str) { \
+        NAME = 0; \
+        ++str; \
+      } \
       if ('.' == *str) { \
         ++str; \
         NAME = 0; \

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -210,6 +210,9 @@ describe('Canvas', function () {
     ctx.fillStyle = 'rgba(255, 250, 255)';
     assert.equal('#fffaff', ctx.fillStyle);
 
+    ctx.fillStyle = 'rgba(124, 58, 26, 0)';
+    assert.equal('rgba(124, 58, 26, 0.00)', ctx.fillStyle);
+
     // hsl / hsla tests
 
     ctx.fillStyle = 'hsl(0, 0%, 0%)'
@@ -985,7 +988,7 @@ describe('Canvas', function () {
       const cm = ctx.measureText('aaaa')
       assertApprox(cm.actualBoundingBoxLeft, 9, 6)
       assertApprox(cm.actualBoundingBoxRight, 11, 6)
-      
+
       ctx.textAlign = 'right'
       const rm = ctx.measureText('aaaa')
       assertApprox(rm.actualBoundingBoxLeft, 19, 6)


### PR DESCRIPTION
In https://github.com/Automattic/node-canvas/commit/52551952c3d78ff12110880a2101ab980dd7bf6c rgba with alpha to 0 is not parsed correctly.

It must be 0.00 instead of 1
