### PR TITLE
Release RsvgHandle and partial surface on SVG decode error paths

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -405,7 +405,6 @@ cairo_surface_t *Image::surface() {
 
     cairo_status_t status = renderSVGToSurface();
     if (status != CAIRO_STATUS_SUCCESS) {
-      g_object_unref(_rsvg);
       Napi::Error::New(env, cairo_status_to_string(status)).ThrowAsJavaScriptException();
 
       return NULL;
@@ -1473,16 +1472,19 @@ Image::loadSVGFromBuffer(uint8_t *buf, unsigned len) {
     return CAIRO_STATUS_READ_ERROR;
   }
 
-  double d_width;
-  double d_height;
+  double d_width = 0;
+  double d_height = 0;
 
-  rsvg_handle_get_intrinsic_size_in_pixels(_rsvg, &d_width, &d_height);
+  gboolean has_size = rsvg_handle_get_intrinsic_size_in_pixels(_rsvg, &d_width, &d_height);
 
-  width = naturalWidth = d_width;
-  height = naturalHeight = d_height;
+  width = naturalWidth = has_size ? d_width : 0;
+  height = naturalHeight = has_size ? d_height : 0;
 
   if (width <= 0 || height <= 0) {
     this->errorInfo.set("Width and height must be set on the svg element");
+    g_object_unref(_rsvg);
+    _rsvg = NULL;
+    _is_svg = false;
     return CAIRO_STATUS_READ_ERROR;
   }
 
@@ -1501,6 +1503,10 @@ Image::renderSVGToSurface() {
   status = cairo_surface_status(_surface);
   if (status != CAIRO_STATUS_SUCCESS) {
     g_object_unref(_rsvg);
+    _rsvg = NULL;
+    cairo_surface_destroy(_surface);
+    _surface = NULL;
+    _is_svg = false;
     return status;
   }
 
@@ -1508,6 +1514,11 @@ Image::renderSVGToSurface() {
   status = cairo_status(cr);
   if (status != CAIRO_STATUS_SUCCESS) {
     g_object_unref(_rsvg);
+    _rsvg = NULL;
+    cairo_destroy(cr);
+    cairo_surface_destroy(_surface);
+    _surface = NULL;
+    _is_svg = false;
     return status;
   }
 
@@ -1520,7 +1531,11 @@ Image::renderSVGToSurface() {
   gboolean render_ok = rsvg_handle_render_document(_rsvg, cr, &viewport, nullptr);
   if (!render_ok) {
     g_object_unref(_rsvg);
+    _rsvg = NULL;
     cairo_destroy(cr);
+    cairo_surface_destroy(_surface);
+    _surface = NULL;
+    _is_svg = false;
     return CAIRO_STATUS_READ_ERROR; // or WRITE?
   }
 


### PR DESCRIPTION
Fixes #2584.

`Image::loadSVGFromBuffer()` ignored the return value of `rsvg_handle_get_intrinsic_size_in_pixels()`, so when the SVG parsed cleanly but had no intrinsic size, `d_width`/`d_height` were read uninitialized and the function returned `CAIRO_STATUS_READ_ERROR` with `_rsvg` still attached and `_is_svg` still set. The orphaned `RsvgHandle` survived until the JS `Image` wrapper was finalized — visible as ~4 KiB/iter of steady RSS growth across repeated `loadImage()` of size-less SVG input.

`Image::renderSVGToSurface()` had the inverse problem on its own error branches: `_rsvg` was unreffed but not nulled, and `_surface` (and the cairo context on later branches) were left live. `Image::surface()` then ran a redundant `g_object_unref(_rsvg)` on the error path, double-touching state that may or may not have already been released.

## Changes

- `loadSVGFromBuffer`: initialize `d_width`/`d_height`, gate the assignment on the `gboolean` return value of `rsvg_handle_get_intrinsic_size_in_pixels()`, and unref/null `_rsvg` plus clear `_is_svg` before returning the missing-dimensions error.
- `renderSVGToSurface`: on each error branch, destroy the cairo context if created, destroy and null `_surface`, unref and null `_rsvg`, clear `_is_svg`.
- `Image::surface`: drop the now-redundant `g_object_unref(_rsvg)` on the `renderSVGToSurface` failure path — the inner function already cleaned up.

## Verification

Repro from #2584, `canvas@3.2.3` on Linux x86_64 / Node 20:

```
baseline rss=45.9 MiB
iter=10000 rss=94.7M slope=3.584 KiB/iter
baseline=45.9M end=94.7M delta=48.8M per-iter=4.997 KiB
```

After this patch the same loop is flat (slope in the range of N-API finalizer / cairo allocator noise).