### PR TITLE
Find the macOS SDK when only the Command Line Tools are installed

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -188,37 +188,23 @@ pub fn build(b: *std.Build) void {
     }
 
     if (target.result.os.tag == .macos) {
-        // Stole this method from
-        // https://github.com/ghostty-org/ghostty/commit/c0722b3652e5e207f34d220f64a03d9d53e93ad0
-
-        // The active SDK we want to use
-        const sdk = "MacOSX15.sdk";
-
-        // Get the path to our active Xcode installation. If this fails then
-        // the zig build will fail.
-        const path = std.mem.trim(
+        // The SDK the toolchain is pointed at, whether that is a full Xcode
+        // or just the Command Line Tools. The macOS version a binary runs on
+        // comes from the target, not from this.
+        const sdk_path = std.mem.trim(
             u8,
-            b.run(&.{ "xcode-select", "--print-path" }),
+            b.run(&.{ "xcrun", "--show-sdk-path" }),
             " \r\n",
         );
 
         canvas.root_module.addSystemFrameworkPath(.{
-            .cwd_relative = b.pathJoin(&.{
-                path,
-                "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/System/Library/Frameworks",
-            }),
+            .cwd_relative = b.pathJoin(&.{ sdk_path, "System/Library/Frameworks" }),
         });
         canvas.root_module.addSystemIncludePath(.{
-            .cwd_relative = b.pathJoin(&.{
-                path,
-                "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/usr/include",
-            }),
+            .cwd_relative = b.pathJoin(&.{ sdk_path, "usr/include" }),
         });
         canvas.root_module.addLibraryPath(.{
-            .cwd_relative = b.pathJoin(&.{
-                path,
-                "Platforms/MacOSX.platform/Developer/SDKs/" ++ sdk ++ "/usr/lib",
-            }),
+            .cwd_relative = b.pathJoin(&.{ sdk_path, "usr/lib" }),
         });
     }
 


### PR DESCRIPTION
Building on a Mac without a full Xcode fails at the link step, after compiling every dependency:

```
error: warning: unable to open library directory
'/Library/Developer/CommandLineTools/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.sdk/usr/lib': FileNotFound
```

`Platforms/MacOSX.platform/Developer/SDKs/` only exists inside an Xcode installation. With the Command Line Tools selected, `xcode-select --print-path` returns `/Library/Developer/CommandLineTools` and the SDKs sit directly under `SDKs/`.

## Changes

Ask `xcrun --show-sdk-path` for the SDK, which answers for either layout. That also retires the `xcode-select` call, which only existed to build the pinned path.

The pinned `MacOSX15.sdk` was not holding the build to that SDK to begin with — zig resolves the SDK for the link itself, and the paths added here only supplement it:

```
same native build     probing for MacOSX15.sdk     minos 26.6.1   sdk 26.5
                      xcrun --show-sdk-path only   minos 26.6.1   sdk 26.5
```

What a binary runs on comes from the target, not from this block. With the triple `publish.yaml` passes:

```
$ zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast
    minos 13.0    sdk 26.4
```

One real difference: the old `-isystem` had compilation pull headers from the 15 SDK, so `FontManagerMacos.cc` now compiles against the newest installed one instead. At `minos 13.0`, anything introduced after 13.0 is weak-linked and clang warns if it is called unguarded — nothing the current CoreText usage goes near, but it is the actual behavioral change between the two versions.

## Verification

macOS 26 arm64, Command Line Tools only (no Xcode), zig 0.16.0: `zig build` succeeds and the full suite passes (305 tests).

- [ ] Have you updated CHANGELOG.md? — no user-visible change
