### PR TITLE
Fix missing canvas property in CanvasRenderingContext2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* Add missing property `canvas` to the `CanvasRenderingContext2D` type
 
 2.11.0
 ==================

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -283,6 +283,7 @@ export class CanvasRenderingContext2D {
 	font: string;
 	textBaseline: CanvasTextBaseline;
 	textAlign: CanvasTextAlign;
+	canvas: Canvas;
 }
 
 export class CanvasGradient {


### PR DESCRIPTION
Yesterday's v2.11 update with the new type definitions is great to have - one thing I noticed missing though is the [`CanvasRenderingContext2D.canvas` property](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/canvas), which is set in `lib/canvas.js` instead of the `Initialize` function of `Context2d`. This is just a small one-line PR to declare it on the type.

- [X] Have you updated CHANGELOG.md?
