### PR TITLE
Fixes related to fillText that caused subsequent calls of fillText to not appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Fix a crash when SVGs without width or height are loaded (#2486)
 * Fix fetching prebuilds during installation on certain newer versions of Node (#2497)
+* Fixed issue with fillText that was breaking subsequent fillText calls (#2171)
 
 3.1.0
 ==================

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -2496,6 +2496,7 @@ Context2d::paintText(const Napi::CallbackInfo& info, bool stroke) {
   pango_context_set_base_dir(pango_layout_get_context(_layout), pango_dir);
 
   if (argsNum == 3) {
+    if (args[2] <= 0) return;
     scaled_by = get_text_scale(layout, args[2]);
     cairo_save(context());
     cairo_scale(context(), scaled_by, 1);


### PR DESCRIPTION
Issue (#2171) fixed. Calling fillText with a maxWidth <= 0 caused subsequent calls of fillText to not appear. Now only the call with a maxWidth <= 0 does not appear.

- [x] Have you updated CHANGELOG.md?
