### PR TITLE
Throw surface errors in toBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release notably changes to using N-API. 🎉
 * Replaced `dtslint` with `tsd` (#2313)
 ### Added
 * Added string tags to support class detection
+* Throw Cairo errors in canvas.toBuffer()
 ### Fixed
 * Fix a case of use-after-free. (#2229)
 * Fix usage of garbage value by filling the allocated memory entirely with zeros if it's not modified. (#2229)

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -382,7 +382,15 @@ Canvas::ToBuffer(const Napi::CallbackInfo& info) {
       closure = static_cast<SvgBackend*>(backend())->closure();
     }
 
-    cairo_surface_finish(surface());
+    cairo_surface_t *surf = surface();
+    cairo_surface_finish(surf);
+
+    cairo_status_t status = cairo_surface_status(surf);
+    if (status != CAIRO_STATUS_SUCCESS) {
+      Napi::Error::New(env, cairo_status_to_string(status)).ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+
     return Napi::Buffer<uint8_t>::Copy(env, &closure->vec[0], closure->vec.size());
   }
 


### PR DESCRIPTION
I noticed this when developing https://github.com/Automattic/node-canvas/pull/2405 

we can check cairo_surface_status for errors, which I've noticed happening when I was making tags incorrectly, but thought this is actually quite helpful, as overwise you just get en empty buffer, and have no idea why it happened.

- [X] Have you updated CHANGELOG.md?
