### PR TITLE
Use delete[] to free new[]-allocated buffer in decodeJPEGIntoSurface OOM path

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -841,7 +841,7 @@ Image::decodeJPEGIntoSurface(jpeg_decompress_struct *args, Orientation orientati
 
   uint8_t *src = new uint8_t[naturalWidth * args->output_components];
   if (!src) {
-    free(data);
+    delete[] data;
     jpeg_abort_decompress(args);
     jpeg_destroy_decompress(args);
     this->errorInfo.set(NULL, "malloc", errno);


### PR DESCRIPTION
Fixes #2573.

`Image::decodeJPEGIntoSurface` allocates a buffer with `new uint8_t[]` and frees it with `free()` on the OOM error path — undefined behavior in C++ (`new[]` and `free()` may use different allocators, and even when they share one they may have different bookkeeping for the array size header).

Every other deallocation of `new uint8_t[]` buffers in `Image.cc` (lines 710, 898, 901, 991) already uses `delete[]` correctly; this is the only outlier. Caught by `g++ -Wmismatched-new-delete`:

```
../src/Image.cc:844:9: warning: 'void free(void*)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  844 |     free(data);
      |     ~~~~^~~~~~
../src/Image.cc:834:70: note: returned from 'void* operator new []'(std::size_t)'
  834 |   uint8_t *data = new uint8_t[naturalWidth * naturalHeight * channels];
```

The triggering condition (the second `new uint8_t[]` returning `nullptr` after the first succeeds) is unlikely in practice, but the bug is real and the fix is one character.
