### PR TITLE
Fix memory leak in JPEG EXIF rotation (rotate90/rotate270)

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -1408,6 +1408,7 @@ Image::rotatePixels(uint8_t* pixels, int width, int height, int channels,
         std::memcpy(pixels + new_idx, unrotated + orig_idx, channels);
       }
     }
+    delete[] unrotated;
   };
 
   auto rotate270 = [](uint8_t* pixels, int width, int height, int channels) {
@@ -1424,6 +1425,7 @@ Image::rotatePixels(uint8_t* pixels, int width, int height, int channels,
         std::memcpy(pixels + new_idx, unrotated + orig_idx, channels);
       }
     }
+    delete[] unrotated;
   };
 
   switch (orientation) {


### PR DESCRIPTION
Fixes #2572.

The `rotate90` and `rotate270` lambdas in `Image::rotatePixels` allocate a temporary `unrotated` buffer via `new uint8_t[n_bytes]` but never free it. Every JPEG decoded with EXIF orientation 5, 6, 7, or 8 leaks the full rotated pixel buffer (`width * height * 4` bytes) on each `loadImage` call.

For a 1200×1800 test image ([`recurser/exif-orientation-examples` `Landscape_6.jpg`](https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_6.jpg), EXIF `Orientation=6`), 100 sequential loads leak 837 MiB (~8.4 MiB/iter, matching `width * height * 4 = 8,640,000` bytes exactly). After this fix, RSS plateaus after the first ~10 iterations and stays flat.

The full repro script and observed numbers are in #2572.

Diff is one line added to each lambda:

```diff
   auto rotate90 = [](uint8_t* pixels, int width, int height, int channels) {
     ...
+    delete[] unrotated;
   };

   auto rotate270 = [](uint8_t* pixels, int width, int height, int channels) {
     ...
+    delete[] unrotated;
   };
```
