### PR TITLE
docs: updated readme with command for installing packages from source using Yarn

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,13 @@ By default, pre-built binaries will be downloaded if you're on one of the follow
 - Linux x86/64 (glibc only)
 - Windows x86/64
 
-If you want to build from source, use `npm install --build-from-source` and see the **Compiling** section below.
+If you want to build from source, 
+use `npm_config_build_from_source=true yarn install`
+
+or with npm:
+use `npm install --build-from-source`
+
+and see the **Compiling** section below.
 
 The minimum version of Node.js required is **18.12.0**.
 
@@ -589,6 +595,10 @@ Notes and caveats:
 First make sure you've built the latest version. Get all the deps you need (see [compiling](#compiling) above), and run:
 
 ```
+npm_config_build_from_source=true yarn install
+
+or with npm:
+
 npm install --build-from-source
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -24,10 +24,10 @@ By default, pre-built binaries will be downloaded if you're on one of the follow
 - Windows x86/64
 
 If you want to build from source, 
-use `npm_config_build_from_source=true yarn install`
 
-or with npm:
-use `npm install --build-from-source`
+For npm, use: `npm install --build-from-source`
+
+or with yarn, use: `npm_config_build_from_source=true yarn install` 
 
 and see the **Compiling** section below.
 
@@ -595,11 +595,9 @@ Notes and caveats:
 First make sure you've built the latest version. Get all the deps you need (see [compiling](#compiling) above), and run:
 
 ```
-npm_config_build_from_source=true yarn install
+For npm, use: `npm install --build-from-source`
 
-or with npm:
-
-npm install --build-from-source
+or with yarn, use: `npm_config_build_from_source=true yarn install`
 ```
 
 For visual tests: `npm run test-server` and point your browser to http://localhost:4000.


### PR DESCRIPTION
Added a command for installing **packages from source** using Yarn.

For npm, use: npm install --build-from-source=true
For yarn use: npm_config_build_from_source=true yarn install

Ref: Please find more details in the Yarn documentation here - https://classic.yarnpkg.com/en/docs/envvars/#toc-npm-config