### PR TITLE
Remove object files and other large not needed artifacts from prebuilds.

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -261,6 +261,8 @@ jobs:
       - name: Bundle pt 2
         shell: msys2 {0}
         run: |
+          # removes object files and debug
+          . prebuild/Windows/bundle.sh
           ./depends.exe -c -oc depends.csv build\\Release\\canvas.node || true
           [ -f depends.csv ] || { echo "error invoking depends.exe"; exit 1; }
 
@@ -272,7 +274,7 @@ jobs:
           for dll in $copies; do
             cp /ucrt64/bin/$dll build/Release
           done;
-
+          
       - name: Test binary
         # By not running in msys2, this doesn't have access to the msys2 libs
         run: npm test

--- a/prebuild/Linux/bundle.sh
+++ b/prebuild/Linux/bundle.sh
@@ -4,6 +4,10 @@ apt install -y patchelf pax-utils
 
 copies=$(lddtree -l build/Release/canvas.node | sed -r -e '/^\/lib/d' -e '/canvas.node$/d');
 
+# remove the big artifacts we will not use.
+rm -r build/Release/.deps
+rm -r build/Release/obj.target
+
 for so in $copies; do
   cp $so build/Release
   # Set the run_path for all dependencies.

--- a/prebuild/Linux/bundle.sh
+++ b/prebuild/Linux/bundle.sh
@@ -13,3 +13,5 @@ for so in $copies; do
   # Set the run_path for all dependencies.
   patchelf --set-rpath '$ORIGIN' build/Release/$(basename $so)
 done;
+
+find "./build/Release" -type f -name "*.so*" -exec strip --strip-unneeded {} \;

--- a/prebuild/Windows/bundle.sh
+++ b/prebuild/Windows/bundle.sh
@@ -1,0 +1,9 @@
+# remove the big artifacts we will not use.
+# on windows this is >45mbytes.
+rm -r build/Release/obj
+rm -r build/Release/canvas.exp
+rm -r build/Release/canvas.iobj
+rm -r build/Release/canvas.ipdb
+rm -r build/Release/canvas.lib
+rm -r build/Release/canvas.pdb
+

--- a/prebuild/macOS/bundle.sh
+++ b/prebuild/macOS/bundle.sh
@@ -1,4 +1,8 @@
 build=build/Release
 
+# remove the big artifacts we will not use.
+rm -r build/Release/.deps
+rm -r build/Release/obj.target
+
 ~/Library/Python/*/bin/macpack build/Release/canvas.node -d .
 


### PR DESCRIPTION
Thanks for contributing!

- [ ] Have you updated CHANGELOG.md? - no there is none for prebuilds?

Removes LARGE artifacts in the prebuilds.

## Macos:
deletes object files (save a few mb)
## Linux:
deletes object files and strips libraries (save ~22mbytes)
## Windows
Deletes object files and debug files. (save 45mbytes)
