### PR TITLE
Fix build error C2664 - cannot convert argument 6 from 'nullptr' to 'DWORD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix Image#complete if the image failed to load.
 * Upgrade node-pre-gyp to v0.15.0 to use latest version of needle to fix error when downloading prebuilds.
 * Don't throw if `fillStyle` or `strokeStyle` is set to an object, but that object is not a Gradient or Pattern. (This behavior was non-standard: invalid inputs are supposed to be ignored.)
+* Fix build error C2664 - cannot convert argument 6 from 'nullptr' to 'DWORD (#2218)
 
 2.6.1
 ==================

--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -264,7 +264,7 @@ get_pango_font_description(unsigned char* filepath) {
         FILE_SHARE_READ,
         NULL,
         OPEN_EXISTING,
-        NULL,
+        0,
         NULL
   );
   if(!hFile){


### PR DESCRIPTION
This is a precursor to https://github.com/Automattic/node-canvas/pull/2218, but it looks like it also fixes an issue in the current prebuild for windows.

In the "prebuilds" workflow there is currently an error

`Fixes "error C2664: 'HANDLE CreateFileW(LPCWSTR,DWORD,DWORD,LPSECURITY_ATTRIBUTES,DWORD,DWORD,HANDLE)': cannot convert argument 6 from 'nullptr' to 'DWORD' [D:\a\node-canvas\node-canvas\build\canvas.vcxproj]"`

![image](https://user-images.githubusercontent.com/3792408/227942197-1f82a6bc-257b-4331-9892-762b7af65694.png)


This change fixes that error.

You can see the build succeeds in my test here https://github.com/acalcutt/node-canvas/actions/runs/4527936648/jobs/7974248529
(note, it still fails to upload since I didn't set that up for my fork)

- [X] Have you updated CHANGELOG.md?
