### PR TITLE
fix(deps): update `prebuild-install` to work on Node 22.14+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * Fix a crash when SVGs without width or height are loaded (#2486)
+* Fix fetching prebuilds during installation on certain newer versions of Node (#2497)
 
 3.1.0
 ==================

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "node-addon-api": "^7.0.0",
-    "prebuild-install": "^7.1.1"
+    "prebuild-install": "^7.1.3"
   },
   "devDependencies": {
     "@types/node": "^10.12.18",


### PR DESCRIPTION
### Motivation

This installation error on Node 22.14+:
```
npm error prebuild-install warn This package does not support N-API version undefined
npm error prebuild-install warn install No prebuilt binaries found (target=undefined runtime=napi arch=x64 libc= platform=linux)
```

is resolved by updating to newer `prebuild-install` 7.1.3, which has a newer version of `napi-build-utils` (2.0.0) with a bugfix for newer N-API version comparison

### Further Reading

This fixes the issue I noted in https://github.com/Automattic/node-canvas/issues/2448#issuecomment-2759459548 with the suggestion in the following comment https://github.com/Automattic/node-canvas/issues/2448#issuecomment-2759866317. See also https://github.com/prebuild/prebuild-install/issues/203,  https://github.com/inspiredware/napi-build-utils/issues/6 for root cause.

### Notes to Reviewers

While consumers can update their version of `prebuild-install` in their lockfiles independently, the version bump here will _require_ a newer version that is backward- and forward-compatible.

### Verification

This dep bump fixed the error for me in https://github.com/agilgur5/react-signature-canvas/pull/132

### template

Thanks for contributing!

- [x] Have you updated CHANGELOG.md?
