### PR TITLE
Fix segfault, use-after-free and per-parse leak in the SVG paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Fixed
 * Load images from Node.js object URLs (#2525)
+* Fix crash loading an SVG with an embedded image in an undecodable format (#2613)
+* Fix use-after-free when re-rendering an SVG image at a size cairo rejects (#2613)
+* Fix leak of one decoded frame per parse of an SVG with an embedded JPEG, GIF or BMP (#2613)
 
 3.2.3
 ==================

--- a/pkg/lunasvg/build.zig.zon
+++ b/pkg/lunasvg/build.zig.zon
@@ -5,8 +5,8 @@
     .dependencies = .{
         .cairo = .{ .path = "../cairo" },
         .lunasvg = .{
-            .url = "https://github.com/iurisilvio/lunasvg/archive/c8fbe875e4c241a8b45c8e274647297db12bda22.tar.gz",
-            .hash = "N-V-__8AAPD5FADyrh8KcLt8S2MOxVcQuxCvX9DkrI5zKsUZ",
+            .url = "https://github.com/iurisilvio/lunasvg/archive/b03b0dd7ba9967bd507c4a13ab12ff37e1d4128a.tar.gz",
+            .hash = "N-V-__8AAGcLFQB2sVL8Tvu9IeCPuaczmK9v1-aj16-Uasup",
         }
     },
 }

--- a/pkg/lunasvg/build.zig.zon
+++ b/pkg/lunasvg/build.zig.zon
@@ -5,8 +5,8 @@
     .dependencies = .{
         .cairo = .{ .path = "../cairo" },
         .lunasvg = .{
-            .url = "https://github.com/chearon/lunasvg/archive/3fd8ba9e0cd5cf0af36b1bda2d0a3bbaf8bd8da7.tar.gz",
-            .hash = "N-V-__8AAFD4FABzdNrtG-6ulAVAPIPJZde38BQWKRcKgkgV",
+            .url = "https://github.com/iurisilvio/lunasvg/archive/c8fbe875e4c241a8b45c8e274647297db12bda22.tar.gz",
+            .hash = "N-V-__8AAPD5FADyrh8KcLt8S2MOxVcQuxCvX9DkrI5zKsUZ",
         }
     },
 }

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -1268,6 +1268,8 @@ Context2d::DrawImage(const Napi::CallbackInfo& info) {
     source_w = sw = img->surface.width;
     source_h = sh = img->surface.height;
     surface = img->surface.surface();
+    // An SVG image re-renders on demand and can fail, throwing from surface().
+    if (!surface) return;
 
   // Canvas
   } else if (obj.InstanceOf(env.GetInstanceData<InstanceData>()->CanvasCtor.Value()).UnwrapOr(false)) {

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -81,9 +81,30 @@ ImageSurface::clearData() {
   state = DEFAULT;
 }
 
+// Identifies the pixel buffer attached to a transferred surface. Only the
+// address matters to cairo.
+static cairo_user_data_key_t transferred_data_key;
+
 cairo_surface_t*
 ImageSurface::transferSurface() {
   cairo_surface_t* surface = _surface;
+
+  // The JPEG, GIF and BMP decoders back the surface with a buffer of our own
+  // that cairo does not own. We are giving up the only pointer to it, so hand
+  // it to the surface before letting go.
+  if (surface && _data) {
+    cairo_status_t status = cairo_surface_set_user_data(
+      surface, &transferred_data_key, _data,
+      [](void* data) { delete[] static_cast<uint8_t*>(data); });
+
+    if (status != CAIRO_STATUS_SUCCESS) {
+      // Out of memory. The buffer would outlive every pointer to it, so drop
+      // the surface with it rather than leak.
+      cairo_surface_destroy(surface);
+      delete[] _data;
+      surface = nullptr;
+    }
+  }
 
   if (env) Napi::MemoryManagement::AdjustExternalMemory(*env, -_data_len);
   _data_len = 0;
@@ -1236,9 +1257,13 @@ cairo_status_t
 ImageSurface::loadSVGFromBuffer(uint8_t *buf, unsigned len) {
   lunasvg::GraphicsCallbacks callbacks;
 
-  callbacks.setDecoderFn([](char* data, int length) {
+  callbacks.setDecoderFn([](char* data, int length) -> cairo_surface_t* {
       ImageSurface bitmap(std::nullopt);
-      bitmap.loadFromBuffer((uint8_t*)data, length);
+      // Embedded images come in whatever format the document author used, so
+      // failing to decode one is routine. lunasvg renders nothing for a null
+      // surface; handing it a half-built one would render garbage.
+      if (bitmap.loadFromBuffer((uint8_t*)data, length) != CAIRO_STATUS_SUCCESS)
+        return nullptr;
       return bitmap.transferSurface();
   });
 
@@ -1251,10 +1276,15 @@ ImageSurface::loadSVGFromBuffer(uint8_t *buf, unsigned len) {
 
   if (width <= 0 || height <= 0) {
     this->errorInfo.set("Width and height must be set on the svg element");
+    width = naturalWidth = height = naturalHeight = 0;
+    svgdoc = nullptr;
     return CAIRO_STATUS_READ_ERROR;
   }
 
-  return renderSVGToSurface();
+  cairo_status_t status = renderSVGToSurface();
+  if (status != CAIRO_STATUS_SUCCESS) svgdoc = nullptr;
+
+  return status;
 }
 
 /*
@@ -1265,8 +1295,16 @@ cairo_status_t
 ImageSurface::renderSVGToSurface() {
   cairo_status_t status;
 
-  if (_surface) cairo_surface_destroy(_surface);
+  // Null as well as destroy: every early return below leaves the caller
+  // holding this object, and clearData() would destroy the surface again.
+  if (_surface) {
+    cairo_surface_destroy(_surface);
+    _surface = nullptr;
+  }
+
   lunasvg::Bitmap bitmap = svgdoc->renderToBitmap(width, height, 0);
+  if (bitmap.isNull()) return CAIRO_STATUS_NO_MEMORY;
+
   status = cairo_surface_status(bitmap.surface());
   if (status != CAIRO_STATUS_SUCCESS) return status;
   _surface = cairo_surface_reference(bitmap.surface());

--- a/test/svg.test.js
+++ b/test/svg.test.js
@@ -1,0 +1,124 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const assert = require('assert')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+// The failure modes below abort the process (SIGSEGV / cairo assertion), so
+// each one has to run in a child process for mocha to be able to report it.
+// Keep the scripts small: Windows caps a command line at 32k.
+function runInChild (body, nodeArgs = []) {
+  const src = `const canvas = require(${JSON.stringify(path.join(__dirname, '..'))})\n${body}`
+  const child = spawnSync(process.execPath, [...nodeArgs, '-e', src], { encoding: 'utf8' })
+  if (child.error) assert.fail(`could not run the child process: ${child.error.message}`)
+  if (child.signal || child.status !== 0) {
+    assert.fail(`child process died with ${child.signal || `exit code ${child.status}`}\n` +
+      (child.stderr || '').trim().split('\n').slice(-3).join('\n'))
+  }
+  return child.stdout
+}
+
+describe('SVG', function () {
+  it('does not crash on an embedded image it cannot decode', function () {
+    // A data URI that base64-decodes fine but is not a format node-canvas
+    // decodes (WebP here). The decode callback hands back a null surface.
+    const junk = Buffer.from('RIFF____WEBPVP8 not a real image, but long enough to sniff').toString('base64')
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">' +
+      `<image width="50" height="50" href="data:image/webp;base64,${junk}"/></svg>`
+
+    const out = runInChild(`
+      const img = new canvas.Image()
+      img.onerror = () => {}
+      img.src = Buffer.from(${JSON.stringify(svg)})
+      console.log('survived')
+    `)
+    assert.strictEqual(out.trim(), 'survived')
+  })
+
+  it('does not double-free the surface when a re-render fails', function () {
+    // Rendering at a size cairo rejects (> 32767) must not leave the previous
+    // surface destroyed-but-not-nulled: the next render destroys it again.
+    // Only an assertion-enabled cairo turns that into an abort, so this needs
+    // a debug build -- the plain `zig build` a contributor runs before the
+    // tests. In a release build the same code is a silent use-after-free.
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">' +
+      '<rect width="16" height="16" fill="red"/></svg>'
+
+    const out = runInChild(`
+      const img = new canvas.Image()
+      img.src = Buffer.from(${JSON.stringify(svg)})
+      const ctx = canvas.createCanvas(64, 64).getContext('2d')
+      ctx.drawImage(img, 0, 0)
+      img.width = img.height = 40000
+      for (let i = 0; i < 3; i++) {
+        try { ctx.drawImage(img, 0, 0) } catch (err) { /* expected: invalid size */ }
+      }
+      console.log('survived')
+    `)
+    assert.strictEqual(out.trim(), 'survived')
+  })
+
+  it('does not leak the pixel buffer of an embedded raster', function () {
+    this.timeout(120000)
+    const size = 1200
+    const warmup = 50
+    const measured = 100
+    // W * H * 4 bytes are leaked per parse if the decoded buffer is orphaned.
+    const frameBytes = size * size * 4
+
+    // An embedded PNG is the control: cairo owns the pixels on that path, so
+    // whatever RSS slope it shows is this build's allocator noise. JPEG (and
+    // GIF and BMP) hand cairo a buffer of ours instead, and orphaning it costs
+    // one whole decoded frame per parse on top of that noise.
+    const out = runInChild(`
+      const size = ${size}
+      const raster = canvas.createCanvas(size, size)
+      const rctx = raster.getContext('2d')
+      for (let i = 0; i < 64; i++) {
+        rctx.fillStyle = \`hsl(\${(i * 11) % 360} 80% 50%)\`
+        rctx.fillRect((i * 37) % size, (i * 53) % size, 40, 40)
+      }
+      const svg = mime => Buffer.from(
+        \`<svg xmlns="http://www.w3.org/2000/svg" width="\${size}" height="\${size}">\` +
+        \`<image width="\${size}" height="\${size}" href="data:\${mime};base64,\` +
+        raster.toBuffer(mime).toString('base64') + '"/></svg>')
+      const png = svg('image/png')
+      const jpeg = svg('image/jpeg')
+
+      const load = svg => {
+        const img = new canvas.Image()
+        img.src = svg
+        if (img.width !== size) throw new Error('svg failed to load')
+      }
+      const drain = async () => {
+        for (let i = 0; i < 3; i++) { global.gc(); await new Promise(setImmediate) }
+        global.gc()
+      }
+      const run = async (svg, n) => {
+        for (let i = 1; i <= n; i++) {
+          load(svg)
+          if (i % 10 === 0) await new Promise(setImmediate)
+        }
+        await drain()
+        return process.memoryUsage().rss
+      }
+      const slope = async svg => {
+        const warm = await run(svg, ${warmup})
+        const end = await run(svg, ${measured})
+        return (end - warm) / ${measured}
+      }
+      ;(async () => console.log(await slope(png), await slope(jpeg)))()
+    `, ['--expose-gc'])
+
+    const [png, jpeg] = out.trim().split(' ').map(Number)
+    assert.ok(
+      jpeg - png < frameBytes / 2,
+      `embedded JPEG retains ${Math.round(jpeg / 1024)} KiB per parse against ` +
+      `${Math.round(png / 1024)} KiB for the same image as PNG, a difference of ` +
+      `${Math.round((jpeg - png) / 1024)} KiB (one decoded frame is ` +
+      `${Math.round(frameBytes / 1024)} KiB)`
+    )
+  })
+})


### PR DESCRIPTION
Three failures in the lunasvg SVG paths, each with a test that fails on master and passes here. Reproduced first against the published `canvas@4.0.0-rc2`, then against a source build of master.

## The failures

**An SVG with an embedded image in a format we cannot decode segfaults.** The decoder callback in `loadSVGFromBuffer()` ignored the status of `loadFromBuffer()` and returned whatever surface the failed decode left behind, which for an unsupported format is null. lunasvg passed that straight to `cairo_surface_set_user_data()`. Loading a document with `<image href="data:image/webp;base64,...">` — or with corrupt image data — takes the process down.

**A failed SVG re-render leaves a dangling surface.** `renderSVGToSurface()` destroyed `_surface` without nulling it before its error returns, so the next render and `clearData()` both destroy it again:

```js
const img = new Image()
img.src = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16"/></svg>')
ctx.drawImage(img, 0, 0)
img.width = img.height = 40000   // > the largest image surface cairo will make
ctx.drawImage(img, 0, 0)         // throws, as it should
ctx.drawImage(img, 0, 0)         // aborts
```

```
Assertion failed: (CAIRO_REFERENCE_COUNT_HAS_REFERENCE (&surface->ref_count)),
function cairo_surface_destroy, file cairo-surface.c, line 963
```

Only an assertion-enabled cairo turns it into an abort, so it shows up on the debug build `zig build` produces and is a silent use-after-free in a `ReleaseFast` one.

**Every parse of an SVG with an embedded JPEG, GIF or BMP leaks one decoded frame.** Those decoders back their surface with a `new uint8_t[]` buffer through `cairo_image_surface_create_for_data()`, which cairo does not own. `transferSurface()` hands the surface to lunasvg and drops `_data` without freeing it or attaching a destroy callback, so nothing frees the pixels — ever. An embedded PNG is unaffected, since cairo owns the pixels on that path, which makes it a clean control:

```
1200x1200 raster, RSS slope over 100 parses after a 50-parse warmup
master     embedded PNG      1 KiB/parse     embedded JPEG  6238 KiB/parse
this PR    embedded PNG      2 KiB/parse     embedded JPEG     5 KiB/parse
                                             (one decoded frame is 5625 KiB)
```

## Changes

- `transferSurface()` attaches `_data` to the surface with a destroy callback, so the buffer dies with the surface that points at it. If cairo cannot store it, the surface goes too rather than leaving a buffer nothing can free.
- `renderSVGToSurface()` nulls `_surface` after destroying it, and treats a null `Bitmap` — what `renderToBitmap()` returns for a document with no intrinsic size, or when the allocation fails — as an error instead of reading a status through a null pointer.
- `Context2d::DrawImage()` stops when `surface()` returns null. It always could, once a re-render fails; nothing checked because the abort came first.
- The decoder callback returns null on a failed decode instead of a half-built surface.
- `loadSVGFromBuffer()` releases the parsed document on both of its error paths, where it is only reachable again through an `Image` that never completed loading.
- `pkg/lunasvg` picks up chearon/lunasvg#1, which null-checks the decoder result. **This currently points at my fork so the tests pass here — happy to re-point it at chearon/lunasvg once that lands, or drop the bump and let it come in separately.**

## Tests

`test/svg.test.js`. Both crashes take the process down, so each case runs in a child process and the test reports the signal. The leak test measures an RSS slope and calibrates it against the same image embedded as a PNG in the same process, rather than against a fixed threshold — debug and release builds differ by two orders of magnitude in allocator noise.

On master: 3 failing. On this branch: the full suite passes, 308 tests, on both `zig build` and `zig build -Doptimize=ReleaseFast`.

- [x] Have you updated CHANGELOG.md?
