### PR TITLE
Add prebuild for macos arm64, enable prebuilds to be run individually.

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -152,6 +152,80 @@ jobs:
               name: assetName,
               data: fs.readFileSync(assetName)
             });
+  macOSarm:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22]
+        canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOSarm64
+    runs-on: macos-latest # macos-14+ is M1
+    if: contains(fromJson(inputs.os), 'macos-latest')
+    env:
+      CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.canvas_tag }}
+          # Fetch all commits/all branches so we can checkout the prebuild
+          # branch's files
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Build
+        run: |
+          set -Eeuxo pipefail
+          git checkout ${{ matrix.canvas_tag }}
+          git checkout $GITHUB_SHA -- prebuild/
+          npm install -g node-gyp
+          npm install --ignore-scripts
+          . prebuild/macOS/preinstall.sh
+          cp prebuild/macOS/binding.gyp binding.gyp
+          node-gyp rebuild -j 2
+          . prebuild/macOS/bundle.sh
+
+      - name: Test binary
+        run: |
+          brew uninstall --force --ignore-dependencies cairo pango librsvg giflib harfbuzz
+          npm test
+
+      - name: Make bundle
+        id: make_bundle
+        run: . prebuild/tarball.sh
+
+      - name: Upload
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const fs = require("fs");
+            const assetName = "${{ steps.make_bundle.outputs.asset_name }}";
+            const tagName = process.env.UPLOAD_TO || process.env.CANVAS_VERSION_TO_BUILD;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+            const releases = await github.repos.listReleases({owner, repo});
+            const release = releases.data.find(r => r.tag_name === tagName);
+            if (!release)
+              throw new Error(`Tag ${tagName} not found. Did you make the GitHub release?`);
+
+            const oldAsset = release.assets.find(a => a.name === assetName);
+            if (oldAsset)
+              await github.repos.deleteReleaseAsset({owner, repo, asset_id: oldAsset.id});
+
+            // (This is equivalent to actions/upload-release-asset. We're
+            // already in a script, so might as well do it here.)
+            const r = await github.repos.uploadReleaseAsset({
+              url: release.upload_url,
+              headers: {
+                "content-type": "application/x-gzip",
+                "content-length": `${fs.statSync(assetName).size}`
+              },
+              name: assetName,
+              data: fs.readFileSync(assetName)
+            });
+
 
   macOS:
     strategy:
@@ -228,80 +302,6 @@ jobs:
             });
 
             
-  macOSarm:
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [22]
-        canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOSarm64
-    runs-on: macos-latest # macos-14+ is M1
-    if: contains(fromJson(inputs.os), 'macos-latest')
-    env:
-      CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ matrix.canvas_tag }}
-          # Fetch all commits/all branches so we can checkout the prebuild
-          # branch's files
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Build
-        run: |
-          set -Eeuxo pipefail
-          git checkout ${{ matrix.canvas_tag }}
-          git checkout $GITHUB_SHA -- prebuild/
-          npm install -g node-gyp
-          npm install --ignore-scripts
-          . prebuild/macOS/preinstall.sh
-          cp prebuild/macOS/binding.gyp binding.gyp
-          node-gyp rebuild -j 2
-          . prebuild/macOS/bundle.sh
-
-      - name: Test binary
-        run: |
-          brew uninstall --force --ignore-dependencies cairo pango librsvg giflib harfbuzz
-          npm test
-
-      - name: Make bundle
-        id: make_bundle
-        run: . prebuild/tarball.sh
-
-      - name: Upload
-        uses: actions/github-script@v2
-        with:
-          script: |
-            const fs = require("fs");
-            const assetName = "${{ steps.make_bundle.outputs.asset_name }}";
-            const tagName = process.env.UPLOAD_TO || process.env.CANVAS_VERSION_TO_BUILD;
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-
-            const releases = await github.repos.listReleases({owner, repo});
-            const release = releases.data.find(r => r.tag_name === tagName);
-            if (!release)
-              throw new Error(`Tag ${tagName} not found. Did you make the GitHub release?`);
-
-            const oldAsset = release.assets.find(a => a.name === assetName);
-            if (oldAsset)
-              await github.repos.deleteReleaseAsset({owner, repo, asset_id: oldAsset.id});
-
-            // (This is equivalent to actions/upload-release-asset. We're
-            // already in a script, so might as well do it here.)
-            const r = await github.repos.uploadReleaseAsset({
-              url: release.upload_url,
-              headers: {
-                "content-type": "application/x-gzip",
-                "content-length": `${fs.statSync(assetName).size}`
-              },
-              name: assetName,
-              data: fs.readFileSync(assetName)
-            });
-
   Win:
     strategy:
       fail-fast: false

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -234,7 +234,7 @@ jobs:
       matrix:
         node: [22]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOSarm64
     runs-on: macos-latest # macos-14+ is M1
     if: contains(fromJson(inputs.os), 'macos-latest')
     env:
@@ -309,7 +309,7 @@ jobs:
         node: [22]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Windows
-    runs-on: target-latest
+    runs-on: windows-latest
     if: contains(fromJson(inputs.os), 'windows-latest')
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -197,7 +197,7 @@ jobs:
         run: . prebuild/tarball.sh
 
       - name: Upload
-        uses: actions/github-script@v2
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -164,7 +164,7 @@ jobs:
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.canvas_tag }}
           # Fetch all commits/all branches so we can checkout the prebuild

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [latest]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOSarm64
     runs-on: macos-latest # macos-14+ is M1

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -32,7 +32,21 @@
 # "edit" and delete any assets that are in purgatory (have a /!\ next to them).
 
 name: Make Prebuilds
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'Target os'
+        required: true
+        type: choice
+        options:
+          - '["ubuntu-latest"]'
+          - '["windows-latest"]'
+          - '["macos-13"]'
+          - '["macos-latest"]'
+          - '["ubuntu-latest", "windows-latest", "macos-13", "macos-latest"]'
+        default: '["ubuntu-latest", "windows-latest", "macos-13", "macos-latest"]'
+        
 
 # UPLOAD_TO can be specified to upload the release assets under a different tag
 # name (e.g. for testing). If omitted, the assets are published under the same
@@ -50,10 +64,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [21]
+        node: [22]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag }}, Node.js ${{ matrix.node }}, Linux
     runs-on: ubuntu-latest
+    if: contains(fromJson(inputs.os), 'ubuntu-latest')
     container:
       image: ${{ matrix.node < 18 && 'chearon/canvas-prebuilt:9' || 'zbbjornson/canvas-prebuilt:11' }}
     env:
@@ -142,10 +157,86 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [21]
+        node: [22]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
-    runs-on: macos-12 # macos-14+ is M1
+    runs-on: macos-13 # macos-14+ is M1
+    if: contains(fromJson(inputs.os), 'macos-13')
+    env:
+      CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.canvas_tag }}
+          # Fetch all commits/all branches so we can checkout the prebuild
+          # branch's files
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Build
+        run: |
+          set -Eeuxo pipefail
+          git checkout ${{ matrix.canvas_tag }}
+          git checkout $GITHUB_SHA -- prebuild/
+          npm install -g node-gyp
+          npm install --ignore-scripts
+          . prebuild/macOS/preinstall.sh
+          cp prebuild/macOS/binding.gyp binding.gyp
+          node-gyp rebuild -j 2
+          . prebuild/macOS/bundle.sh
+
+      - name: Test binary
+        run: |
+          brew uninstall --force --ignore-dependencies cairo pango librsvg giflib harfbuzz
+          npm test
+
+      - name: Make bundle
+        id: make_bundle
+        run: . prebuild/tarball.sh
+
+      - name: Upload
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const fs = require("fs");
+            const assetName = "${{ steps.make_bundle.outputs.asset_name }}";
+            const tagName = process.env.UPLOAD_TO || process.env.CANVAS_VERSION_TO_BUILD;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+            const releases = await github.repos.listReleases({owner, repo});
+            const release = releases.data.find(r => r.tag_name === tagName);
+            if (!release)
+              throw new Error(`Tag ${tagName} not found. Did you make the GitHub release?`);
+
+            const oldAsset = release.assets.find(a => a.name === assetName);
+            if (oldAsset)
+              await github.repos.deleteReleaseAsset({owner, repo, asset_id: oldAsset.id});
+
+            // (This is equivalent to actions/upload-release-asset. We're
+            // already in a script, so might as well do it here.)
+            const r = await github.repos.uploadReleaseAsset({
+              url: release.upload_url,
+              headers: {
+                "content-type": "application/x-gzip",
+                "content-length": `${fs.statSync(assetName).size}`
+              },
+              name: assetName,
+              data: fs.readFileSync(assetName)
+            });
+
+            
+  macOSarm:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22]
+        canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
+    runs-on: macos-latest # macos-14+ is M1
+    if: contains(fromJson(inputs.os), 'macos-latest')
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
     steps:
@@ -215,10 +306,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [21]
+        node: [22]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Windows
-    runs-on: windows-2019
+    runs-on: target-latest
+    if: contains(fromJson(inputs.os), 'windows-latest')
     env:
       CANVAS_VERSION_TO_BUILD: ${{ matrix.canvas_tag }}
     steps:

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -171,7 +171,7 @@ jobs:
           # branch's files
           fetch-depth: 0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -306,7 +306,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [latest]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, Windows
     runs-on: windows-latest

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -231,7 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [latest]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOS
     runs-on: macos-13 # macos-14+ is M1

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [latest]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
     name: ${{ matrix.canvas_tag }}, Node.js ${{ matrix.node }}, Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -158,7 +158,7 @@ jobs:
       matrix:
         node: [latest]
         canvas_tag: ["v3.0.0-rc2"] # e.g. "v2.6.1"
-    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, macOSarm64
+    name: ${{ matrix.canvas_tag}}, Node.js ${{ matrix.node }}, ${{ runner.os }} on ${{ runner.arch }}
     runs-on: macos-latest # macos-14+ is M1
     if: contains(fromJson(inputs.os), 'macos-latest')
     env:

--- a/README.md
+++ b/README.md
@@ -82,13 +82,3 @@ and
 in the installed branch to reflect the repo you want to pull released prebuilds from,
 
 and for version, this MUST match your tag without 'v' prefix (e.g. a version of 'dev' needs a tag of 'vdev')
-
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
-This is the prebuild branch. The only directory used in it is prebuild/. Otherwise files are taken from the branch being built.
+This is the prebuild branch. 
+
+The only directory used in it is prebuild/. 
+
+Otherwise files are taken from the branch being built.
+
+# Changes:
+
+## 2024-11-01 btsimonh
+
+Added the below notes.
+
+Added macos arm64 prebuilds.
+
+
+
+# notes from prebuild.yml:
+
+```
+# Release procedure:
+# 1. On the master branch, update the changelog and stage it in git.
+# 2. Run `yarn version --[major|minor|patch]`. (This tags the commit.)
+# 3. Push both the commit and tags to GitHub (`git push --tags Automattic` and
+#    `git push Automattic HEAD:master`, where "Automattic" is the remote name
+#    for git@github.com:Automattic/node-canvas.git).
+# 4. Create a draft release manually using the GitHub UI for the new tag.
+# 5. Switch to the prebuilds branch.
+# 6. Set the `jobs.*.strategy.matrix.node` arrays to the set of Node.js versions
+#    to build for.
+# 7. Set the `jobs.*.strategy.matrix.canvas_tag` arrays to the set of Canvas
+#    tags to build. (Usually this is a single tag, but can be an array when a
+#    new version of Node.js is released and older versions of Canvas need to be
+#    built.)
+# 8. Commit this file and push.
+# 9. In the Actions tab, navigate to the "Make Prebuilds" workflow and click
+#    "Run workflow". Select the `prebuilds` branch so that that branch's
+#    prebuild.yaml file is used.
+# 10.Once the builds succeed, promote the draft release to a full release and
+#    run npm publish.
+
+# Note that the files in the prebuild/ directory will be used from the commit
+# that was used to trigger the prebuild workflow. They will not be from the
+# commit/tag that you are building. Because of differences in the provided
+# versions of git, this is achieved in a different way on Linux than on Mac and
+# Win.
+#
+# Pay particular attention to changes to binding.gyp on master. That file is not
+# used! The ones in prebuild/**/ are.
+
+# Tip: If uploads are inexplicably failing, open the release in GitHub, click
+# "edit" and delete any assets that are in purgatory (have a /!\ next to them).
+```
+
+### Prebuilding only a specific platform:
+
+When manually running `Make Prebuilds`, you should be asked for `Target os`.
+
+Select the single target os OR the default multiple OSes.
+
+
+### prebuilding for your own repo.
+
+If you fork, and prebuild on your own repo, you will need to create a release based on a tag.
+
+Prebuild WILL checkout the tag you specify in the cavnas tag property for each OS, and will build THAT tag from master - not your master HEAD or another branch.
+
+e.g.:
+```
+        canvas_tag: ["vdev"] # e.g. "v2.6.1"`
+```        
+
+Prebuild will upload the output to YOUR repo into the release you created.
+
+IF you want to USE your prebuilds, you would need to change (in package.json):
+```
+  "repository": "git://github.com/Automattic/node-canvas.git",
+```
+and
+```
+  "version": "3.0.0-rc2",
+```
+in the installed branch to reflect the repo you want to pull released prebuilds from,
+
+and for version, this MUST match your tag without 'v' prefix (e.g. a version of 'dev' needs a tag of 'vdev')
+
+
+
+
+
+
+
+
+
+

--- a/prebuild/macOS/binding.gyp
+++ b/prebuild/macOS/binding.gyp
@@ -34,6 +34,8 @@
         '<!@(pkg-config pangocairo --libs)',
         '<!@(pkg-config freetype2 --libs)',
         '<!@(pkg-config librsvg-2.0 --libs)',
+        '<!@(pkg-config libjpeg --libs)',
+        '-L/opt/homebrew/lib',
         '-ljpeg',
         '-lgif'
       ],
@@ -43,7 +45,8 @@
         '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)',
-        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)'
+        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)',
+        '/opt/homebrew/include'
       ],
       'cflags+': ['-fvisibility=hidden'],
       'xcode_settings': {

--- a/prebuild/tarball.sh
+++ b/prebuild/tarball.sh
@@ -1,8 +1,11 @@
 # Generate the prebuild-install formatted filename from the node environment
+# match prebuild-install style.
 FILENAME=$(
   node -e "
-    var p = process, v = p.versions, libc = require('detect-libc').familySync() || 'unknown';
-    if (libc === 'glibc') libc = '';
+    var p = process, v = p.versions;
+    const detectLibc = require('detect-libc');
+    const libc = process.env.LIBC || process.env.npm_config_libc ||
+      (detectLibc.isNonGlibcLinuxSync() && detectLibc.familySync()) || ''
     const tagName = p.env.UPLOAD_TO || p.env.CANVAS_VERSION_TO_BUILD;
     console.log('canvas-' + tagName + '-napi-v7-' + p.platform + libc + '-' + p.arch);
   "


### PR DESCRIPTION
Thanks for contributing!

- [ ] Have you updated CHANGELOG.md? - no, there is none for prebuild?

1. adds ability to select the build target.  Default is all of `'["ubuntu-latest", "windows-latest", "macos-13", "macos-latest"]'`.
2. update to use node 22 since it is the LTS version.
3. update runners to be from "ubuntu-latest", "windows-latest", "macos-13", "macos-latest".
4. add some library paths to prebuild/macOS/binding.gyp which enable macos arm64 to build.

for best effect, combine with https://github.com/Automattic/node-canvas/pull/2450 to result in smaller prebuilds

I note that 2 tests are failing during prebuild - on the original and on this branch (at least on linux - maybe a font issue).  Maybe we should build the libraries from source, as test on main repo is not failing?

Also note https://github.com/Automattic/node-canvas/pull/2354 - almost identical changes for actually building on arm64.  But I have not included signing.  I have never needed to sign a .node or a library before? - but then I don't have an M1/M2 mac.

@zbjornson @jamesbvaughan - pls. comment or combine the two PRs?