### PR TITLE
`npm config set node_gyp` is no longer supported

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
 
   macOS:
     name: Test on macOS
-    runs-on: macos-26
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
     name: Test on Linux
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
     steps:
@@ -32,6 +33,7 @@ jobs:
     name: Test on Windows
     runs-on: windows-2025
     strategy:
+      fail-fast: false
       matrix:
         node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
     steps:
@@ -46,8 +48,6 @@ jobs:
           Invoke-WebRequest "https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-2.0.4-vc64.exe" -OutFile "libjpeg.exe" -UserAgent NativeHost
           .\libjpeg.exe /S
           winget install --accept-source-agreements --id=Microsoft.VCRedist.2010.x64 -e
-          npm install -g node-gyp
-          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
       - name: Install
         run: npm install --build-from-source
       - name: Test
@@ -57,6 +57,7 @@ jobs:
     name: Test on macOS
     runs-on: macos-26
     strategy:
+      fail-fast: false
       matrix:
         node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         run: |
           sudo apt update
@@ -35,10 +35,10 @@ jobs:
       matrix:
         node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         run: |
           Invoke-WebRequest "https://ftp.gnome.org/pub/GNOME/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip" -OutFile "gtk.zip"
@@ -46,7 +46,7 @@ jobs:
           Invoke-WebRequest "https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-2.0.4-vc64.exe" -OutFile "libjpeg.exe" -UserAgent NativeHost
           .\libjpeg.exe /S
           winget install --accept-source-agreements --id=Microsoft.VCRedist.2010.x64 -e
-          npm install -g node-gyp@8
+          npm install -g node-gyp
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
       - name: Install
         run: npm install --build-from-source
@@ -55,15 +55,15 @@ jobs:
 
   macOS:
     name: Test on macOS
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       matrix:
         node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         run: |
           brew update
@@ -77,10 +77,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20.9.0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install
         run: npm install --ignore-scripts
       - name: Lint


### PR DESCRIPTION
> npm error `node_gyp` is not a valid option in npm >= 10.

Thanks for contributing!

- [ ] Have you updated CHANGELOG.md?
