### PR TITLE
Drop support for older versions of Node.js

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,4 +14,4 @@ var ctx = canvas.getContext('2d');
 
 ## Your Environment
 * Version of node-canvas (output of `npm list canvas` or `yarn list canvas`):
-* Environment (e.g. node 4.2.0 on Mac OS X 10.8):
+* Environment (e.g. node 20.9.0 on macOS 14.1.1):

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,7 @@ jobs:
           brew update
           brew install python3 || : # python doesn't need to be linked
           brew install pkg-config cairo pango libpng jpeg giflib librsvg
+          pip install setuptools
       - name: Install
         run: npm install --build-from-source
       - name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16, 18, 20]
+        node: [18.12.0, 20.9.0]
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node: [10, 12, 14, 16, 18, 20]
+        node: [18.12.0, 20.9.0]
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16, 18, 20]
+        node: [18.12.0, 20.9.0]
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 20.9.0
       - uses: actions/checkout@v3
       - name: Install
         run: npm install --ignore-scripts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,11 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node: [18.12.0, 20.9.0]
+        # FIXME: Node.js 20.9.0 is currently broken on Windows, in the `registerFont` test:
+        # ENOENT: no such file or directory, lstat 'D:\a\node-canvas\node-canvas\examples\pfennigFont\pfennigMultiByte🚀.ttf'
+        # ref: https://github.com/nodejs/node/issues/48673
+        # ref: https://github.com/nodejs/node/pull/50650
+        node: [18.12.0]
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -24,7 +24,7 @@ jobs:
   Linux:
     strategy:
       matrix:
-        node: [8, 9, 10, 11, 12, 13, 14, 16, 18, 20]
+        node: [18.12.0, 20.9.0]
         canvas_tag: [] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Linux
     runs-on: ubuntu-latest
@@ -97,7 +97,7 @@ jobs:
   macOS:
     strategy:
       matrix:
-        node: [8, 9, 10, 11, 12, 13, 14, 16, 18, 20]
+        node: [18.12.0, 20.9.0]
         canvas_tag: [] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
     runs-on: macos-latest
@@ -163,7 +163,7 @@ jobs:
   Win:
     strategy:
       matrix:
-        node: [8, 9, 10, 11, 12, 13, 14, 16, 18, 20]
+        node: [18.12.0, 20.9.0]
         canvas_tag: [] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Windows
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 This release notably changes to using N-API. 🎉
 
+### Breaking
+* Dropped support for Node.js 16.x and below.
 ### Changed
 * Migrated to N-API (by way of node-addon-api) and removed libuv and v8 dependencies
 * Defer the initialization of the `op` variable to the `default` switch case to avoid a compiler warning. (#2229)

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^4.2.2"
   },
   "engines": {
-    "node": ">=10.20.0"
+    "node": "^18.12.0 || >= 20.9.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Part of breaking changes discussed in #2232, this changes to align with LTS-supported Node.js versions

This changes the minimum supported versions of Node.js:
- 16 and earlier = unsupported
- 17 = unsupported
- 18 = supported from 18.12.0 (LTS)
- 19 = unsupported
- 20 = supported from 20.9.0 (LTS)
- 21 and later = not tested, but should work

- [x] Have you updated CHANGELOG.md?
