### PR TITLE
Update simple-get to 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Changed
+* Updated simple-get to 4.0.1.
 ### Added
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "node-addon-api": "^7.0.0",
     "prebuild-install": "^7.1.1",
-    "simple-get": "^3.0.3"
+    "simple-get": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^10.12.18",


### PR DESCRIPTION
Previous versions of simple-get are vulnerable to CVE-2022-0355.

https://nvd.nist.gov/vuln/detail/CVE-2022-0355

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
