### PR TITLE
macOS: Fix deps in preinstall, reenable arm64 builds

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -144,8 +144,9 @@ jobs:
       matrix:
         node: [21]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
-    runs-on: macos-12 # macos-14+ is M1
+        macos_version: ["13", "latest"] # macos-14+ is M1
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS ${{ matrix.macos_version }}
+    runs-on: macos-${{ matrix.macos_version }}
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
     steps:
@@ -174,7 +175,7 @@ jobs:
 
       - name: Test binary
         run: |
-          brew uninstall --force --ignore-dependencies cairo pango librsvg giflib harfbuzz
+          brew uninstall --force --ignore-dependencies cairo pango libpng jpeg giflib librsvg pixman harfbuzz
           npm test
 
       - name: Make bundle

--- a/prebuild/macOS/binding.gyp
+++ b/prebuild/macOS/binding.gyp
@@ -34,7 +34,8 @@
         '<!@(pkg-config pangocairo --libs)',
         '<!@(pkg-config freetype2 --libs)',
         '<!@(pkg-config librsvg-2.0 --libs)',
-        '-ljpeg',
+        '<!@(pkg-config libjpeg --libs)',
+        '-L<!(brew --prefix)/lib',
         '-lgif'
       ],
       'include_dirs': [
@@ -43,7 +44,9 @@
         '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)',
-        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)'
+        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)',
+        '<!@(pkg-config libjpeg --cflags-only-I | sed s/-I//g)',
+        '<!(brew --prefix)/include'
       ],
       'cflags+': ['-fvisibility=hidden'],
       'xcode_settings': {

--- a/prebuild/macOS/preinstall.sh
+++ b/prebuild/macOS/preinstall.sh
@@ -10,6 +10,6 @@ rm -f /usr/local/bin/python3-config || :
 
 # two or more of these packages have python3 as a dependency, and --overwrite
 # doesn't work to make them ignore conflicts. For now just ignore errors, yolo.
-brew install --force pkg-config cairo pango librsvg giflib || :
+brew install --force pkg-config cairo pango libpng jpeg giflib librsvg pixman || :
 
 pip3 install --user --break-system-packages macpack


### PR DESCRIPTION
The arm64 macOS builds seem to have been failing due to a lack of `jpeg`, so this updates the brew dependencies to match the README.md and reenables arm64 builds.

This is built on top of the work for #2354. I confirmed builds worked here:
- https://github.com/kevinji/node-canvas/actions/runs/9798525936
- https://github.com/kevinji/node-canvas/releases/tag/v3.0.0-rc2