### PR TITLE
fix not compiling on certain windows versions

### DIFF
--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -264,7 +264,7 @@ get_pango_font_description(unsigned char* filepath) {
         FILE_SHARE_READ,
         NULL,
         OPEN_EXISTING,
-        NULL,
+        FILE_ATTRIBUTE_NORMAL,
         NULL
   );
   if(!hFile){


### PR DESCRIPTION
`msbuild` is throwing this in the prebuild workflow, and I give up trying to figure out why it's different than the main workflow.

```
Error: D:\a\node-canvas\node-canvas\src\register_font.cc(261,18): error C2664: 'HANDLE CreateFileW(LPCWSTR,DWORD,DWORD,LPSECURITY_ATTRIBUTES,DWORD,DWORD,HANDLE)': cannot convert argument 6 from 'nullptr' to 'DWORD' [D:\a\node-canvas\node-canvas\build\canvas.vcxproj]
```

The error makes sense, this arg should not be `NULL`.
