### PR TITLE
Fix compilation on GCC 15 by including <cstdint>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Fix error message HTTP response status code in image src setter
 * `roundRect()` shape incorrect when radii were large relative to rectangle size (#2400)
 * Reject loadImage when src is null or invalid (#2304)
+* Fix compilation on GCC 15 by including <cstdint> (#2545)
 
 3.2.0
 ==================

--- a/src/CharData.h
+++ b/src/CharData.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace CharData {
   static constexpr uint8_t Whitespace = 0x1;
   static constexpr uint8_t Newline = 0x2;


### PR DESCRIPTION
As per the GCC 15 porting guide, section "Header dependency changes": https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes

> Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.
>
> In particular, the following headers are used less widely within libstdc++ and may need to be included explicitly when compiling with GCC 15:
>
> `<stdint.h>` (for `int8_t`, `int32_t` etc.) and `<cstdint>` (for `std::int8_t`, `std::int32_t` etc.)
> `<ostream>` (for `std::endl`, `std::flush` etc.)

`<cstdint>` must now be explicitly included to use these types and was missing from `CharData.h`.

This resolves issue #2545 

Thanks for contributing!

- [X] Have you updated CHANGELOG.md?
