### PR TITLE
fix: reject loadImage when src is null or invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Fixed
+* fix: reject loadImage when src is null or invalid
 
 3.1.1
 ==================

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ function createImageData (array, width, height) {
 
 function loadImage (src) {
   return new Promise((resolve, reject) => {
+    if (!src) return reject(new Error("Invalid image source"));
+
     const image = new Image()
 
     function cleanup () {

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -516,6 +516,27 @@ describe('Image', function () {
       img.src = path.join(bmpDir, 'bomb.bmp')
     })
 
+    it('rejects when loadImage is called with null', async function () {
+        await assert.rejects(
+            loadImage(null),
+            /Invalid image source/
+        )
+    })
+
+    it('rejects when loadImage is called with undefined', async function () {
+        await assert.rejects(
+            loadImage(undefined),
+            /Invalid image source/
+        )
+    })
+
+    it('rejects when loadImage is called with empty string', async function () {
+        await assert.rejects(
+            loadImage(''),
+            /Invalid image source/
+        )
+    })
+
     function testImgd (img, data) {
       const ctx = createCanvas(img.width, img.height).getContext('2d')
       ctx.drawImage(img, 0, 0)


### PR DESCRIPTION
Description:
- Prevents loadImage() from getting stuck when given null or undefined
- Add test cases for '', null, and undefined inputs to loadImage()

Test Result:
```
npm test

> canvas@3.1.1 test
> mocha test/*.test.js

  Canvas
    ✓ Prototype and ctor are well-shaped, don't hit asserts on accessors (GH-803)
    ✓ registerFont
    ✓ color serialization
    ✓ color parser
    ✓ Canvas#type
    ✓ Canvas#getContext("2d")
    ✓ Canvas#getContext("2d", {pixelFormat: string})
    ✓ Canvas#getContext("2d", {alpha: boolean})
    ✓ Canvas#{width,height}=
    ✓ Canvas#width= (resurfacing) doesn't crash when fillStyle is a pattern (#1357)
    ✓ SVG Canvas#width changes don't crash (#1380)
    ✓ Canvas#stride
    ✓ Canvas#getContext("invalid")
    ✓ Context2d#patternQuality
    ✓ Context2d#imageSmoothingEnabled
    ✓ Context2d#font=
    ✓ Context2d#lineWidth=
    ✓ Context2d#antiAlias=
    ✓ Context2d#lineCap=
    ✓ Context2d#lineJoin=
    ✓ Context2d#globalAlpha=
    ✓ Context2d#isPointInPath()
    ✓ Context2d#textAlign
    ✓ Context2d#fillText()
    ✓ Context2d#currentTransform
    ✓ Context2d#createImageData(ImageData)
    ✓ Context2d#createPattern(Canvas)
    ✓ Context2d#createPattern(Canvas).setTransform()
    ✓ Context2d#createPattern(Image)
    ✓ CanvasPattern stringifies as [object CanvasPattern]
    ✓ CanvasPattern has class string of `CanvasPattern`
    ✓ Context2d#createLinearGradient()
    ✓ Canvas has class string of `HTMLCanvasElement`
    ✓ CanvasGradient stringifies as [object CanvasGradient]
    ✓ CanvasGradient has class string of `CanvasGradient`
    ✓ Canvas#createPNGStream()
    ✓ Canvas#createPDFStream()
    ✓ Canvas#createJPEGStream()
    ✓ EOI at end of Canvas#createJPEGStream()
    ✓ Context2d#fill()
    ✓ Context2d#clip()
    ✓ Context2d#IsPointInPath()
    ✓ Context2d#rotate(angle)
    ✓ Context2d#drawImage()
    ✓ Context2d#SetFillColor()
    #toBuffer
      ✓ Canvas#toBuffer()
      ✓ Canvas#toBuffer("image/png")
      ✓ Canvas#toBuffer("image/png", {resolution: 96})
      ✓ Canvas#toBuffer("image/png", {compressionLevel: 5})
      ✓ Canvas#toBuffer("image/png", {filters: PNG_ALL_FILTERS})
      ✓ Canvas#toBuffer("image/jpeg")
      ✓ Canvas#toBuffer("image/jpeg", {quality: 0.95})
      ✓ Canvas#toBuffer(callback)
      ✓ Canvas#toBuffer(callback, "image/jpeg")
      ✓ Canvas#toBuffer(callback, "image/jpeg", {quality: 0.95})
      ✓ Canvas#toBuffer("application/pdf")
      #toBuffer("raw")
        ✓ should have the correct size
        ✓ does not premultiply alpha
        ✓ draws red
        ✓ draws green
        ✓ draws black
        ✓ leaves undrawn pixels black, transparent
        ✓ is immutable
    #toDataURL()
      ✓ toDataURL() works and defaults to PNG
      ✓ toDataURL(0.5) works and defaults to PNG
      ✓ toDataURL(undefined) works and defaults to PNG
      ✓ toDataURL("image/png") works
      ✓ toDataURL("image/png", 0.5) works
      ✓ toDataURL("iMaGe/PNg") works
      ✓ toDataURL("image/jpeg") works
      ✓ toDataURL(function (err, str) {...}) works and defaults to PNG
      ✓ toDataURL(function (err, str) {...}) is async even with no canvas data
      ✓ toDataURL(0.5, function (err, str) {...}) works and defaults to PNG
      ✓ toDataURL(undefined, function (err, str) {...}) works and defaults to PNG
      ✓ toDataURL("image/png", function (err, str) {...}) works
      ✓ toDataURL("image/png", 0.5, function (err, str) {...}) works
      ✓ toDataURL("image/png", {}) works
      ✓ toDataURL("image/jpeg", {}) works
      ✓ toDataURL("image/jpeg", function (err, str) {...}) works
      ✓ toDataURL("iMAge/JPEG", function (err, str) {...}) works
      ✓ toDataURL("image/jpeg", undefined, function (err, str) {...}) works
      ✓ toDataURL("image/jpeg", 0.5, function (err, str) {...}) works
      ✓ toDataURL("image/jpeg", opts, function (err, str) {...}) works
    Context2d#createImageData(width, height)
      ✓ works
      ✓ works, A8 format
      ✓ works, A1 format
      ✓ works, RGB24 format
      ✓ works, RGB16_565 format
    Context2d#measureText()
      ✓ Context2d#measureText().width
      ✓ works
      ✓ actualBoundingBox is correct for left, center and right alignment (#1909)
      ✓ resolves text alignment wrt Context2d#direction #2508
    Context2d#getImageData()
      ✓ works, full width, RGBA32
      ✓ works, full width, RGB24
      ✓ works, full width, RGB16_565
      ✓ works, full width, A8
      - works, full width, A1
      - works, full width, RGB30
      ✓ works, slice, RGBA32
      ✓ works, slice, RGB24
      ✓ works, slice, RGB16_565
      ✓ works, slice, A8
      - works, slice, A1
      - works, slice, RGB30
      ✓ works, assignment
      ✓ throws if indexes are invalid
      ✓ throws if canvas is a PDF canvas (#1853)
      slice partially outside the canvas
        left
          ✓ works, RGB24
          ✓ works, RGB16_565
          ✓ works, A8
        right
          ✓ works, RGBA32
          ✓ works, RGB24
          ✓ works, RGB16_565
          ✓ works, A8
        left and right
          ✓ works, RGBA32
          ✓ works, RGB24
          ✓ works, RGB16_565
          ✓ works, A8
        top
          ✓ works, RGBA32
          ✓ works, RGB24
          ✓ works, RGB16_565
          ✓ works, A8
        bottom
          ✓ works, RGBA32
          ✓ works, RGB24
          ✓ works, RGB16_565
          ✓ works, A8
        top to bottom
          ✓ works, RGBA32
          ✓ works, RGB24
          ✓ works, RGB16_565
          ✓ works, A8
      does not throw if rectangle is outside the canvas (#2024)
        ✓ on the left
        ✓ on the right
        ✓ on the top
        ✓ on the bottom
    Context2d#putImageData()
      ✓ throws for invalid arguments
      ✓ throws if canvas is a PDF canvas (#1853)
      ✓ works for negative source values
      ✓ works, RGBA32
      ✓ works, RGB24/alpha:false
      ✓ works, A8
      ✓ works, RGB16_565
    Context2d#save()/restore()
      ✓ 2d.state.saverestore.strokeStyle
      ✓ 2d.state.saverestore.fillStyle
      ✓ 2d.state.saverestore.globalAlpha
      ✓ 2d.state.saverestore.lineWidth
      ✓ 2d.state.saverestore.lineCap
      ✓ 2d.state.saverestore.lineJoin
      ✓ 2d.state.saverestore.miterLimit
      ✓ 2d.state.saverestore.shadowOffsetX
      ✓ 2d.state.saverestore.shadowOffsetY
      ✓ 2d.state.saverestore.shadowBlur
      ✓ 2d.state.saverestore.shadowColor
      ✓ 2d.state.saverestore.globalCompositeOperation
      ✓ 2d.state.saverestore.font
      ✓ 2d.state.saverestore.textAlign
      ✓ 2d.state.saverestore.textBaseline
      ✓ 2d.state.saverestore.imageSmoothingEnabled
      ✓ 2d.state.saverestore.lineDashOffset
      ✓ 2d.state.saverestore.patternQuality
      ✓ 2d.state.saverestore.textDrawingMode
      ✓ 2d.state.saverestore.antialias
    Context2d#beingTag()/endTag()
      ✓ generates a pdf
      ✓ requires tag argument
      ✓ requires attributes to be a string
    loadImage
      ✓ doesn't crash when you don't specify width and height

  DOMMatrix
    constructor, general
      ✓ aliases a,b,c,d,e,f properly
      ✓ parses lists of transforms per spec
      ✓ parses matrix2d(<16 numbers>) per spec
      ✓ sets is2D to true if matrix2d(<16 numbers>) is 2D
    multiply
      ✓ performs self.other, returning a new DOMMatrix
    multiplySelf
      ✓ performs self.other, mutating self
    preMultiplySelf
      ✓ performs other.self, mutating self
    translateSelf
      ✓ works, 1 arg
      ✓ works, 2 args
      ✓ works, 3 args
    scale
      ✓ works, 1 arg
      ✓ works, 2 args
      ✓ works, 3 args
      ✓ works, 4 args
      ✓ works, 5 args
      ✓ works, 6 args
    scale3d
      ✓ works, 0 args
      ✓ works, 1 arg
      ✓ works, 2 args
      ✓ works, 3 args
      ✓ works, 4 args
    rotate
      ✓ works, 1 arg
      ✓ works, 2 args
      ✓ works, 3 args
    rotateFromVector
      ✓ works, no args and x/y=0
      ✓ works
    rotateAxisAngle
      ✓ works, 0 args
      ✓ works, 4 args
    skewX
      ✓ works
    skewY
      ✓ works
    flipX
      ✓ works
    flipY
      ✓ works
    invertSelf
      ✓ works for invertible matrices
      ✓ works for non-invertible matrices
    inverse
      ✓ preserves the original DOMMatrix
      ✓ preserves the original DOMMatrix for non-invertible matrices
    transformPoint
      ✓ works
    toFloat32Array
      ✓ works
    toFloat64Array
      ✓ works
    toString
      ✓ works, 2d
      ✓ works, 3d
    toJSON
      ✓ works, 2d
      ✓ works, 3d

  Font parser
    ✓ 20px Arial
    ✓ 20pt Arial
    ✓ 20.5pt Arial
    ✓ 20% Arial
    ✓ 20mm Arial
    ✓ 20px serif
    ✓ 20px sans-serif
    ✓ 20px monospace
    ✓ 50px Arial, sans-serif
    ✓ bold italic 50px Arial, sans-serif
    ✓ 50px Helvetica ,  Arial, sans-serif
    ✓ 50px "Helvetica Neue", sans-serif
    ✓ 50px "Helvetica Neue", "foo bar baz" , sans-serif
    ✓ 50px 'Helvetica Neue'
    ✓ italic 20px Arial
    ✓ oblique 20px Arial
    ✓ normal 20px Arial
    ✓ 300 20px Arial
    ✓ 800 20px Arial
    ✓ bolder 20px Arial
    ✓ lighter 20px Arial
    ✓ normal normal normal 16px Impact
    ✓ italic small-caps bolder 16px cursive
    ✓ 20px "new century schoolbook", serif
    ✓ 20px "Arial bold 300"
    ✓ 50px "Helvetica 'Neue'", "foo \"bar\" baz" , "Someone's weird \'edge\' case", sans-serif
    ✓ Helvetica, sans
    ✓ 123px thefont/123abc
    ✓ 123px /   normal thefont
    ✓ 12px/1.2whoops arial
    ✓ bold bold 12px thefont
    ✓ italic italic 12px Arial
    ✓ small-caps bold italic small-caps 12px Arial
    ✓ small-caps bold oblique 12px 'A'ri\61l
    ✓ 12px/34% "The\
 Word"
    ✓
    ✓ normal normal normal 1%/normal a   ,     'b'
    ✓ normalnormalnormal 1px/normal a
    ✓ 12px _the_font
    ✓ 9px 7 birds
    ✓ 2em "Courier
    ✓ 2em \'Courier\"
    ✓ 1px \10abcde
    ✓ 3E+2 1e-1px yay

  Image
    ✓ Prototype and ctor are well-shaped, don't hit asserts on accessors (GH-803)
    ✓ Image has class string of `HTMLImageElement`
    ✓ loads JPEG image
    ✓ loads JPEG data URL
    ✓ loads PNG image
    ✓ loads PNG data URL
    ✓ detects invalid PNG
    ✓ propagates exceptions thrown by onload
    ✓ propagates exceptions thrown by onerror
    ✓ loads SVG data URL base64
    ✓ loads SVG data URL utf8
    ✓ calls Image#onload multiple times
    ✓ handles errors
    ✓ returns a nice, coded error for fopen failures
    ✓ captures errors from libjpeg
    ✓ calls Image#onerror multiple times
    ✓ Image#{width,height}
    ✓ Image#src set empty buffer
    ✓ should unbind Image#onload
    ✓ should unbind Image#onerror
    ✓ does not crash on invalid images
    ✓ does not contain `source` property
    supports BMP
      ✓ parses 1-bit image
      ✓ parses 4-bit image
      - parses 8-bit image
      ✓ parses 24-bit image
      ✓ parses 32-bit image
      ✓ parses minimal BMP
      ✓ properly handles negative height
      ✓ color palette
      ✓ V3 header
      - V5 header
      ✓ catches BMP errors
      ✓ BMP bomb
      ✓ rejects when loadImage is called with null
      ✓ rejects when loadImage is called with undefined
      ✓ rejects when loadImage is called with empty string

  ImageData
    ✓ Prototype and ctor are well-shaped, don't hit asserts on accessors (GH-803)
    ✓ stringifies as [object ImageData]
    ✓ gives class string as `ImageData`
    ✓ should throw with invalid numeric arguments
    ✓ should construct with width and height
    ✓ should throw with invalid typed array
    ✓ should construct with Uint8ClampedArray
    ✓ should construct with Uint16Array

  291 passing (192ms)
  6 pending
```

Thanks for contributing!

- [O] Have you updated CHANGELOG.md?

Fix #2304 
