### PR TITLE
Context2d: keep fillStyle/strokeStyle strong, fix resetState and ~Context2d teardown

### DIFF
--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -242,6 +242,10 @@ Context2d::Context2d(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Context2
  */
 
 Context2d::~Context2d() {
+  // Destroy states before _context so each canvas_state_t is torn down while
+  // the context is still valid.
+  while (!states.empty()) states.pop();
+  state = nullptr;
   if (_layout) g_object_unref(_layout);
   if (_context) cairo_destroy(_context);
   _resetPersistentHandles();
@@ -252,8 +256,9 @@ Context2d::~Context2d() {
  */
 
 void Context2d::resetState() {
-  states.pop();
+  while (!states.empty()) states.pop();
   states.emplace();
+  state = &states.top();
   pango_layout_set_font_description(_layout, state->fontDescription);
   _resetPersistentHandles();
 }
@@ -1966,11 +1971,11 @@ Context2d::SetFillStyle(const Napi::CallbackInfo& info, const Napi::Value& value
     InstanceData *data = env.GetInstanceData<InstanceData>();
     Napi::Object obj = value.As<Napi::Object>();
     if (obj.InstanceOf(data->CanvasGradientCtor.Value()).UnwrapOr(false)) {
-      _fillStyle.Reset(obj);
+      _fillStyle.Reset(obj, 1);
       Gradient *grad = Gradient::Unwrap(obj);
       state->fillGradient = grad->pattern();
     } else if (obj.InstanceOf(data->CanvasPatternCtor.Value()).UnwrapOr(false)) {
-      _fillStyle.Reset(obj);
+      _fillStyle.Reset(obj, 1);
       Pattern *pattern = Pattern::Unwrap(obj);
       state->fillPattern = pattern->pattern();
     }
@@ -2006,11 +2011,11 @@ Context2d::SetStrokeStyle(const Napi::CallbackInfo& info, const Napi::Value& val
     InstanceData *data = env.GetInstanceData<InstanceData>();
     Napi::Object obj = value.As<Napi::Object>();
     if (obj.InstanceOf(data->CanvasGradientCtor.Value()).UnwrapOr(false)) {
-      _strokeStyle.Reset(obj);
+      _strokeStyle.Reset(obj, 1);
       Gradient *grad = Gradient::Unwrap(obj);
       state->strokeGradient = grad->pattern();
     } else if (obj.InstanceOf(data->CanvasPatternCtor.Value()).UnwrapOr(false)) {
-      _strokeStyle.Reset(value);
+      _strokeStyle.Reset(value, 1);
       Pattern *pattern = Pattern::Unwrap(obj);
       state->strokePattern = pattern->pattern();
     }


### PR DESCRIPTION
## Context2d state-handling correctness (split out of #2582)

Three small, independent fixes to `Context2d` state handling. Split from #2582 — which now contains only the `cairo_pattern_t` refcounting — this PR is the correctness half and does not depend on it.

### 1. Keep `fillStyle` / `strokeStyle` as strong references

`_fillStyle` / `_strokeStyle` are weak references (`.Reset(obj)`, refcount 0). For an **image-backed `CanvasPattern`**, the cairo pattern's surface points at the `Image`'s pixel buffer (`cairo_image_surface_create_for_data`), which `Image::clearData()` frees unconditionally when the `Image` is GC'd. If the wrapper is collected while the Context2d state still references that pattern, drawing reads freed memory.

`.Reset(obj, 1)` keeps the wrapper alive while it is the active style. (Pairs with the source retention in #2583, which keeps the `Image` itself alive for the pattern's lifetime.)

### 2. `resetState()` leaves `state` dangling

```cpp
void Context2d::resetState() {
  states.pop();      // pops one level only
  states.emplace();  // `state` still points at the popped/old top -> dangling
  ...
}
```

Fix: pop all states, emplace one, and re-point `state = &states.top()`.

### 3. `~Context2d()` teardown order

Pop states before destroying the cairo context, so each `canvas_state_t` is torn down while the context is still valid.

---

Note: this overlaps with #2582 in `SetFillStyle` / `SetStrokeStyle` (both touch those lines). Whichever merges first, the other rebases trivially.
