### PR TITLE
Add link tags for pdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+* Support for links in PDFs
 ### Fixed
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -521,6 +521,22 @@ ctx.addPage(400, 800)
 ctx.fillText('Hello World 2', 50, 80)
 ```
 
+It is possible to add hyperlinks use `.beginTag()` and `.closeTag()`:
+
+```js
+ctx.beginTag({name: 'Link', uri: 'https://google.com'})
+ctx.font = '22px Helvetica'
+ctx.fillText('Hello World', 50, 80)
+ctx.closeTag()
+```
+
+Or with a defined rectangle:
+
+```js
+ctx.beginTag({name: 'Link', uri: 'https://google.com', rect: { x: 50, y: 80, width: 100, height: 20 }})
+ctx.closeTag()
+```
+
 See also:
 
 * [Image#dataMode](#imagedatamode) for embedding JPEGs in PDFs

--- a/examples/pdf-link-rect.js
+++ b/examples/pdf-link-rect.js
@@ -1,0 +1,20 @@
+const fs = require('fs')
+const Canvas = require('..')
+
+const canvas = Canvas.createCanvas(400, 200, 'pdf')
+const ctx = canvas.getContext('2d')
+
+let x = 50
+let y = 80
+
+ctx.beginTag({ name: 'Link', uri: 'https://google.com', rect: { x: 40, y: 70, width: 100, height: 50 } })
+ctx.closeTag()
+
+ctx.font = '22px Helvetica'
+ctx.fillText('node-canvas pdf', x, y)
+
+fs.writeFile('out.pdf', canvas.toBuffer(), function (err) {
+  if (err) throw err
+
+  console.log('created out.pdf')
+})

--- a/examples/pdf-link.js
+++ b/examples/pdf-link.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+const Canvas = require('..')
+
+const canvas = Canvas.createCanvas(400, 200, 'pdf')
+const ctx = canvas.getContext('2d')
+
+let y = 80
+let x = 50
+
+ctx.beginTag({ name: 'Link', uri: 'https://google.com' })
+ctx.font = '22px Helvetica'
+ctx.fillText('node-canvas pdf', x, y)
+ctx.closeTag()
+
+fs.writeFile('out.pdf', canvas.toBuffer(), function (err) {
+  if (err) throw err
+
+  console.log('created out.pdf')
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -232,6 +232,8 @@ export class CanvasRenderingContext2D {
 	createPattern(image: Canvas|Image, repetition: 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat' | '' | null): CanvasPattern
 	createLinearGradient(x0: number, y0: number, x1: number, y1: number): CanvasGradient;
 	createRadialGradient(x0: number, y0: number, r0: number, x1: number, y1: number, r1: number): CanvasGradient;
+	beginTag(config: {name: 'Link', uri: string, rect?: {x: number, y: number, width: number, height: number}}): void;
+	closeTag(): void;
 	/**
 	 * _Non-standard_. Defaults to 'good'. Affects pattern (gradient, image,
 	 * etc.) rendering quality.

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -178,6 +178,10 @@ class Context2d : public Napi::ObjectWrap<Context2d> {
     void SetFont(const Napi::CallbackInfo& info, const Napi::Value& value);
     void SetTextBaseline(const Napi::CallbackInfo& info, const Napi::Value& value);
     void SetTextAlign(const Napi::CallbackInfo& info, const Napi::Value& value);
+    #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
+    void BeginTag(const Napi::CallbackInfo& info);
+    void CloseTag(const Napi::CallbackInfo& info);
+    #endif
     inline void setContext(cairo_t *ctx) { _context = ctx; }
     inline cairo_t *context(){ return _context; }
     inline Canvas *canvas(){ return _canvas; }


### PR DESCRIPTION
Interested to see if people think this is a reasonable implementation.

I went with as simple as possible based off https://www.cairographics.org/manual/cairo-Tags-and-Links.html#link

I know its not standard api, but there isn't one for this in canvas, and as was mentioned in the linked issue the project should be open to such an addition.

Fixes https://github.com/Automattic/node-canvas/issues/2044

- [X] Have you updated CHANGELOG.md?
