### PR TITLE
fix broken font matching due to a use-after-free

### DIFF
--- a/src/register_font.cc
+++ b/src/register_font.cc
@@ -303,7 +303,7 @@ get_pango_font_description(unsigned char* filepath) {
         return NULL;
       }
 
-      pango_font_description_set_family_static(desc, family);
+      pango_font_description_set_family(desc, family);
       free(family);
       pango_font_description_set_weight(desc, get_pango_weight(table->usWeightClass));
       pango_font_description_set_stretch(desc, get_pango_stretch(table->usWidthClass));


### PR DESCRIPTION
f3184ba9da2737dbe25275631678a7ef5924fe6b introduced a use-after- free bug. Pango does not copy the string when you use the _static version of pango_font_description_set_family. Font selection was not working for me at all. Luckily we haven't released this yet.