### PR TITLE
Update simple-get dependency ^3.0.3 to ^4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
-- Upgrade single-get dependency ^3.0.3 to ^4.0.1
+- Upgrade sinmle-get dependency ^3.0.3 to ^4.0.1
 
 2.11.2
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+- Upgrade single-get dependency ^3.0.3 to ^4.0.1
 
 2.11.2
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
-- Upgrade sinmle-get dependency ^3.0.3 to ^4.0.1
+- Upgrade simple-get dependency ^3.0.3 to ^4.0.1
 
 2.11.2
 ==================

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.0",
     "nan": "^2.17.0",
-    "simple-get": "^3.0.3"
+    "simple-get": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^10.12.18",


### PR DESCRIPTION
I've updated the versionof  simple-get module due to security issue.

versions bellow 4.0.1 have a vulnerability that leaks cookie headers to third-party sites. 

url: https://huntr.dev/bounties/42c79c23-6646-46c4-871d-219c0d4b4e31/

- [x] Have you updated CHANGELOG.md?


