### PR TITLE
remove save() limit, improve save/restore perf, fix some props not saved/restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Changed
+* Improve performance and memory usage of `save()`/`restore()`.
+* `save()`/`restore()` no longer have a maximum depth (previously 64 states).
 ### Added
 ### Fixed
+* `textBaseline` and `textAlign` were not saved/restored by `save()`/`restore()`. ([#1936](https://github.com/Automattic/node-canvas/issues/2029))
 
 2.10.1
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -91,7 +91,7 @@ This project is an implementation of the Web Canvas API and implements that API 
 * [CanvasRenderingContext2D#patternQuality](#canvasrenderingcontext2dpatternquality)
 * [CanvasRenderingContext2D#quality](#canvasrenderingcontext2dquality)
 * [CanvasRenderingContext2D#textDrawingMode](#canvasrenderingcontext2dtextdrawingmode)
-* [CanvasRenderingContext2D#globalCompositeOperator = 'saturate'](#canvasrenderingcontext2dglobalcompositeoperator--saturate)
+* [CanvasRenderingContext2D#globalCompositeOperation = 'saturate'](#canvasrenderingcontext2dglobalcompositeoperation--saturate)
 * [CanvasRenderingContext2D#antialias](#canvasrenderingcontext2dantialias)
 
 ### createCanvas()

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -64,6 +64,18 @@ function done (benchmark, times, start, isAsync) {
 
 // node-canvas
 
+bm('save/restore', function () {
+  for (let i = 0; i < 1000; i++) {
+    const max = i & 15
+    for (let j = 0; j < max; ++j) {
+      ctx.save()
+    }
+    for (let j = 0; j < max; ++j) {
+      ctx.restore()
+    }
+  }
+})
+
 bm('fillStyle= name', function () {
   for (let i = 0; i < 10000; i++) {
     ctx.fillStyle = '#fefefe'

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -12,15 +12,6 @@
 #include <cstddef>
 
 /*
- * Maxmimum states per context.
- * TODO: remove/resize
- */
-
-#ifndef CANVAS_MAX_STATES
-#define CANVAS_MAX_STATES 64
-#endif
-
-/*
  * FontFace describes a font file in terms of one PangoFontDescription that
  * will resolve to it and one that the user describes it as (like @font-face)
  */
@@ -29,6 +20,29 @@ class FontFace {
     PangoFontDescription *sys_desc = nullptr;
     PangoFontDescription *user_desc = nullptr;
     unsigned char file_path[1024];
+};
+
+enum text_baseline_t : uint8_t {
+  TEXT_BASELINE_ALPHABETIC = 0,
+  TEXT_BASELINE_TOP = 1,
+  TEXT_BASELINE_BOTTOM = 2,
+  TEXT_BASELINE_MIDDLE = 3,
+  TEXT_BASELINE_IDEOGRAPHIC = 4,
+  TEXT_BASELINE_HANGING = 5
+};
+
+enum text_align_t : int8_t {
+  TEXT_ALIGNMENT_LEFT = -1,
+  TEXT_ALIGNMENT_CENTER = 0,
+  TEXT_ALIGNMENT_RIGHT = 1,
+  // Currently same as LEFT and RIGHT without RTL support:
+  TEXT_ALIGNMENT_START = -2,
+  TEXT_ALIGNMENT_END = 2
+};
+
+enum canvas_draw_mode_t : uint8_t {
+  TEXT_DRAW_PATHS,
+  TEXT_DRAW_GLYPHS
 };
 
 /*

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -7,11 +7,7 @@
 #include "color.h"
 #include "nan.h"
 #include <pango/pangocairo.h>
-
-typedef enum {
-  TEXT_DRAW_PATHS,
-  TEXT_DRAW_GLYPHS
-} canvas_draw_mode_t;
+#include <stack>
 
 /*
  * State struct.
@@ -20,25 +16,54 @@ typedef enum {
  * cairo's gstate maintains only a single source pattern at a time.
  */
 
-typedef struct {
-  rgba_t fill;
-  rgba_t stroke;
-  cairo_filter_t patternQuality;
-  cairo_pattern_t *fillPattern;
-  cairo_pattern_t *strokePattern;
-  cairo_pattern_t *fillGradient;
-  cairo_pattern_t *strokeGradient;
-  float globalAlpha;
-  short textAlignment;
-  short textBaseline;
-  rgba_t shadow;
-  int shadowBlur;
-  double shadowOffsetX;
-  double shadowOffsetY;
-  canvas_draw_mode_t textDrawingMode;
-  PangoFontDescription *fontDescription;
-  bool imageSmoothingEnabled;
-} canvas_state_t;
+struct canvas_state_t {
+  rgba_t fill = { 0, 0, 0, 1 };
+  rgba_t stroke = { 0, 0, 0, 1 };
+  rgba_t shadow = { 0, 0, 0, 0 };
+  double shadowOffsetX = 0.;
+  double shadowOffsetY = 0.;
+  cairo_pattern_t* fillPattern = nullptr;
+  cairo_pattern_t* strokePattern = nullptr;
+  cairo_pattern_t* fillGradient = nullptr;
+  cairo_pattern_t* strokeGradient = nullptr;
+  PangoFontDescription* fontDescription = nullptr;
+  cairo_filter_t patternQuality = CAIRO_FILTER_GOOD;
+  float globalAlpha = 1.f;
+  int shadowBlur = 0;
+  text_align_t textAlignment = TEXT_ALIGNMENT_LEFT; // TODO default is supposed to be START
+  text_baseline_t textBaseline = TEXT_BASELINE_ALPHABETIC;
+  canvas_draw_mode_t textDrawingMode = TEXT_DRAW_PATHS;
+  bool imageSmoothingEnabled = true;
+
+  canvas_state_t() {
+    fontDescription = pango_font_description_from_string("sans");
+    pango_font_description_set_absolute_size(fontDescription, 10 * PANGO_SCALE);
+  }
+
+  canvas_state_t(const canvas_state_t& other) {
+    fill = other.fill;
+    stroke = other.stroke;
+    patternQuality = other.patternQuality;
+    fillPattern = other.fillPattern;
+    strokePattern = other.strokePattern;
+    fillGradient = other.fillGradient;
+    strokeGradient = other.strokeGradient;
+    globalAlpha = other.globalAlpha;
+    textAlignment = other.textAlignment;
+    textBaseline = other.textBaseline;
+    shadow = other.shadow;
+    shadowBlur = other.shadowBlur;
+    shadowOffsetX = other.shadowOffsetX;
+    shadowOffsetY = other.shadowOffsetY;
+    textDrawingMode = other.textDrawingMode;
+    fontDescription = pango_font_description_copy(other.fontDescription);
+    imageSmoothingEnabled = other.imageSmoothingEnabled;
+  }
+
+  ~canvas_state_t() {
+    pango_font_description_free(fontDescription);
+  }
+};
 
 /*
  * Equivalent to a PangoRectangle but holds floats instead of ints
@@ -54,12 +79,9 @@ typedef struct {
   float height;
 } float_rectangle;
 
-void state_assign_fontFamily(canvas_state_t *state, const char *str);
-
-class Context2d: public Nan::ObjectWrap {
+class Context2d : public Nan::ObjectWrap {
   public:
-    short stateno;
-    canvas_state_t *states[CANVAS_MAX_STATES];
+    std::stack<canvas_state_t> states;
     canvas_state_t *state;
     Context2d(Canvas *canvas);
     static Nan::Persistent<v8::Function> _DOMMatrix;
@@ -180,7 +202,7 @@ class Context2d: public Nan::ObjectWrap {
     void save();
     void restore();
     void setFontFromState();
-    void resetState(bool init = false);
+    void resetState();
     inline PangoLayout *layout(){ return _layout; }
 
   private:
@@ -195,8 +217,6 @@ class Context2d: public Nan::ObjectWrap {
     Nan::Persistent<v8::Value> _fillStyle;
     Nan::Persistent<v8::Value> _strokeStyle;
     Nan::Persistent<v8::Value> _font;
-    Nan::Persistent<v8::Value> _textBaseline;
-    Nan::Persistent<v8::Value> _textAlign;
     Canvas *_canvas;
     cairo_t *_context;
     cairo_path_t *_path;

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -547,6 +547,8 @@ describe('Canvas', function () {
     const canvas = createCanvas(200, 200)
     const ctx = canvas.getContext('2d')
 
+    assert.equal('left', ctx.textAlign) // default TODO wrong default
+    ctx.textAlign = 'start'
     assert.equal('start', ctx.textAlign)
     ctx.textAlign = 'center'
     assert.equal('center', ctx.textAlign)
@@ -1899,5 +1901,56 @@ describe('Canvas', function () {
     data.forEach(function (byte, index) {
       if (index + 1 & 3) { assert.strictEqual(byte, 128) } else { assert.strictEqual(byte, 255) }
     })
+  })
+
+  describe('Context2d#save()/restore()', function () {
+    // Based on WPT meta:2d.state.saverestore
+    const state = [ // non-default values to test with
+      ['strokeStyle', '#ff0000'],
+      ['fillStyle', '#ff0000'],
+      ['globalAlpha', 0.5],
+      ['lineWidth', 0.5],
+      ['lineCap', 'round'],
+      ['lineJoin', 'round'],
+      ['miterLimit', 0.5],
+      ['shadowOffsetX', 5],
+      ['shadowOffsetY', 5],
+      ['shadowBlur', 5],
+      ['shadowColor', '#ff0000'],
+      ['globalCompositeOperation', 'copy'],
+      // ['font', '25px serif'], // TODO #1946
+      ['textAlign', 'center'],
+      ['textBaseline', 'bottom'],
+      // Added vs. WPT
+      ['imageSmoothingEnabled', false],
+      // ['imageSmoothingQuality', ], // not supported by node-canvas, #2114
+      ['lineDashOffset', 1.0],
+      // Non-standard properties:
+      ['patternQuality', 'best'],
+      // ['quality', 'best'], // doesn't do anything, TODO remove
+      ['textDrawingMode', 'glyph'],
+      ['antialias', 'gray']
+    ]
+
+    for (const [k, v] of state) {
+      it(`2d.state.saverestore.${k}`, function () {
+        const canvas = createCanvas(0, 0)
+        const ctx = canvas.getContext('2d')
+
+        // restore() undoes modification:
+        let old = ctx[k]
+        ctx.save()
+        ctx[k] = v
+        ctx.restore()
+        assert.strictEqual(ctx[k], old)
+  
+        // save() doesn't modify the value:
+        ctx[k] = v
+        old = ctx[k]
+        ctx.save()
+        assert.strictEqual(ctx[k], old)
+        ctx.restore()
+      })
+    }
   })
 })


### PR DESCRIPTION
1. One WPT test fails if there are not at least 512 save/restore slots. This removes that limit entirely.

2. Gets rid of clunky C code and uses `std::stack` with a proper C++ class. End result is >1.6x faster with MSVC.

3. Reorders fields and types some enums so the state struct shrinks from 192 bytes to 168 bytes (-24 bytes; i.e. 24 bytes saved per state).

4. Fixes several properties that were not saved/restored: `textBaseline`, `textAlign`. `quality` is not saved/restored, but it's not wired up to anything and needs to be removed.

Fixes #1936


- [x] Have you updated CHANGELOG.md?
