### PR TITLE
GitHub Actions: Test on the latest macOS X64 and ARM64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,71 +8,35 @@ on:
       - ".github/workflows/prebuild.yaml"
 
 jobs:
-  Linux:
-    name: Test on Linux
-    runs-on: ubuntu-latest
+  Test:
+    name: Test on Node.js
     strategy:
+      fail-fast: false
       matrix:
-        node: [18.12.0, 20.9.0]
+        node: [18.x, 20.x, 22.x, latest]
+        os: [macos-13, macos-latest, ubuntu-latest, windows-2019]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - uses: actions/checkout@v4
-      - name: Install Dependencies
+      - name: Install Linux Dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install -y libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
-      - name: Install
-        run: npm install --build-from-source
-      - name: Test
-        run: npm test
-
-  Windows:
-    name: Test on Windows
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        # FIXME: Node.js 20.9.0 is currently broken on Windows, in the `registerFont` test:
-        # ENOENT: no such file or directory, lstat 'D:\a\node-canvas\node-canvas\examples\pfennigFont\pfennigMultiByte🚀.ttf'
-        # ref: https://github.com/nodejs/node/issues/48673
-        # ref: https://github.com/nodejs/node/pull/50650
-        node: [18.12.0]
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v4
-      - name: Install Dependencies
+          sudo apt install -y libcairo2-dev libgif-dev libjpeg-dev libpango1.0-dev librsvg2-dev
+      - name: Install macOS Dependencies
+        if: runner.os == 'macOS'
+        # Pre-installed on GitHub Actions macOS images: cairo giflib libpng pkg-config
+        run: brew install jpeg librsvg pango  # cairo giflib libpng pkg-config  
+      - name: Install Windows Dependencies
+        if: runner.os == 'Windows'
         run: |
           Invoke-WebRequest "https://ftp-osl.osuosl.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip" -OutFile "gtk.zip"
           Expand-Archive gtk.zip -DestinationPath "C:\GTK"
           Invoke-WebRequest "https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-2.0.4-vc64.exe" -OutFile "libjpeg.exe" -UserAgent NativeHost
-          .\libjpeg.exe /S
-          npm install -g node-gyp@8
-          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-      - name: Install
-        run: npm install --build-from-source
-      - name: Test
-        run: npm test
-
-  macOS:
-    name: Test on macOS
-    runs-on: macos-12
-    strategy:
-      matrix:
-        node: [18.12.0, 20.9.0]
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v4
-      - name: Install Dependencies
-        run: |
-          brew update
-          brew install python3 || : # python doesn't need to be linked
-          brew install pkg-config cairo pango libpng jpeg giflib librsvg
-          pip install setuptools
+          .\libjpeg.exe /S      
       - name: Install
         run: npm install --build-from-source
       - name: Test
@@ -84,7 +48,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.9.0
+          node-version: latest
       - uses: actions/checkout@v4
       - name: Install
         run: npm install --ignore-scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+* Added testing on Node.js 22.x and simplified GitHub Actions `ci.yaml`.
 ### Fixed
 
 


### PR DESCRIPTION
On GitHub Actions macOS-13 is X64 and macOS-14 is ARM64.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
```yaml
  Test:
    name: Test on Node.js
    strategy:
      fail-fast: false
      matrix:
        node: [18, 20, 22]
        os: [macos-13, macos-latest, ubuntu-latest, windows-2019]
    runs-on: ${{ matrix.os }}
```

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
