### PR TITLE
Bump `node-addon-api` to fix memory leak #2436

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Changed
+* Upgrade node-addon-api from 7.x to 8.x
 ### Added
 ### Fixed
+* Fix memory leak caused by N-API weak reference callbacks being deferred to SetImmediate instead of running during GC. Enabled `NAPI_EXPERIMENTAL` to use `node_api_nogc_finalize` for ObjectWrap destructor. (#2436)
 
 3.2.3
 ==================

--- a/binding.gyp
+++ b/binding.gyp
@@ -58,7 +58,7 @@
     {
       'target_name': 'canvas',
       'include_dirs': ["<!(node -p \"require('node-addon-api').include_dir\")"],
-      'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NODE_ADDON_API_ENABLE_MAYBE' ],
+      'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NODE_ADDON_API_ENABLE_MAYBE', 'NAPI_EXPERIMENTAL' ],
       'sources': [
         'src/bmp/BMPParser.cc',
         'src/Canvas.cc',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "util/"
   ],
   "dependencies": {
-    "node-addon-api": "^7.0.0",
+    "node-addon-api": "^8.7.0",
     "prebuild-install": "^7.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prebenchmark": "node-gyp build",
     "benchmark": "node benchmarks/run.js",
     "lint": "standard examples/*.js test/server.js test/public/*.js benchmarks/run.js lib/context2d.js util/has_lib.js browser.js index.js",
-    "test": "mocha test/*.test.js",
+    "test": "mocha --node-option expose-gc test/*.test.js",
     "pretest-server": "node-gyp build",
     "test-server": "node test/server.js",
     "generate-wpt": "node ./test/wpt/generate.js",

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -141,12 +141,6 @@ Canvas::~Canvas() {
   destroySurface();
 }
 
-void Canvas::Finalize(Napi::Env env) {
-  if (_surface && type == CANVAS_TYPE_IMAGE) {
-    Napi::MemoryManagement::AdjustExternalMemory(env, -(int64_t)approxBytesPerPixel() * width * height);
-  }
-}
-
 /*
  * Get type string.
  */
@@ -997,6 +991,9 @@ Canvas::ensureSurface() {
 void
 Canvas::destroySurface() {
   if (_surface) {
+    if (type == CANVAS_TYPE_IMAGE) {
+      Napi::MemoryManagement::AdjustExternalMemory(env, -(int64_t)approxBytesPerPixel() * width * height);
+    }
     // flush any operations that may use the closure that is freed below
     cairo_surface_finish(_surface);
     cairo_surface_destroy(_surface);

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -141,6 +141,12 @@ Canvas::~Canvas() {
   destroySurface();
 }
 
+void Canvas::Finalize(Napi::Env env) {
+  if (_surface && type == CANVAS_TYPE_IMAGE) {
+    Napi::MemoryManagement::AdjustExternalMemory(env, -(int64_t)approxBytesPerPixel() * width * height);
+  }
+}
+
 /*
  * Get type string.
  */
@@ -993,9 +999,6 @@ Canvas::destroySurface() {
   if (_surface) {
     // flush any operations that may use the closure that is freed below
     cairo_surface_finish(_surface);
-    if (type == CANVAS_TYPE_IMAGE) {
-      Napi::MemoryManagement::AdjustExternalMemory(env, -(int64_t)approxBytesPerPixel() * width * height);
-    }
     cairo_surface_destroy(_surface);
     _surface = nullptr;
   }

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -65,6 +65,7 @@ class Canvas : public Napi::ObjectWrap<Canvas> {
   public:
     Canvas(const Napi::CallbackInfo& info);
     ~Canvas();
+    void Finalize(Napi::Env env);
     static void Initialize(Napi::Env& env, Napi::Object& target);
 
     Napi::Value ToBuffer(const Napi::CallbackInfo& info);

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -65,7 +65,6 @@ class Canvas : public Napi::ObjectWrap<Canvas> {
   public:
     Canvas(const Napi::CallbackInfo& info);
     ~Canvas();
-    void Finalize(Napi::Env env);
     static void Initialize(Napi::Env& env, Napi::Object& target);
 
     Napi::Value ToBuffer(const Napi::CallbackInfo& info);

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -64,6 +64,7 @@ Pattern::Pattern(const Napi::CallbackInfo& info) : ObjectWrap<Pattern>(info), en
     return;
   }
   _pattern = cairo_pattern_create_for_surface(surface);
+  _source = Napi::Persistent(obj);
 
   if (info[1].IsString()) {
     if ("no-repeat" == info[1].As<Napi::String>().Utf8Value()) {
@@ -126,4 +127,8 @@ repeat_type_t Pattern::get_repeat_type_for_cairo_pattern(cairo_pattern_t *patter
 
 Pattern::~Pattern() {
   if (_pattern) cairo_pattern_destroy(_pattern);
+}
+
+void Pattern::Finalize(Napi::Env env) {
+  _source.Reset();
 }

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -26,8 +26,10 @@ class Pattern : public Napi::ObjectWrap<Pattern> {
     static repeat_type_t get_repeat_type_for_cairo_pattern(cairo_pattern_t *pattern);
     inline cairo_pattern_t *pattern(){ return _pattern; }
     ~Pattern();
+    void Finalize(Napi::Env env);
     Napi::Env env;
   private:
     cairo_pattern_t *_pattern;
+    Napi::Reference<Napi::Object> _source;
     repeat_type_t _repeat = REPEAT;
 };

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -244,6 +244,9 @@ Context2d::Context2d(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Context2
 Context2d::~Context2d() {
   if (_layout) g_object_unref(_layout);
   if (_context) cairo_destroy(_context);
+}
+
+void Context2d::Finalize(Napi::Env env) {
   _resetPersistentHandles();
 }
 

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -214,6 +214,7 @@ class Context2d : public Napi::ObjectWrap<Context2d> {
     void resetState();
     inline PangoLayout *layout(){ return _layout; }
     ~Context2d();
+    void Finalize(Napi::Env env);
     Napi::Env env;
 
   private:

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,0 +1,36 @@
+/* eslint-env mocha */
+
+'use strict'
+
+// These tests require --expose-gc. Skip gracefully if not available.
+const gcAvailable = typeof gc === 'function'
+
+const assert = require('assert')
+const { createCanvas } = require('../')
+
+describe('Memory management', function () {
+  before(function () {
+    if (!gcAvailable) this.skip()
+  })
+
+  it('Canvas objects are freed by GC', function () {
+    const ITERATIONS = 100
+    const SIZE = 1024 // 1024x1024 ARGB = 4 MiB per canvas
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      const canvas = createCanvas(SIZE, SIZE)
+      const ctx = canvas.getContext('2d')
+      ctx.fillStyle = 'red'
+      ctx.fillRect(0, 0, SIZE, SIZE)
+      gc()
+    }
+
+    gc()
+    gc()
+
+    // 100 canvases x 4 MiB = 400 MiB if leaked.
+    // With proper GC, RSS should stay well under 150 MiB.
+    const rssMiB = process.memoryUsage().rss / 1024 / 1024
+    assert(rssMiB < 150, `RSS is ${rssMiB.toFixed(0)} MiB, expected < 150 MiB`)
+  })
+})


### PR DESCRIPTION
## Fix memory leak from deferred N-API weak reference callbacks

Fixes #2436

### Problem

Since the NAN -> N-API migration (v3.0.0), `ObjectWrap` destructors (which free cairo surfaces) are deferred to the next `SetImmediate` instead of running during GC. In server environments where the event loop is always busy, these destructors never fire and memory grows indefinitely.

This was reported upstream in nodejs/node-addon-api#1140 and fixed in nodejs/node#42651 by introducing `node_api_nogc_finalize`, a finalizer that runs directly during GC for native-only cleanup.

### Fix

- Upgrade `node-addon-api` from 7.x to 8.x (which uses `node_api_nogc_finalize` for `ObjectWrap::FinalizeCallback`)
- Add `NAPI_EXPERIMENTAL` to `binding.gyp` defines (required to enable `NODE_API_EXPERIMENTAL_HAS_POST_FINALIZER` in [Node's headers](https://github.com/nodejs/node/blob/4f08c6478d6ecd073c03536b8a6c473232e16c37/src/js_native_api.h#L540))

No code changes, `node-addon-api` 8.x automatically routes `ObjectWrap` destructor callbacks through the nogc finalizer path when the flag is set.

I don't fully understand the impact of `node-addon-api` upgrade or enabling `NAPI_EXPERIMENTAL`.

### Before / After

200 requests decoding 3000x2000 JPEG images into thumbnails:

```javascript
// node --expose-gc stress.js
const { createCanvas, loadImage } = require("canvas");

let s = 1;
function rand() {
    s = (s + 0x6d2b79f5) | 0;
    let t = Math.imul(s ^ (s >>> 15), 1 | s);
    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
}

function genImage(w, h) {
    const c = createCanvas(w, h);
    const ctx = c.getContext("2d");
    for (let i = 0; i < 10; i++) {
        ctx.fillStyle = `rgb(${(rand() * 255) | 0},${(rand() * 255) | 0},${(rand() * 255) | 0})`;
        ctx.fillRect((rand() * w) | 0, (rand() * h) | 0, (rand() * w) / 2, (rand() * h) / 2);
    }
    return c.toBuffer("image/jpeg");
}

async function run() {
    const imgs = [genImage(2000, 1500), genImage(3000, 2000)];
    let peak = 0;
    for (let i = 0; i < 50; i++) {
        const promises = [];
        for (let j = 0; j < 4; j++) {
            promises.push(
                loadImage(imgs[j % 2]).then((img) => {
                    const c = createCanvas(200, Math.round((img.height / img.width) * 200));
                    c.getContext("2d").drawImage(img, 0, 0, c.width, c.height);
                    return c.toBuffer("image/jpeg");
                })
            );
        }
        await Promise.all(promises);
        const rss = process.memoryUsage().rss;
        if (rss > peak) peak = rss;
        if ((i + 1) % 10 === 0)
            console.log(`  batch ${i + 1}: rss=${Math.round(rss / 1024 / 1024)}MB`);
    }
    console.log(`Peak RSS: ${Math.round(peak / 1024 / 1024)}MB`);
}

run();
```

```
// Before (node-addon-api 8, no NAPI_EXPERIMENTAL):
  batch 10: rss=784MB
  batch 20: rss=1477MB
  batch 30: rss=2169MB
  batch 40: rss=2862MB
  batch 50: rss=3555MB
Peak RSS: 3555MB

// After (node-addon-api 8 + NAPI_EXPERIMENTAL):
  batch 10: rss=196MB
  batch 20: rss=195MB
  batch 30: rss=196MB
  batch 40: rss=196MB
  batch 50: rss=196MB
Peak RSS: 196MB
```
