### PR TITLE
Free native resources on three rare decoder error paths

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -358,6 +358,8 @@ create_transparent_pattern(cairo_pattern_t *source, float alpha) {
     height);
   cairo_t *mask_context = cairo_create(mask_surface);
   if (cairo_status(mask_context) != CAIRO_STATUS_SUCCESS) {
+    cairo_destroy(mask_context);
+    cairo_surface_destroy(mask_surface);
     return NULL;
   }
   cairo_set_source(mask_context, source);

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -617,6 +617,7 @@ Image::loadGIFFromBuffer(uint8_t *buf, unsigned len) {
 
   if (colormap == nullptr) {
     GIF_CLOSE_FILE(gif);
+    delete[] data;
     return CAIRO_STATUS_READ_ERROR;
   }
 
@@ -1041,12 +1042,20 @@ Image::assignDataAsMime(uint8_t *data, int len, const char *mime_type) {
 
   Napi::MemoryManagement::AdjustExternalMemory(env, len);
 
-  return cairo_surface_set_mime_data(_surface
+  cairo_status_t status = cairo_surface_set_mime_data(_surface
     , mime_type
     , mime_data
     , len
     , clearMimeData
     , mime_closure);
+
+  if (status) {
+    Napi::MemoryManagement::AdjustExternalMemory(env, -len);
+    free(mime_data);
+    free(mime_closure);
+  }
+
+  return status;
 }
 
 /*


### PR DESCRIPTION
Fixes #2586.

Three small ownership bugs on rare error paths in image decoders and pattern construction. None are reachable in normal operation, but each is a real leak when its gate fires.

## Changes

- `Image::loadGIFFromBuffer`: `delete[]` the decode buffer before returning `CAIRO_STATUS_READ_ERROR` when neither a local nor a global color map exists. Per-occurrence leak is the full `width * height * 4` buffer.
- `Image::assignDataAsMime`: capture the `cairo_surface_set_mime_data` return status; on non-success, reverse the `Napi::MemoryManagement::AdjustExternalMemory(env, len)` and `free` both `mime_data` (a copy of the JPEG buffer) and `mime_closure`. Cairo doesn't take ownership in the failure case and never calls `clearMimeData`, so both allocations otherwise live forever.
- `create_transparent_pattern`: destroy `mask_context` and `mask_surface` before returning `NULL` when `cairo_create` reports an error status. Only reachable on cairo OOM.

## Verification

These are behind error/OOM gates that aren't reachable from JS without poking at internals, so no RSS reproduction is attached. The fixes are visible by inspection and total +12 / -1 lines.