### PR TITLE
Fix invalid `boolean` type conversions

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -956,7 +956,7 @@ Image::decodeJPEGBufferIntoMimeSurface(uint8_t *buf, unsigned len) {
 
   jpeg_mem_src(&args, buf, len);
 
-  jpeg_read_header(&args, 1);
+  jpeg_read_header(&args, (boolean)1);
   jpeg_start_decompress(&args);
   width = naturalWidth = args.output_width;
   height = naturalHeight = args.output_height;
@@ -1080,7 +1080,7 @@ Image::loadJPEGFromBuffer(uint8_t *buf, unsigned len) {
 
   jpeg_mem_src(&args, buf, len);
 
-  jpeg_read_header(&args, 1);
+  jpeg_read_header(&args, (boolean)1);
   jpeg_start_decompress(&args);
   width = naturalWidth = args.output_width;
   height = naturalHeight = args.output_height;
@@ -1129,7 +1129,7 @@ Image::loadJPEG(FILE *stream) {
 
     jpeg_stdio_src(&args, stream);
 
-    jpeg_read_header(&args, 1);
+    jpeg_read_header(&args, (boolean)1);
     jpeg_start_decompress(&args);
 
     if (args.output_width > canvas_max_side || args.output_height > canvas_max_side) {

--- a/src/JPEGStream.h
+++ b/src/JPEGStream.h
@@ -36,7 +36,7 @@ empty_closure_output_buffer(j_compress_ptr cinfo){
   dest->buffer = (JOCTET *)malloc(dest->bufsize);
   cinfo->dest->next_output_byte = dest->buffer;
   cinfo->dest->free_in_buffer = dest->bufsize;
-  return true;
+  return (boolean)true;
 }
 
 void
@@ -93,12 +93,12 @@ void encode_jpeg(jpeg_compress_struct cinfo, cairo_surface_t *surface, int quali
   jpeg_set_defaults(&cinfo);
   if (progressive)
     jpeg_simple_progression(&cinfo);
-  jpeg_set_quality(&cinfo, quality, (quality < 25) ? 0 : 1);
+  jpeg_set_quality(&cinfo, quality, (boolean)((quality < 25) ? 0 : 1));
   cinfo.comp_info[0].h_samp_factor = chromaHSampFactor;
   cinfo.comp_info[0].v_samp_factor = chromaVSampFactor;
 
   JSAMPROW slr;
-  jpeg_start_compress(&cinfo, TRUE);
+  jpeg_start_compress(&cinfo, (boolean)TRUE);
   unsigned char *dst;
   unsigned int *src = (unsigned int *)cairo_image_surface_get_data(surface);
   int sl = 0;


### PR DESCRIPTION
on my GNU Guix System computer (where i can't use the pre-built binaries because they rely on dynamic linking which needs special considerations in GNU Guix System similar to ones in NixOS) when trying to build node-canvas i get this error:

```
make: Entering directory '/home/kimapr/stuff/software/node-canvas/build'
  SOLINK_MODULE(target) Release/obj.target/canvas-postbuild.node
  COPY Release/canvas-postbuild.node
  CXX(target) Release/obj.target/canvas/src/bmp/BMPParser.o
  CXX(target) Release/obj.target/canvas/src/Canvas.o
In file included from ../src/Canvas.cc:27:
../src/JPEGStream.h: In function ‘boolean empty_closure_output_buffer(j_compress_ptr)’:
../src/JPEGStream.h:39:10: error: cannot convert ‘bool’ to ‘boolean’ in return
   39 |   return true;
      |          ^~~~
../src/JPEGStream.h: In function ‘void encode_jpeg(jpeg_compress_struct, cairo_surface_t*, int, bool, int, int)’:
../src/JPEGStream.h:96:52: error: invalid conversion from ‘int’ to ‘boolean’ [-fpermissive]
   96 |   jpeg_set_quality(&cinfo, quality, (quality < 25) ? 0 : 1);
      |                                     ~~~~~~~~~~~~~~~^~~~~~~
      |                                                    |
      |                                                    int
In file included from ../src/closure.h:13,
                 from ../src/Canvas.h:8,
                 from ../src/Canvas.cc:3:
/gnu/store/vwq4dsfk2j8a94b1c7qmg2p0vs631xxk-libjpeg-9f/include/jpeglib.h:993:44: note:   initializing argument 3 of ‘void jpeg_set_quality(j_compress_ptr, int, boolean)’
  993 |                                    boolean force_baseline));
      |                                    ~~~~~~~~^~~~~~~~~~~~~~
/gnu/store/vwq4dsfk2j8a94b1c7qmg2p0vs631xxk-libjpeg-9f/include/jpeglib.h:877:25: note: in definition of macro ‘JPP’
  877 | #define JPP(arglist)    arglist
      |                         ^~~~~~~
In file included from /gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/lib/glib-2.0/include/glibconfig.h:9,
                 from /gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/include/glib-2.0/glib/gtypes.h:34,
                 from /gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/include/glib-2.0/glib/galloca.h:34,
                 from /gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/include/glib-2.0/glib.h:32,
                 from /gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/include/glib-2.0/gobject/gbinding.h:30,
                 from /gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/include/glib-2.0/glib-object.h:24,
                 from /gnu/store/bs30dsx41yk626d25vrz4b0qixmmfsbd-pango-1.56.4/include/pango-1.0/pango/pango-coverage.h:25,
                 from /gnu/store/bs30dsx41yk626d25vrz4b0qixmmfsbd-pango-1.56.4/include/pango-1.0/pango/pango-font.h:25,
                 from /gnu/store/bs30dsx41yk626d25vrz4b0qixmmfsbd-pango-1.56.4/include/pango-1.0/pango/pango-attributes.h:25,
                 from /gnu/store/bs30dsx41yk626d25vrz4b0qixmmfsbd-pango-1.56.4/include/pango-1.0/pango/pango.h:25,
                 from /gnu/store/bs30dsx41yk626d25vrz4b0qixmmfsbd-pango-1.56.4/include/pango-1.0/pango/pangocairo.h:25,
                 from ../src/Canvas.h:12:
/gnu/store/b1dkq30pbiwwz5ykann1k5n39mavf069-glib-2.86.0/include/glib-2.0/glib/gmacros.h:935:18: error: cannot convert ‘bool’ to ‘boolean’
  935 | #define TRUE    (!FALSE)
      |                 ~^~~~~~~
      |                  |
      |                  bool
../src/JPEGStream.h:101:31: note: in expansion of macro ‘TRUE’
  101 |   jpeg_start_compress(&cinfo, TRUE);
      |                               ^~~~
/gnu/store/vwq4dsfk2j8a94b1c7qmg2p0vs631xxk-libjpeg-9f/include/jpeglib.h:1014:47: note:   initializing argument 2 of ‘void jpeg_start_compress(j_compress_ptr, boolean)’
 1014 |                                       boolean write_all_tables));
      |                                       ~~~~~~~~^~~~~~~~~~~~~~~~
/gnu/store/vwq4dsfk2j8a94b1c7qmg2p0vs631xxk-libjpeg-9f/include/jpeglib.h:877:25: note: in definition of macro ‘JPP’
  877 | #define JPP(arglist)    arglist
      |                         ^~~~~~~
make: *** [canvas.target.mk:189: Release/obj.target/canvas/src/Canvas.o] Error 1
make: Leaving directory '/home/kimapr/stuff/software/node-canvas/build'
```

I have no idea what is `boolean` type and why it exists when we've already had `bool` built into C++ itself since eons ago and I have even less idea why one can't be implicitly converted into the other or from an `int` but it is what it is.

Just adding some casts fixes the compile error.  It's probably better to fix the actual `boolean` type so that it allows implicit conversions but I don't even know where it is defined so i'm not doing that