### PR TITLE
Set canvas size on addPage and don't destroy PDF surface on width/height change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Fixed
 * Fix dangling env pointer in image MIME data cleanup (#2550)
+* Set canvas size on addPage and don't destroy PDF surface on width/height change (#2538)
 
 3.2.1
 ==================

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -671,7 +671,7 @@ str_value(Napi::Maybe<Napi::Value> maybe, const char *fallback, bool can_be_numb
       return strdup(fallback);
     }
   }
-  
+
   return NULL;
 }
 
@@ -907,8 +907,10 @@ Canvas::resurface(Napi::Object This) {
   Napi::Value context;
 
   if (This.Get("context").UnwrapTo(&context) && context.IsObject()) {
-    backend()->destroySurface();
-    backend()->ensureSurface();
+    if (backend()->getName() != "pdf") {
+      backend()->destroySurface();
+      backend()->ensureSurface();
+    }
     // Reset context
     Context2d *context2d = Context2d::Unwrap(context.As<Napi::Object>());
     cairo_t *prev = context2d->context();

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -763,7 +763,7 @@ Context2d::AddPage(const Napi::CallbackInfo& info) {
   int height = info[1].ToNumber().UnwrapOr(zero).Int32Value();
   if (width < 1) width = canvas()->getWidth();
   if (height < 1) height = canvas()->getHeight();
-  cairo_pdf_surface_set_size(canvas()->surface(), width, height);
+  canvas()->backend()->setSize(width, height);
 }
 
 /*

--- a/src/backend/Backend.cc
+++ b/src/backend/Backend.cc
@@ -29,8 +29,7 @@ int Backend::getWidth()
 }
 void Backend::setWidth(int width_)
 {
-  this->destroySurface();
-  this->width = width_;
+  setSize(width_, height);
 }
 
 int Backend::getHeight()
@@ -39,8 +38,17 @@ int Backend::getHeight()
 }
 void Backend::setHeight(int height_)
 {
+  setSize(width, height_);
+}
+
+void Backend::setSize(int width_, int height_) {
+  width = width_;
+  height = height_;
+  resetSurface();
+}
+
+void Backend::resetSurface() {
   this->destroySurface();
-  this->height = height_;
 }
 
 bool Backend::isSurfaceValid() {

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -28,6 +28,7 @@ class Backend
 
     virtual cairo_surface_t* ensureSurface() = 0;
     virtual void destroySurface() = 0;
+    virtual void resetSurface();
 
     DLL_PUBLIC std::string getName();
 
@@ -36,6 +37,8 @@ class Backend
 
     DLL_PUBLIC int getHeight();
     virtual void setHeight(int height);
+
+    void setSize(int width, int height);
 
     // Overridden by ImageBackend. SVG and PDF thus always return INVALID.
     virtual cairo_format_t getFormat() {

--- a/src/backend/PdfBackend.cc
+++ b/src/backend/PdfBackend.cc
@@ -31,6 +31,10 @@ void PdfBackend::destroySurface() {
   }
 }
 
+void PdfBackend::resetSurface() {
+  cairo_pdf_surface_set_size(ensureSurface(), width, height);
+}
+
 void
 PdfBackend::Initialize(Napi::Object target) {
   Napi::Env env = target.Env();

--- a/src/backend/PdfBackend.h
+++ b/src/backend/PdfBackend.h
@@ -9,6 +9,7 @@ class PdfBackend : public Napi::ObjectWrap<PdfBackend>, public Backend
   private:
     cairo_surface_t* ensureSurface();
     void destroySurface();
+    void resetSurface();
     cairo_surface_t* surface = nullptr;
 
   public:


### PR DESCRIPTION
Changes explained:

* Moved cairo_pdf_surface_set_size from addPage method to setSize method of PDF backend. addPage now calls this setSize method so the canvas size is also changed.
* Changing width/height on canvas now calls the same setSize method so in PDF backend this also affects the PDF surface size.
* Changing width/height on canvas no longer destroyes the PDF surface, it only changes the page size and resets the context.

Fixes #2538 

- [X] Have you updated CHANGELOG.md?
