### PR TITLE
Clear image.src on loadImage error to release partial cairo state

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ function loadImage (src) {
     }
 
     image.onload = () => { cleanup(); resolve(image) }
-    image.onerror = (err) => { cleanup(); reject(err) }
+    image.onerror = (err) => {
+      cleanup()
+      image.src = Buffer.alloc(0)
+      reject(err)
+    }
 
     image.src = src
   })


### PR DESCRIPTION
Fixes #2576.

`loadImage()` in `index.js` rejects the Promise on error but doesn't clear `image.src`. The Image keeps a reference to the input buffer (and, depending on the format, any partial cairo surface) until V8 garbage-collects the Image wrapper. Under sustained load on malformed inputs that fail mid-decode, this delays cleanup arbitrarily.

The fix assigns `image.src = Buffer.alloc(0)` before rejecting, which triggers `Image::SetSource()` → `clearData()` synchronously — destroying any partial cairo surface and resetting the buffer reference.

One-line change; the full rationale and a standalone repro are in #2576.
