### PR TITLE
move ctx.font string to the state struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Add missing property `canvas` to the `CanvasRenderingContext2D` type
 * Fixed glyph positions getting rounded, resulting text having a slight `letter-spacing` effect
+* Fixed `ctx.font` not being restored correctly after `ctx.restore()` (#1946)
 
 2.11.0
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -207,7 +207,6 @@ void Context2d::resetState() {
 void Context2d::_resetPersistentHandles() {
   _fillStyle.Reset();
   _strokeStyle.Reset();
-  _font.Reset();
 }
 
 /*
@@ -2553,15 +2552,8 @@ NAN_METHOD(Context2d::MoveTo) {
 NAN_GETTER(Context2d::GetFont) {
   CHECK_RECEIVER(Context2d.GetFont);
   Context2d *context = Nan::ObjectWrap::Unwrap<Context2d>(info.This());
-  Isolate *iso = Isolate::GetCurrent();
-  Local<Value> font;
 
-  if (context->_font.IsEmpty())
-    font = Nan::New("10px sans-serif").ToLocalChecked();
-  else
-    font = context->_font.Get(iso);
-
-  info.GetReturnValue().Set(font);
+  info.GetReturnValue().Set(Nan::New(context->state->font).ToLocalChecked());
 }
 
 /*
@@ -2624,7 +2616,7 @@ NAN_SETTER(Context2d::SetFont) {
   context->state->fontDescription = sys_desc;
   pango_layout_set_font_description(context->_layout, sys_desc);
 
-  context->_font.Reset(value);
+  context->state->font = *Nan::Utf8String(value);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -27,6 +27,7 @@ struct canvas_state_t {
   cairo_pattern_t* fillGradient = nullptr;
   cairo_pattern_t* strokeGradient = nullptr;
   PangoFontDescription* fontDescription = nullptr;
+  std::string font = "10px sans-serif";
   cairo_filter_t patternQuality = CAIRO_FILTER_GOOD;
   float globalAlpha = 1.f;
   int shadowBlur = 0;
@@ -57,6 +58,7 @@ struct canvas_state_t {
     shadowOffsetY = other.shadowOffsetY;
     textDrawingMode = other.textDrawingMode;
     fontDescription = pango_font_description_copy(other.fontDescription);
+    font = other.font;
     imageSmoothingEnabled = other.imageSmoothingEnabled;
   }
 
@@ -216,7 +218,6 @@ class Context2d : public Nan::ObjectWrap {
     void _setStrokePattern(v8::Local<v8::Value> arg);
     Nan::Persistent<v8::Value> _fillStyle;
     Nan::Persistent<v8::Value> _strokeStyle;
-    Nan::Persistent<v8::Value> _font;
     Canvas *_canvas;
     cairo_t *_context;
     cairo_path_t *_path;

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -1918,7 +1918,7 @@ describe('Canvas', function () {
       ['shadowBlur', 5],
       ['shadowColor', '#ff0000'],
       ['globalCompositeOperation', 'copy'],
-      // ['font', '25px serif'], // TODO #1946
+      ['font', '25px serif'],
       ['textAlign', 'center'],
       ['textBaseline', 'bottom'],
       // Added vs. WPT


### PR DESCRIPTION
I don't totally understand why we were using a `Nan::Persistent<v8::Value>` instead of storing a standard string + turn it into a v8 value on the fly, so hopefully this is right. 

fixes #1946 