### PR TITLE
Add support for % in rgb and fix parsing for % in alpha.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix error message HTTP response status code in image src setter
 * `roundRect()` shape incorrect when radii were large relative to rectangle size (#2400)
 * Reject loadImage when src is null or invalid (#2304)
+* Add support for percentage in rgb and rgba parsing. Fix bug with parsing for alpha and percentages.
 
 3.2.0
 ==================

--- a/test/canvas.test.js
+++ b/test/canvas.test.js
@@ -232,6 +232,27 @@ describe('Canvas', function () {
 
     ctx.fillStyle = 'rgb( 255, 300.09, 90, 40%)'
     assert.equal('rgba(255, 255, 90, 0.40)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 100%, 50%, 60%)'
+    assert.equal('rgba(255, 255, 128, 0.60)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 255, 20%, 90, 70%)'
+    assert.equal('rgba(255, 51, 90, 0.70)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 100%, 300%, 90, 50%)'
+    assert.equal('rgba(255, 255, 90, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 100%, 300.09, 90%, 0)'
+    assert.equal('rgba(255, 255, 230, 0.00)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 100%, 99%, 80%     50%)'
+    assert.equal('rgba(255, 253, 204, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 100%, 99.99%, 40% / 50%)'
+    assert.equal('rgba(255, 255, 102, 0.50)', ctx.fillStyle)
+
+    ctx.fillStyle = 'rgb( 100%, 33.33%, 66.66%, 2%)'
+    assert.equal('rgba(255, 85, 170, 0.02)', ctx.fillStyle)
     // hsl / hsla tests
 
     ctx.fillStyle = 'hsl(0, 0%, 0%)'


### PR DESCRIPTION
- [x] Have you updated CHANGELOG.md?

The parsing for % values in alpha wasn't working properly for single digit integers and for all decimal percentages starting with 0. Also added support for % parsing in rgb and rgba. This was mentioned in issue #1391 too.