### PR TITLE
fix TextMetrics type to include `alphabeticBaseline`, `emHeightAscent`, and `emHeightDescent` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release notably changes to using N-API. 🎉
 * Fix issue related to improper parsing of leading and trailing whitespaces in CSS color. (#2301)
 * RGB functions should support real numbers now instead of just integers. (#2339)
 * Allow alternate or properly escaped quotes *within* font-family names
+* Fix TextMetrics type to include alphabeticBaseline, emHeightAscent, and emHeightDescent properties
 
 2.11.2
 ==================

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,10 +128,13 @@ export class Canvas {
 }
 
 export interface TextMetrics {
+	readonly alphabeticBaseline: number;
 	readonly actualBoundingBoxAscent: number;
 	readonly actualBoundingBoxDescent: number;
 	readonly actualBoundingBoxLeft: number;
 	readonly actualBoundingBoxRight: number;
+	readonly emHeightAscent: number;
+	readonly emHeightDescent: number;
 	readonly fontBoundingBoxAscent: number;
 	readonly fontBoundingBoxDescent: number;
 	readonly width: number;


### PR DESCRIPTION
Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
