### PR TITLE
Add M1 prebuilds

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -175,6 +175,7 @@ jobs:
           . prebuild/macOS/bundle.sh
 
       - name: Test binary
+        if: matrix.arch == 'x64'
         run: |
           brew uninstall --force --ignore-dependencies cairo pango librsvg giflib harfbuzz
           npm test

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -150,6 +150,7 @@ jobs:
     runs-on: macos-latest
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
+      CANVAS_ARCH_TO_BUILD: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -145,7 +145,8 @@ jobs:
       matrix:
         node: [20]
         canvas_tag: ["v2.11.2"] # e.g. "v2.6.1"
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
+        arch: ["x64", "arm64"]
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Arch ${{ matrix.arch }}, macOS
     runs-on: macos-latest
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
@@ -170,7 +171,7 @@ jobs:
           npm install --ignore-scripts
           . prebuild/macOS/preinstall.sh
           cp prebuild/macOS/binding.gyp binding.gyp
-          node-gyp rebuild -j 2
+          node-gyp rebuild -j 2 --arch=${{ matrix.arch }}
           . prebuild/macOS/bundle.sh
 
       - name: Test binary

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -146,7 +146,7 @@ jobs:
         node: [20]
         canvas_tag: ["v2.11.2"] # e.g. "v2.6.1"
         arch: ["x64", "arm64"]
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Arch ${{ matrix.arch }}, macOS
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, ${{ matrix.arch }}, macOS
     runs-on: macos-latest
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}

--- a/prebuild/tarball.sh
+++ b/prebuild/tarball.sh
@@ -3,7 +3,8 @@ FILENAME=$(
   node -e "
     var p = process, v = p.versions, libc = require('detect-libc').familySync() || 'unknown';
     const tagName = p.env.UPLOAD_TO || p.env.CANVAS_VERSION_TO_BUILD;
-    console.log(['canvas', tagName, 'node-v' + v.modules, p.platform, libc, p.arch].join('-'));
+    const arch = p.env.CANVAS_ARCH_TO_BUILD || p.arch;
+    console.log(['canvas', tagName, 'node-v' + v.modules, p.platform, libc, arch].join('-'));
   "
 ).tar.gz;
 


### PR DESCRIPTION
I have no idea whether this will work, but maybe worth a try? I don't have a M1, so I can't even test this :)

But it _does_ build something when I run the workflow on my fork, and the compiler log has output that suggests it is actually building an arm64 version. The upload step fails in my fork, and I am not familiar enough with that to fix this. Maybe a maintainer here could test things and see whether this might actually be producing the correct binaries?