### PR TITLE
Fix rgba parsing (#2300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This release notably changes to using N-API. 🎉
 * Fix usage of garbage value by filling the allocated memory entirely with zeros if it's not modified. (#2229)
 * Fix a potential memory leak. (#2229)
 * Fix the wrong type of setTransform
+* Fix the improper parsing of rgb functions issue. (#2300)
 
 2.11.2
 ==================

--- a/src/color.cc
+++ b/src/color.cc
@@ -210,6 +210,9 @@ parse_clipped_percentage(const char** pStr, float *pFraction) {
 #define WHITESPACE_OR_COMMA \
   while (' ' == *str || ',' == *str) ++str;
 
+#define WHITESPACE_OR_COMMA_OR_SLASH \
+  while (' ' == *str || ',' == *str || '/' == *str) ++str;
+
 #define CHANNEL(NAME) \
    if (!parse_rgb_channel(&str, &NAME)) \
     return 0; \
@@ -649,7 +652,7 @@ rgba_from_rgba_string(const char *str, short *ok) {
     CHANNEL(g);
     WHITESPACE_OR_COMMA;
     CHANNEL(b);
-    WHITESPACE_OR_COMMA;
+    WHITESPACE_OR_COMMA_OR_SLASH;
     ALPHA(a);
     WHITESPACE;
     return *ok = 1, rgba_from_rgba(r, g, b, (int) (a * 255));

--- a/src/color.cc
+++ b/src/color.cc
@@ -625,13 +625,15 @@ rgba_from_rgb_string(const char *str, short *ok) {
     str += 4;
     WHITESPACE;
     uint8_t r = 0, g = 0, b = 0;
+    float a=1.f;
     CHANNEL(r);
     WHITESPACE_OR_COMMA;
     CHANNEL(g);
     WHITESPACE_OR_COMMA;
     CHANNEL(b);
-    WHITESPACE;
-    return *ok = 1, rgba_from_rgb(r, g, b);
+    WHITESPACE_OR_COMMA_OR_SLASH;
+    ALPHA(a);
+    return *ok = 1, rgba_from_rgba(r, g, b, (int) (255 * a));
   }
   return *ok = 0;
 }

--- a/src/color.cc
+++ b/src/color.cc
@@ -226,7 +226,16 @@ parse_clipped_percentage(const char** pStr, float *pFraction) {
 
 #define ALPHA(NAME) \
     if (*str >= '1' && *str <= '9') { \
-      NAME = 1; \
+      NAME = 0; \
+      float n = .1f; \
+      while(*str >='0' && *str <= '9') { \
+        NAME += (*str - '0') * n; \
+        str++; \
+      } \
+      while(*str == ' ')str++; \
+      if(*str != '%') { \
+        NAME = 1; \
+      } \
     } else { \
       if ('0' == *str) { \
         NAME = 0; \

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -213,6 +213,17 @@ describe('Canvas', function () {
     ctx.fillStyle = 'rgba(124, 58, 26, 0)';
     assert.equal('rgba(124, 58, 26, 0.00)', ctx.fillStyle);
 
+    ctx.fillStyle = 'rgba( 255, 200, 90, 40%)'
+    assert.equal('rgba(255, 200, 90, 0.40)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90, 50 %)'
+    assert.equal('rgba(255, 200, 90, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90, 10%)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90, 10 %)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
     // hsl / hsla tests
 
     ctx.fillStyle = 'hsl(0, 0%, 0%)'

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -224,6 +224,25 @@ describe('Canvas', function () {
 
     ctx.fillStyle = 'rgba( 255, 200, 90, 10 %)'
     assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90 / 40%)'
+    assert.equal('rgba(255, 200, 90, 0.40)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90 / 0.5)'
+    assert.equal('rgba(255, 200, 90, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90 / 10%)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255, 200, 90 / 0.1)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255 200 90 / 10%)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgba( 255 200 90  0.1)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
     // hsl / hsla tests
 
     ctx.fillStyle = 'hsl(0, 0%, 0%)'

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -243,6 +243,46 @@ describe('Canvas', function () {
     ctx.fillStyle = 'rgba( 255 200 90  0.1)'
     assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
 
+    ctx.fillStyle = 'rgb(0, 0, 0, 42.42)'
+    assert.equal('#000000', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb(255, 250, 255)';
+    assert.equal('#fffaff', ctx.fillStyle);
+
+    ctx.fillStyle = 'rgb(124, 58, 26, 0)';
+    assert.equal('rgba(124, 58, 26, 0.00)', ctx.fillStyle);
+
+    ctx.fillStyle = 'rgb( 255, 200, 90, 40%)'
+    assert.equal('rgba(255, 200, 90, 0.40)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90, 50 %)'
+    assert.equal('rgba(255, 200, 90, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90, 10%)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90, 10 %)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90 / 40%)'
+    assert.equal('rgba(255, 200, 90, 0.40)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90 / 0.5)'
+    assert.equal('rgba(255, 200, 90, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90 / 10%)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 200, 90 / 0.1)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255 200 90 / 10%)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255 200 90  0.1)'
+    assert.equal('rgba(255, 200, 90, 0.10)', ctx.fillStyle)
+
+
     // hsl / hsla tests
 
     ctx.fillStyle = 'hsl(0, 0%, 0%)'


### PR DESCRIPTION
Fixes issues related for rgba parsing (#2300). Browser allows percentage signs in alpha, as well as / as separator. I've also added test cases for the same.

- [x] Have you updated CHANGELOG.md?
