### PR TITLE
Add prebuilds for ARM64 Macs

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -144,8 +144,13 @@ jobs:
       matrix:
         node: [21]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
-    runs-on: macos-12 # macos-14+ is M1
+        os:
+          - runner: macos-12
+            arch: x64
+          - runner: macos-14
+            arch: arm64
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS ${{ matrix.os.arch }}
+    runs-on: ${{ matrix.os.runner }}
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
     steps:
@@ -176,6 +181,11 @@ jobs:
         run: |
           brew uninstall --force --ignore-dependencies cairo pango librsvg giflib harfbuzz
           npm test
+
+      - name: Sign the executable
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: build/Release/canvas.node
 
       - name: Make bundle
         id: make_bundle

--- a/prebuild/macOS/binding.gyp
+++ b/prebuild/macOS/binding.gyp
@@ -34,6 +34,7 @@
         '<!@(pkg-config pangocairo --libs)',
         '<!@(pkg-config freetype2 --libs)',
         '<!@(pkg-config librsvg-2.0 --libs)',
+        '-L/opt/homebrew/lib',
         '-ljpeg',
         '-lgif'
       ],
@@ -43,7 +44,8 @@
         '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)',
-        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)'
+        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)',
+        '/opt/homebrew/include'
       ],
       'cflags+': ['-fvisibility=hidden'],
       'xcode_settings': {


### PR DESCRIPTION
This is an updated attempt at #2245, making use of GitHub's new Apple Silicon runners.

With many Mac-based developers transitioning to Apple Silicon, this addition will have a significant impact on their cumulative `yarn/npm install` time.