### PR TITLE
Prevent crashing for "Unsupported image type" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+
+- added a try and catch block in lib/image.js in the setSource function, to prevent unexpected crashing, if an 'Unsupported image type' is provided.
+
 ### Fixed
 
 3.0.0

--- a/lib/image.js
+++ b/lib/image.js
@@ -91,6 +91,11 @@ function getSource (img) {
 }
 
 function setSource (img, src, origSrc) {
-  SetSource.call(img, src)
-  img._originalSource = origSrc
+  try {
+    SetSource.call(img, src)
+    img._originalSource = origSrc
+  } catch (err) {
+    img._originalSource = null
+    throw err
+  }
 }


### PR DESCRIPTION
Hi,

I hope this message finds all of you well. I have encountered an issue where the "Unsupported image type" error was being thrown in the `setSource` function of the canvas library. After investigating, I found out that this error was causing unexpected crashes in certain scenarios.

In my case these certain scenarios were pretty interesting. I have not been interacting directly with the library, randomly, my code crashed because of this error. My motivation to fix this error is a more robust code base, because in my case, my application should not crash in no matter what case.

To address this issue, I have added a try-catch block to the `setSource` function in the lib/image.js file. This should prevent unexpected crashes hopefully and ensures that the application can gracefully handle cases where the image type is not supported.

I have added the following code to address this issue. 

 ```js
 function setSource (img, src, origSrc) {
  try {
    SetSource.call(img, src)
    img._originalSource = origSrc
  } catch (err) {
    img._originalSource = null
    throw err
  }
}
 ``` 

I will already say thank you for reviewing my pull requests! let me know if it's possible to apply these changes.

sincerely Rosie!