### PR TITLE
Tests occasionally timeout on macOS 26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,10 @@ jobs:
   Linux:
     name: Test on Linux
     runs-on: ubuntu-latest
-    strategy:
+    strategy: &job_strategy  # Define a YAML anchor on first use
+      fail-fast: false
       matrix:
-        node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
+        node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0, 25.2.0]
     steps:
       - uses: actions/setup-node@v4
         with:
@@ -31,9 +32,7 @@ jobs:
   Windows:
     name: Test on Windows
     runs-on: windows-2025
-    strategy:
-      matrix:
-        node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
+    strategy: *job_strategy  # Reuse the YAML anchor defined above
     steps:
       - uses: actions/setup-node@v4
         with:
@@ -55,10 +54,8 @@ jobs:
 
   macOS:
     name: Test on macOS
-    runs-on: macos-15
-    strategy:
-      matrix:
-        node: [18.20.5, 20.18.1, 22.12.0, 23.3.0, 24.2.0]
+    runs-on: macos-26
+    strategy: *job_strategy  # Reuse the YAML anchor defined above
     steps:
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Should we increase the `timeout` value or do something different?

>    291 passing (3s)
  6 pending
  1 failing

>  1) Canvas
       Canvas#getContext("2d"):
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/node-canvas/node-canvas/test/canvas.test.js)
      at process.processImmediate (node:internal/timers:491:21)

Also, add Node.js 25.2.0 and DRY the CI strategy so it can be configured once and reused.
* https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates

Thanks for contributing!

- [ ] Have you updated CHANGELOG.md?
