### PR TITLE
Set pango language through ctx.lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ==================
 ### Changed
 ### Added
+* Added `ctx.lang` to set the ISO language code for text
 ### Fixed
 
 3.1.2

--- a/index.d.ts
+++ b/index.d.ts
@@ -291,6 +291,7 @@ export class CanvasRenderingContext2D {
 	textAlign: CanvasTextAlign;
 	canvas: Canvas;
 	direction: 'ltr' | 'rtl';
+	lang: string;
 }
 
 export class CanvasGradient {

--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,6 @@ export class CanvasRenderingContext2D {
 	textAlign: CanvasTextAlign;
 	canvas: Canvas;
 	direction: 'ltr' | 'rtl';
-	lang: string;
 }
 
 export class CanvasGradient {

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -792,7 +792,12 @@ Context2d::SetDirection(const Napi::CallbackInfo& info, const Napi::Value& value
  */
 Napi::Value
 Context2d::GetLanguage(const Napi::CallbackInfo& info) {
-  return Napi::String::New(env, state->lang);
+  PangoLanguage* lang = pango_context_get_language(pango_layout_get_context(_layout));
+  if (!lang) {
+    return Napi::String::New(env, "");
+  }
+  std::string langCode = pango_language_to_string(lang);
+  return Napi::String::New(env, langCode);
 }
 
 /*
@@ -803,10 +808,7 @@ Context2d::SetLanguage(const Napi::CallbackInfo& info, const Napi::Value& value)
   if (!value.IsString()) return;
 
   std::string lang = value.As<Napi::String>();
-  state->lang = lang;
-
   pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(lang.c_str()));
-  pango_cairo_update_layout(context(), _layout);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -806,7 +806,6 @@ Context2d::SetLanguage(const Napi::CallbackInfo& info, const Napi::Value& value)
   state->lang = lang;
 
   pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(lang.c_str()));
-  pango_cairo_update_layout(context(), _layout);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -792,12 +792,7 @@ Context2d::SetDirection(const Napi::CallbackInfo& info, const Napi::Value& value
  */
 Napi::Value
 Context2d::GetLanguage(const Napi::CallbackInfo& info) {
-  PangoLanguage* lang = pango_context_get_language(pango_layout_get_context(_layout));
-  if (!lang) {
-    return Napi::String::New(env, "");
-  }
-  std::string langCode = pango_language_to_string(lang);
-  return Napi::String::New(env, langCode);
+  return Napi::String::New(env, state->lang);
 }
 
 /*
@@ -808,7 +803,10 @@ Context2d::SetLanguage(const Napi::CallbackInfo& info, const Napi::Value& value)
   if (!value.IsString()) return;
 
   std::string lang = value.As<Napi::String>();
+  state->lang = lang;
+
   pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(lang.c_str()));
+  pango_cairo_update_layout(context(), _layout);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -43,7 +43,7 @@ constexpr double twoPi = M_PI * 2.;
 #define PANGO_LAYOUT_GET_METRICS(LAYOUT) pango_context_get_metrics( \
    pango_layout_get_context(LAYOUT), \
    pango_layout_get_font_description(LAYOUT), \
-   pango_context_get_language(pango_layout_get_context(LAYOUT)))
+   pango_language_from_string(state->lang.c_str()))
 
 inline static bool checkArgs(const Napi::CallbackInfo&info, double *args, int argsNum, int offset = 0){
   Napi::Env env = info.Env();
@@ -804,8 +804,6 @@ Context2d::SetLanguage(const Napi::CallbackInfo& info, const Napi::Value& value)
 
   std::string lang = value.As<Napi::String>();
   state->lang = lang;
-
-  pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(lang.c_str()));
 }
 
 /*
@@ -2512,6 +2510,9 @@ Context2d::paintText(const Napi::CallbackInfo& info, bool stroke) {
 
   checkFonts();
   pango_layout_set_text(layout, str.c_str(), -1);
+  if (state->lang != "") {
+    pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(state->lang.c_str()));
+  }
   pango_cairo_update_layout(context(), layout);
 
   PangoDirection pango_dir = state->direction == "ltr" ? PANGO_DIRECTION_LTR : PANGO_DIRECTION_RTL;
@@ -2824,6 +2825,9 @@ Context2d::MeasureText(const Napi::CallbackInfo& info) {
 
   checkFonts();
   pango_layout_set_text(layout, str.Utf8Value().c_str(), -1);
+  if (state->lang != "") {
+    pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(state->lang.c_str()));
+  }
   pango_cairo_update_layout(ctx, layout);
 
   // Normally you could use pango_layout_get_pixel_extents and be done, or use

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -162,7 +162,8 @@ Context2d::Initialize(Napi::Env& env, Napi::Object& exports) {
     InstanceAccessor<&Context2d::GetFont, &Context2d::SetFont>("font", napi_default_jsproperty),
     InstanceAccessor<&Context2d::GetTextBaseline, &Context2d::SetTextBaseline>("textBaseline", napi_default_jsproperty),
     InstanceAccessor<&Context2d::GetTextAlign, &Context2d::SetTextAlign>("textAlign", napi_default_jsproperty),
-    InstanceAccessor<&Context2d::GetDirection, &Context2d::SetDirection>("direction", napi_default_jsproperty)
+    InstanceAccessor<&Context2d::GetDirection, &Context2d::SetDirection>("direction", napi_default_jsproperty),
+    InstanceAccessor<&Context2d::GetLanguage, &Context2d::SetLanguage>("lang", napi_default_jsproperty)
   });
 
   exports.Set("CanvasRenderingContext2d", ctor);
@@ -784,6 +785,28 @@ Context2d::SetDirection(const Napi::CallbackInfo& info, const Napi::Value& value
   if (dir != "ltr" && dir != "rtl") return;
 
   state->direction = dir;
+}
+
+/*
+ * Get language.
+ */
+Napi::Value
+Context2d::GetLanguage(const Napi::CallbackInfo& info) {
+  return Napi::String::New(env, state->lang);
+}
+
+/*
+ * Set language.
+ */
+void
+Context2d::SetLanguage(const Napi::CallbackInfo& info, const Napi::Value& value) {
+  if (!value.IsString()) return;
+
+  std::string lang = value.As<Napi::String>();
+  state->lang = lang;
+
+  pango_context_set_language(pango_layout_get_context(_layout), pango_language_from_string(lang.c_str()));
+  pango_cairo_update_layout(context(), _layout);
 }
 
 /*

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -36,6 +36,7 @@ struct canvas_state_t {
   canvas_draw_mode_t textDrawingMode = TEXT_DRAW_PATHS;
   bool imageSmoothingEnabled = true;
   std::string direction = "ltr";
+  std::string lang = "";
 
   canvas_state_t() {
     fontDescription = pango_font_description_from_string("sans");

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -36,7 +36,6 @@ struct canvas_state_t {
   canvas_draw_mode_t textDrawingMode = TEXT_DRAW_PATHS;
   bool imageSmoothingEnabled = true;
   std::string direction = "ltr";
-  std::string lang = "";
 
   canvas_state_t() {
     fontDescription = pango_font_description_from_string("sans");

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -62,6 +62,7 @@ struct canvas_state_t {
     fontDescription = pango_font_description_copy(other.fontDescription);
     font = other.font;
     imageSmoothingEnabled = other.imageSmoothingEnabled;
+    lang = other.lang;
   }
 
   ~canvas_state_t() {

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -36,6 +36,7 @@ struct canvas_state_t {
   canvas_draw_mode_t textDrawingMode = TEXT_DRAW_PATHS;
   bool imageSmoothingEnabled = true;
   std::string direction = "ltr";
+  std::string lang = "";
 
   canvas_state_t() {
     fontDescription = pango_font_description_from_string("sans");
@@ -157,6 +158,7 @@ class Context2d : public Napi::ObjectWrap<Context2d> {
     Napi::Value GetFont(const Napi::CallbackInfo& info);
     Napi::Value GetTextBaseline(const Napi::CallbackInfo& info);
     Napi::Value GetTextAlign(const Napi::CallbackInfo& info);
+    Napi::Value GetLanguage(const Napi::CallbackInfo& info);
     void SetPatternQuality(const Napi::CallbackInfo& info, const Napi::Value& value);
     void SetImageSmoothingEnabled(const Napi::CallbackInfo& info, const Napi::Value& value);
     void SetGlobalCompositeOperation(const Napi::CallbackInfo& info, const Napi::Value& value);
@@ -179,6 +181,7 @@ class Context2d : public Napi::ObjectWrap<Context2d> {
     void SetFont(const Napi::CallbackInfo& info, const Napi::Value& value);
     void SetTextBaseline(const Napi::CallbackInfo& info, const Napi::Value& value);
     void SetTextAlign(const Napi::CallbackInfo& info, const Napi::Value& value);
+    void SetLanguage(const Napi::CallbackInfo& info, const Napi::Value& value);
     #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
     void BeginTag(const Napi::CallbackInfo& info);
     void EndTag(const Napi::CallbackInfo& info);

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -486,24 +486,6 @@ describe('Canvas', function () {
     assert.equal(ctx.font, '15px Arial, sans-serif')
   })
 
-  it('Context2d#lang=', function () {
-    const canvas1 = createCanvas(200, 200)
-    const ctx1 = canvas1.getContext('2d')
-    assert.equal(ctx1.lang, '')
-    ctx1.font = '20px sans-serif';
-    ctx1.lang = 'ja'
-    assert.equal(ctx1.lang, 'ja')
-    ctx1.fillText('门', 10, 10)
-
-    const canvas2 = createCanvas(200, 200)
-    const ctx2 = canvas2.getContext('2d')
-    ctx2.font = '20px sans-serif';
-    ctx2.lang = 'zh'
-    ctx2.fillText('门', 10, 10)
-
-    assert.notDeepEqual(ctx1.getImageData(10, 10, 40, 40), ctx2.getImageData(10, 10, 40, 40))
-  })
-
   it('Context2d#lineWidth=', function () {
     const canvas = createCanvas(200, 200)
     const ctx = canvas.getContext('2d')
@@ -2508,7 +2490,8 @@ describe('Canvas', function () {
       ['patternQuality', 'best'],
       // ['quality', 'best'], // doesn't do anything, TODO remove
       ['textDrawingMode', 'glyph'],
-      ['antialias', 'gray']
+      ['antialias', 'gray'],
+      ['lang', 'eu']
     ]
 
     for (const [k, v] of state) {

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -486,6 +486,24 @@ describe('Canvas', function () {
     assert.equal(ctx.font, '15px Arial, sans-serif')
   })
 
+  it('Context2d#lang=', function () {
+    const canvas1 = createCanvas(200, 200)
+    const ctx1 = canvas1.getContext('2d')
+    assert.equal(ctx1.lang, '')
+    ctx1.font = '20px sans-serif';
+    ctx1.lang = 'ja'
+    assert.equal(ctx1.lang, 'ja')
+    ctx1.fillText('门', 10, 10)
+
+    const canvas2 = createCanvas(200, 200)
+    const ctx2 = canvas2.getContext('2d')
+    ctx2.font = '20px sans-serif';
+    ctx2.lang = 'zh'
+    ctx2.fillText('门', 10, 10)
+
+    assert.notDeepEqual(ctx1.getImageData(10, 10, 40, 40), ctx2.getImageData(10, 10, 40, 40))
+  })
+
   it('Context2d#lineWidth=', function () {
     const canvas = createCanvas(200, 200)
     const ctx = canvas.getContext('2d')


### PR DESCRIPTION
This would set pango's language through the Canvas context ( `ctx.lang`, docs: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lang )

My goal was to fix issues where the same Unicode codepoint should appear differently in Simplified Chinese, Traditional Chinese, and Japanese (as an example: lang=zh <span lang="zh">门</span> vs. lang=ja <span lang="ja">门</span>). This can be done with language-specific fonts, but modern fonts often support all options and use the lang tag.
Han unification: https://en.wikipedia.org/wiki/Han_unification
Related issue for Chrome client-side canvas: https://github.com/mapbox/tiny-sdf/pull/58

I'm submitting the code and test as a draft PR because **this is still failing** to change the output.
I did rebuild bindings, and tried with and without `pango_cairo_update_layout`.
Other ideas: this is failing to set the language, setting it at the wrong time, the fonts or something needs to be reset, or pango handles Han unification using something else? I'm a longtime node-canvas user but new to the internals.
I found this reference to `PANGO_LANGUAGE` and `%PANGO_SCRIPT_HAN` https://github.com/gtk-rs/gir-files/blob/main/Pango-1.0.gir#L11631